### PR TITLE
Fix: Add permissions to security scan job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,6 +48,9 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
This PR adds the `security-events: write` permission to the security scan job to allow it to upload SARIF results.