### PR TITLE
docs(core): Improve docstrings and comments across codebase

### DIFF
--- a/src/dyvine/core/decorators.py
+++ b/src/dyvine/core/decorators.py
@@ -1,3 +1,10 @@
+"""Route-level error handling decorators.
+
+Provides ``handle_errors``, a parameterized decorator that maps Dyvine
+exception types to HTTP status codes so individual route handlers don't
+need repetitive try/except blocks.
+"""
+
 from collections.abc import Callable
 from functools import wraps
 from typing import Any
@@ -19,12 +26,19 @@ def handle_errors(
     error_mapping: dict[type[Exception], int] | None = None,
     logger: ContextLogger | None = None,
 ) -> Callable:
-    """
-    Decorator for handling exceptions in route handlers.
+    """Decorator for handling exceptions in route handlers.
+
+    Wraps an async route function so that ``DyvineError`` subclasses are
+    automatically translated to ``HTTPException`` responses using the
+    appropriate status code, while unexpected exceptions become 500s.
 
     Args:
-        error_mapping: Custom exception to status code mapping
-        logger: Optional logger instance
+        error_mapping: Optional overrides merged into the default
+            exception-to-status-code map.
+        logger: When provided, errors are logged before raising.
+
+    Returns:
+        A decorator that wraps an async route handler.
     """
     default_mapping: dict[type[Exception], int] = {
         NotFoundError: 404,

--- a/src/dyvine/core/error_handlers.py
+++ b/src/dyvine/core/error_handlers.py
@@ -23,7 +23,21 @@ class ErrorResponse:
         include_traceback: bool = False,
         exception: Exception | None = None,
     ) -> JSONResponse:
-        """Create standardized error response."""
+        """Create a standardized error JSON response.
+
+        Args:
+            status_code: HTTP status code for the response.
+            message: Human-readable error message.
+            error_code: Machine-readable error code (defaults to ``UNKNOWN_ERROR``).
+            details: Optional extra context about the error.
+            correlation_id: Request correlation ID for tracing.
+            include_traceback: Whether to include the Python traceback.
+            exception: The exception instance (only used when
+                *include_traceback* is True).
+
+        Returns:
+            A ``JSONResponse`` with the error payload and the given status code.
+        """
         content = {
             "error": True,
             "message": message,
@@ -46,7 +60,19 @@ class ErrorResponse:
 
 
 async def dyvine_error_handler(request: Request, exc: DyvineError) -> JSONResponse:
-    """Handle all Dyvine-specific errors in a unified way."""
+    """Handle all ``DyvineError`` subclasses in a unified way.
+
+    Maps exception types to HTTP status codes (``NotFoundError`` -> 404,
+    ``ServiceError`` -> 500, others -> 400), logs with the appropriate
+    severity, and returns a structured ``ErrorResponse``.
+
+    Args:
+        request: The incoming FastAPI request (used for correlation ID).
+        exc: The Dyvine-specific exception that was raised.
+
+    Returns:
+        A ``JSONResponse`` with a standardized error payload.
+    """
     correlation_id = getattr(request.state, "correlation_id", None)
 
     # Determine status code based on exception type
@@ -83,7 +109,19 @@ async def dyvine_error_handler(request: Request, exc: DyvineError) -> JSONRespon
 
 
 async def generic_exception_handler(request: Request, exc: Exception) -> JSONResponse:
-    """Handle unexpected exceptions."""
+    """Handle unexpected (non-Dyvine) exceptions as 500 Internal Server Error.
+
+    Logs the full traceback at error level.  In debug mode the traceback
+    is included in the response body; in production only a generic message
+    is returned.
+
+    Args:
+        request: The incoming FastAPI request (used for correlation ID).
+        exc: The unhandled exception.
+
+    Returns:
+        A ``JSONResponse`` with status 500 and a standardized error payload.
+    """
     correlation_id = getattr(request.state, "correlation_id", None)
 
     logger.error(
@@ -113,7 +151,11 @@ async def generic_exception_handler(request: Request, exc: Exception) -> JSONRes
 
 
 def register_error_handlers(app: Any) -> None:
-    """Register all error handlers with the FastAPI app."""
+    """Register Dyvine and generic exception handlers with the FastAPI app.
+
+    Args:
+        app: The FastAPI application instance.
+    """
 
     # Handle all DyvineError subclasses with one handler
     app.add_exception_handler(DyvineError, dyvine_error_handler)

--- a/src/dyvine/schemas/livestreams.py
+++ b/src/dyvine/schemas/livestreams.py
@@ -53,12 +53,13 @@ class LiveStreamDownloadResponse(BaseModel):
     """Response model for livestream download operations.
 
     Attributes:
-        status: The status of the download operation ('success' or 'error').
-        download_path: The path where the stream was saved (only present on success).
+        status: ``"pending"`` when a background download has been started,
+            ``"success"`` when a status query finds a completed file.
+        download_path: The path where the stream is (or will be) saved.
         error: Error message if the operation failed (only present on error).
     """
 
-    status: str = Field(..., description="Status of the download operation")
+    status: str = Field(..., description="Download status: pending | success | error")
     download_path: str | None = Field(
         None, description="Path where the stream was saved"
     )

--- a/src/dyvine/schemas/users.py
+++ b/src/dyvine/schemas/users.py
@@ -37,11 +37,15 @@ class UserResponse(BaseModel):
 
 
 class DownloadResponse(BaseModel):
-    """Schema for download operation response."""
+    """Schema for download operation response.
+
+    The ``status`` field transitions through: ``pending`` -> ``running``
+    -> ``completed`` | ``failed``.
+    """
 
     task_id: str = Field(..., description="Unique task identifier")
     status: str = Field(
-        ..., description="Task status (pending/running/completed/failed)"
+        ..., description="Task status: pending | running | completed | failed"
     )
     message: str = Field(..., description="Status message")
     progress: float | None = Field(None, description="Download progress (0-100)")

--- a/src/dyvine/services/livestreams.py
+++ b/src/dyvine/services/livestreams.py
@@ -47,7 +47,8 @@ class LivestreamService:
         self.download_jobs: dict[str, asyncio.Task[Any]] = {}
         self.user_service = UserService()
         self.douyin_handler = get_service_container().douyin_handler
-        # Disable optional Bark notifications to avoid network noise in service usage.
+        # f2's Bark push notifications are meant for interactive CLI use;
+        # in a server context they add latency and unneeded network calls.
         self.douyin_handler.enable_bark = False
 
     async def _load_live_filter(
@@ -239,7 +240,22 @@ class LivestreamService:
         }
 
     async def get_room_info(self, webcast_id: str) -> dict[str, Any]:
-        """Resolve livestream metadata via f2 for monitoring and downloads."""
+        """Resolve livestream metadata via f2 for monitoring and downloads.
+
+        Args:
+            webcast_id: The Douyin webcast (room) identifier.
+
+        Returns:
+            A dict with at least the following keys:
+
+            - ``status`` (int): Live status code (2 = live, 0 = offline).
+            - ``room_id`` (str): The room identifier.
+            - ``webcast_id`` (str): The webcast identifier.
+            - ``stream_map`` (dict[str, str]): Quality-label -> HLS URL mapping.
+
+        Raises:
+            LivestreamError: If the metadata cannot be resolved.
+        """
         try:
             live_filter = await self._load_live_filter(webcast_id=webcast_id)
             if not live_filter:
@@ -358,8 +374,17 @@ class LivestreamService:
     ) -> tuple[dict[str, str], dict[str, str]]:
         """Merge stream maps from profile data and live filter.
 
+        Profile room info takes priority; the live filter is used as a
+        fallback when the profile data lacks stream URLs.
+
+        Args:
+            live_filter: An f2 live filter object (may be ``None``).
+            profile_room_info: Room info dict derived from a user profile
+                (may be ``None``).
+
         Returns:
-            (hls_stream_map, flv_stream_map)
+            A tuple of ``(hls_stream_map, flv_stream_map)`` where each map
+            is ``{quality_label: url}``.
         """
         resolved_stream_map: dict[str, str] = {}
         resolved_flv_map: dict[str, str] = {}
@@ -394,14 +419,18 @@ class LivestreamService:
         """Download a Douyin livestream.
 
         Args:
-            url: The livestream room URL (e.g., https://live.douyin.com/123456789).
-            output_path: Optional path where to save the stream.
+            url: The livestream room URL (e.g., https://live.douyin.com/123456789),
+                a user profile URL, or a bare numeric webcast ID.
+            output_path: Optional directory path where the stream file is saved.
+                Defaults to ``data/douyin/downloads/livestreams``.
 
         Returns:
-            Tuple of (status, message/path).
+            A ``("pending", target_file_path)`` tuple on success.  The actual
+            download runs as a background ``asyncio.Task``.
 
         Raises:
-            LivestreamError: If download fails.
+            LivestreamError: If the URL is empty, the webcast ID cannot be
+                resolved, the user is offline, or no suitable stream is found.
         """
         normalized = url.strip()
         if not normalized:

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -465,7 +465,15 @@ class PostService:
         return image_urls
 
     def _extract_video_info(self, post: dict[str, Any]) -> VideoInfo | None:
-        """Extract video information from a Douyin post."""
+        """Extract video information from a Douyin post.
+
+        Args:
+            post: Raw post dict from the Douyin API containing a ``video`` key.
+
+        Returns:
+            A ``VideoInfo`` with play URL and dimensions, or ``None`` if the
+            post has no playable video address.
+        """
         video = post.get("video", {})
         play_addr = video.get("play_addr", {})
         if play_addr and play_addr.get("url_list"):
@@ -479,7 +487,14 @@ class PostService:
         return None
 
     def _extract_image_info(self, post: dict[str, Any]) -> list[ImageInfo] | None:
-        """Extract image information from a Douyin post."""
+        """Extract image information from a Douyin post.
+
+        Args:
+            post: Raw post dict from the Douyin API containing an ``images`` key.
+
+        Returns:
+            A list of ``ImageInfo`` objects, or ``None`` if the post has no images.
+        """
         images = post.get("images", [])
         if not images:
             return None

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -294,10 +294,8 @@ class UserService:
         task = self._active_downloads[task_id]
         temp_dir = None
         try:
-            # Update status to running
             task["status"] = "running"
 
-            # Create temporary downloads directory
             temp_dir = Path("temp_downloads")
             temp_dir.mkdir(exist_ok=True)
 


### PR DESCRIPTION
## Summary
Improve docstring completeness and comment quality across the codebase to meet Google Python Style Guide standards, addressing gaps found during a documentation audit.

## Related
- Follow-up to #32

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| core/decorators.py | No module docstring | Full module + function docstring | Was the only file missing a module docstring |
| core/error_handlers.py | One-liner docstrings | Full Args/Returns docstrings | 4 functions documented |
| services/posts.py | Missing Args sections | Complete Args/Returns | _extract_video_info, _extract_image_info |
| services/livestreams.py | Minimal Returns docs | Structured return docs | get_room_info, download_stream, _resolve_streams |
| schemas/users.py | Generic status field | Documented valid values | pending/running/completed/failed |
| schemas/livestreams.py | Generic status field | Documented valid values | pending/success/error |
| Noise comments | 3 code-repeating comments | Removed or replaced with why-comments | livestreams.py, users.py |

## Details
### Implementation notes
- All docstrings follow Google Python Style Guide format
- Return value structures documented with key names and types for dict returns
- Schema status fields now document valid enum-like values in both Field description and class docstring

### Reviewer focus
- Verify docstring accuracy matches actual method behavior
- Check that removed noise comments don't lose important context

## Testing
- `make lint` -- ruff: All checks passed, mypy: Success (19 source files)
- `make test` -- 49/49 passed

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable

## Risks and rollout
- Documentation-only changes, zero runtime risk

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted