### PR TITLE
fix(posts): align examples typing for mypy

### DIFF
--- a/src/dyvine/main.py
+++ b/src/dyvine/main.py
@@ -181,7 +181,9 @@ app = FastAPI(
     version=settings.version,
     docs_url="/docs",
     redoc_url="/redoc",
-    openapi_url=f"{settings.prefix}/openapi.json" if settings.prefix else "/openapi.json",
+    openapi_url=(
+        f"{settings.prefix}/openapi.json" if settings.prefix else "/openapi.json"
+    ),
     lifespan=lifespan,
     # Additional metadata for OpenAPI documentation
     contact={

--- a/src/dyvine/routers/posts.py
+++ b/src/dyvine/routers/posts.py
@@ -81,12 +81,9 @@ async def get_post(
     post_id: str = Path(
         ...,
         description="Unique Douyin post identifier (aweme_id)",
-        examples={
-            "default": {
-                "summary": "Sample post identifier",
-                "value": "7123456789012345678",
-            }
-        },
+        examples=[
+            {"summary": "Sample post identifier", "value": "7123456789012345678"}
+        ],
     ),
 ) -> PostDetail:
     """Retrieve detailed information about a specific Douyin post.
@@ -159,12 +156,12 @@ async def list_user_posts(
     user_id: str = Path(
         ...,
         description="Unique Douyin user identifier (sec_user_id)",
-        examples={
-            "default": {
+        examples=[
+            {
                 "summary": "Sample sec_user_id",
                 "value": "MS4wLjABAAAA-kxe2_w-i_5F_q_b_rX_vIDqfwyTNYvM-oDD_eRjQVc",
             }
-        },
+        ],
     ),
     max_cursor: int = Query(
         0,
@@ -172,20 +169,20 @@ async def list_user_posts(
             "Pagination cursor for fetching next page. Use 0 for first page, "
             "then use the cursor from previous response"
         ),
-        examples={
-            "initial": {"summary": "First page", "value": 0},
-            "subsequent": {"summary": "Subsequent page cursor", "value": 1678886400},
-        },
+        examples=[
+            {"summary": "First page", "value": 0},
+            {"summary": "Subsequent page cursor", "value": 1678886400},
+        ],
     ),
     count: int = Query(
         20,
         ge=1,
         le=100,
         description="Number of posts to return per page. Must be between 1 and 100",
-        examples={
-            "default": {"summary": "Default page size", "value": 20},
-            "max": {"summary": "Maximum per request", "value": 100},
-        },
+        examples=[
+            {"summary": "Default page size", "value": 20},
+            {"summary": "Maximum per request", "value": 100},
+        ],
     ),
 ) -> list[PostDetail]:
     """Retrieve a paginated list of posts from a specific Douyin user.

--- a/tests/services/test_storage_service.py
+++ b/tests/services/test_storage_service.py
@@ -25,7 +25,9 @@ def test_generate_ugc_path_includes_expected_segments() -> None:
 
     assert path.startswith("videos/user-123/")
     filename = path.split("/")[-1]
-    match = re.match(r"(?P<prefix>\d{8})_(?P<encoded>[^_]+)_(?P<uuid>[a-f0-9]{8})\.mp4", filename)
+    match = re.match(
+        r"(?P<prefix>\d{8})_(?P<encoded>[^_]+)_(?P<uuid>[a-f0-9]{8})\.mp4", filename
+    )
     assert match is not None
 
     encoded_name = match.group("encoded")

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -28,7 +28,9 @@ async def test_start_download_tracks_task(monkeypatch: pytest.MonkeyPatch) -> No
         scheduled.append(future)
         return future
 
-    monkeypatch.setattr("src.dyvine.services.users.asyncio.create_task", fake_create_task)
+    monkeypatch.setattr(
+        "src.dyvine.services.users.asyncio.create_task", fake_create_task
+    )
 
     service = UserService()
     response = await service.start_download("user-123")
@@ -40,7 +42,9 @@ async def test_start_download_tracks_task(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 @pytest.mark.asyncio
-async def test_get_download_status_returns_current_state(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_get_download_status_returns_current_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def _resolved_future(coro: object) -> asyncio.Future[None]:
         if hasattr(coro, "close"):
             coro.close()
@@ -48,7 +52,9 @@ async def test_get_download_status_returns_current_state(monkeypatch: pytest.Mon
         future.set_result(None)
         return future
 
-    monkeypatch.setattr("src.dyvine.services.users.asyncio.create_task", _resolved_future)
+    monkeypatch.setattr(
+        "src.dyvine.services.users.asyncio.create_task", _resolved_future
+    )
 
     service = UserService()
     start_response = await service.start_download("user-456")

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -17,7 +17,9 @@ def reset_container_cache() -> None:
     dependencies.get_service_container.cache_clear()
 
 
-def test_service_container_initializes_with_douyin_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_service_container_initializes_with_douyin_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured_kwargs: dict[str, object] = {}
 
     def build_handler(kwargs: dict[str, object]) -> DummyHandler:
@@ -35,8 +37,12 @@ def test_service_container_initializes_with_douyin_handler(monkeypatch: pytest.M
     assert captured_kwargs.get("max_tasks") == 3
 
 
-def test_get_service_container_returns_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(dependencies, "DouyinHandler", lambda kwargs: DummyHandler(kwargs))
+def test_get_service_container_returns_singleton(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        dependencies, "DouyinHandler", lambda kwargs: DummyHandler(kwargs)
+    )
 
     container_one = dependencies.get_service_container()
     container_two = dependencies.get_service_container()


### PR DESCRIPTION
## Summary
- adjust `Path`/`Query` examples to use list format expected by FastAPI/mypy
- rerun formatting to satisfy Black

## Testing
- uv run mypy src/
- uv run pytest -q