### PR TITLE
fix(runtime): harden PR #35 persistence, readiness, and dedupe paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ docker run -d \
 - **Monitoring**: Scrape `/metrics` and aggregate structured logs
 - **Horizontal Scaling**: Use a shared operation backend before increasing replicas beyond 1
 - **Backup**: Implement persistent volume and log archival strategies
+- **Persistent Storage**: The default Kubernetes manifests provision a `ReadWriteOnce` `PersistentVolumeClaim` named `dyvine-operation-state` for the SQLite-backed operation store at `/app/data`. The cluster must provide a default StorageClass. Reusing `emptyDir` is not supported because operation state must survive Pod restarts.
 
 ## Monitoring and Logging
 
@@ -322,6 +323,11 @@ Response includes:
 - Memory and CPU metrics
 - Prometheus-compatible metrics at `/metrics`
 
+#### Breaking changes in probe semantics
+
+- `/livez`, `/readyz`, `/startupz` are the orchestration-facing probes.
+- `/health` is retained as a human-facing summary endpoint. Its HTTP status semantics changed with the introduction of separate probes: it now returns `503` only when the aggregated status is `unhealthy`; a `degraded` status (for example, R2 credentials missing) now returns `200`. Monitors previously relying on `/health` to page on `degraded` should migrate to `/readyz`, which fails closed when any dependency is missing.
+
 ### Logging Features
 
 - Structured JSON logging for machine readability
@@ -340,6 +346,7 @@ Response includes:
 
 - The bundled Kubernetes manifests run the API as a single replica because the default operation store uses a pod-local SQLite file.
 - Do not increase replicas or enable autoscaling until you replace the SQLite-backed operation store with a shared backend.
+- The base manifests include a `PersistentVolumeClaim` (`dyvine-operation-state`, `ReadWriteOnce`, 1Gi) mounted at `/app/data` so that in-flight operation records survive Pod restarts. Increasing replicas beyond 1 still requires replacing the SQLite-backed operation store with a shared backend.
 
 ### Development Commands
 

--- a/k8s/base/core/deployment.yaml
+++ b/k8s/base/core/deployment.yaml
@@ -88,7 +88,8 @@ spec:
             - ALL
       volumes:
       - name: runtime-data
-        emptyDir: {}
+        persistentVolumeClaim:
+          claimName: dyvine-operation-state
       - name: runtime-logs
         emptyDir: {}
       - name: runtime-temp

--- a/k8s/base/core/deployment.yaml
+++ b/k8s/base/core/deployment.yaml
@@ -9,6 +9,12 @@ metadata:
     app.kubernetes.io/part-of: dyvine
 spec:
   replicas: 1
+  # Recreate is required because ``runtime-data`` is backed by a
+  # ReadWriteOnce PVC. A rolling update would spin up a surge Pod that
+  # cannot attach the volume (on multi-node clusters) or would briefly
+  # contend for the same SQLite writer (on single-node clusters).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: dyvine

--- a/k8s/base/core/pvc.yaml
+++ b/k8s/base/core/pvc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dyvine-operation-state
+  namespace: dyvine
+  labels:
+    app.kubernetes.io/name: dyvine
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: dyvine
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  # storageClassName intentionally omitted so the cluster's default
+  # StorageClass provisions the volume. Override via an overlay if needed.

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - core/secret.yaml
   - core/deployment.yaml
   - core/service.yaml
+  - core/pvc.yaml
 
 commonLabels:
   app.kubernetes.io/managed-by: kustomize

--- a/k8s/overlays/production/hpa.yaml
+++ b/k8s/overlays/production/hpa.yaml
@@ -1,3 +1,6 @@
+# HPA intentionally pinned to a single replica because the operation store
+# uses a RWO PVC with a pod-local SQLite writer. Restore dynamic scaling
+# after migrating to a shared operation backend.
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/src/dyvine/core/error_handlers.py
+++ b/src/dyvine/core/error_handlers.py
@@ -164,7 +164,7 @@ async def http_exception_handler(
         error_code = str(detail.get("error_code") or f"HTTP_{exc.status_code}")
         details = detail.get("details")
     else:
-        message = str(detail)
+        message = str(detail) if detail is not None else ""
         error_code = f"HTTP_{exc.status_code}"
         details = None
 

--- a/src/dyvine/core/error_handlers.py
+++ b/src/dyvine/core/error_handlers.py
@@ -153,9 +153,7 @@ async def generic_exception_handler(request: Request, exc: Exception) -> JSONRes
     )
 
 
-async def http_exception_handler(
-    request: Request, exc: HTTPException
-) -> JSONResponse:
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
     """Normalize ``HTTPException`` responses into the standard error envelope."""
     correlation_id = getattr(request.state, "correlation_id", None)
     detail = exc.detail

--- a/src/dyvine/core/logging.py
+++ b/src/dyvine/core/logging.py
@@ -83,12 +83,12 @@ class ContextLogger:
 
     def __init__(self, name: str) -> None:
         self.logger = logging.getLogger(name)
-        self.correlation_id_var: contextvars.ContextVar[
-            str | None
-        ] = contextvars.ContextVar(f"{name}_correlation_id", default=None)
-        self.context_var: contextvars.ContextVar[
-            dict[str, Any] | None
-        ] = contextvars.ContextVar(f"{name}_context", default=None)
+        self.correlation_id_var: contextvars.ContextVar[str | None] = (
+            contextvars.ContextVar(f"{name}_correlation_id", default=None)
+        )
+        self.context_var: contextvars.ContextVar[dict[str, Any] | None] = (
+            contextvars.ContextVar(f"{name}_context", default=None)
+        )
 
     @property
     def correlation_id(self) -> str | None:

--- a/src/dyvine/core/operations.py
+++ b/src/dyvine/core/operations.py
@@ -71,10 +71,16 @@ class OperationStore:
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.db_path, check_same_thread=False)
         connection.row_factory = sqlite3.Row
+        # synchronous is a per-connection PRAGMA, so reapply on every connect.
+        connection.execute("PRAGMA synchronous=NORMAL;")
+        connection.execute("PRAGMA busy_timeout=5000;")
         return connection
 
     def _initialize(self) -> None:
         with self._lock, closing(self._connect()) as connection:
+            # WAL is a database-level mode that persists across connections
+            # and enables concurrent readers while a writer is active.
+            connection.execute("PRAGMA journal_mode=WAL;")
             connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS operations (
@@ -94,7 +100,28 @@ class OperationStore:
                 )
                 """
             )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_operations_subject_type_updated
+                ON operations (subject_id, operation_type, updated_at DESC)
+                """
+            )
             connection.commit()
+
+    def healthcheck(self) -> None:
+        """Verify the backing store is reachable and writable.
+
+        Raises:
+            Exception: Propagates any sqlite3.Error / OSError from opening
+                the connection or executing a trivial write-capable probe,
+                so callers can treat failure as "not ready".
+        """
+        # BEGIN IMMEDIATE acquires a RESERVED lock, which proves the database
+        # file is writable without mutating any rows.
+        with closing(self._connect()) as connection:
+            connection.execute("SELECT 1").fetchone()
+            connection.execute("BEGIN IMMEDIATE")
+            connection.rollback()
 
     @staticmethod
     def _now() -> str:
@@ -119,8 +146,10 @@ class OperationStore:
                 if row["completed_items"] is not None
                 else None
             ),
-            download_path=str(row["download_path"]) if row["download_path"] else None,
-            error=str(row["error"]) if row["error"] else None,
+            download_path=(
+                str(row["download_path"]) if row["download_path"] is not None else None
+            ),
+            error=str(row["error"]) if row["error"] is not None else None,
             metadata=json.loads(str(row["metadata"])) if row["metadata"] else {},
             created_at=str(row["created_at"]),
             updated_at=str(row["updated_at"]),

--- a/src/dyvine/core/operations.py
+++ b/src/dyvine/core/operations.py
@@ -70,10 +70,18 @@ class OperationStore:
 
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.db_path, check_same_thread=False)
-        connection.row_factory = sqlite3.Row
-        # synchronous is a per-connection PRAGMA, so reapply on every connect.
-        connection.execute("PRAGMA synchronous=NORMAL;")
-        connection.execute("PRAGMA busy_timeout=5000;")
+        try:
+            connection.row_factory = sqlite3.Row
+            # synchronous is a per-connection PRAGMA, so reapply on every connect.
+            connection.execute("PRAGMA synchronous=NORMAL;")
+            connection.execute("PRAGMA busy_timeout=5000;")
+        except Exception:
+            # A post-open configuration failure (e.g. attempting to set
+            # synchronous on a read-only WAL database) must not leak the
+            # already-opened handle, or Python 3.13 will flag it as an
+            # unclosed database on garbage collection.
+            connection.close()
+            raise
         return connection
 
     def _initialize(self) -> None:
@@ -117,11 +125,19 @@ class OperationStore:
                 so callers can treat failure as "not ready".
         """
         # BEGIN IMMEDIATE acquires a RESERVED lock, which proves the database
-        # file is writable without mutating any rows.
+        # file is writable without mutating any rows. The rollback lives in
+        # ``finally`` so a failed BEGIN never leaves a pending transaction
+        # on the connection -- Python 3.13 turns that into a ResourceWarning
+        # at close time, which becomes an error under ``-W error``.
         with closing(self._connect()) as connection:
-            connection.execute("SELECT 1").fetchone()
-            connection.execute("BEGIN IMMEDIATE")
-            connection.rollback()
+            try:
+                connection.execute("SELECT 1").fetchone()
+                connection.execute("BEGIN IMMEDIATE")
+            finally:
+                try:
+                    connection.rollback()
+                except sqlite3.Error:
+                    pass
 
     @staticmethod
     def _now() -> str:

--- a/src/dyvine/core/settings.py
+++ b/src/dyvine/core/settings.py
@@ -182,6 +182,7 @@ class R2Settings(BaseSettings):
                 self.access_key_id,
                 self.secret_access_key,
                 self.bucket_name,
+                self.endpoint,
             ]
         )
 

--- a/src/dyvine/main.py
+++ b/src/dyvine/main.py
@@ -484,7 +484,7 @@ async def readiness_probe(request: Request) -> JSONResponse:
     # makes content downloads fail at the first write.
     operation_store_ok = False
     operation_store_status = "missing"
-    if container_ok:
+    if container is not None:
         try:
             container.operation_store.healthcheck()
             operation_store_ok = True

--- a/src/dyvine/main.py
+++ b/src/dyvine/main.py
@@ -462,9 +462,48 @@ async def liveness_probe(request: Request) -> JSONResponse:
     tags=["System"],
 )
 async def readiness_probe(request: Request) -> JSONResponse:
-    """Return readiness based on required runtime dependencies."""
+    """Return readiness based on required runtime dependencies.
+
+    The probe inspects every dependency required to serve a real request
+    and fails fast (HTTP 503) if any of them are missing or unreachable.
+    The checks are intentionally conservative: a Pod that cannot accept
+    work must not be routed traffic by the orchestrator.
+    """
     correlation_id = getattr(request.state, "correlation_id", str(uuid.uuid4()))
-    ready = bool(settings.douyin.cookie and hasattr(app.state, "container"))
+
+    # Douyin API authentication cookie must be configured to reach upstream.
+    douyin_ok = bool(settings.douyin.cookie)
+    douyin_status = "configured" if douyin_ok else "missing_credentials"
+
+    # Service container must be wired before any request handler runs.
+    container = getattr(app.state, "container", None)
+    container_ok = container is not None
+    container_status = "initialized" if container_ok else "missing"
+
+    # Operation store backs asynchronous workflows; a broken SQLite path
+    # makes content downloads fail at the first write.
+    operation_store_ok = False
+    operation_store_status = "missing"
+    if container_ok:
+        try:
+            container.operation_store.healthcheck()
+            operation_store_ok = True
+            operation_store_status = "available"
+        except Exception:
+            operation_store_ok = False
+            operation_store_status = "unavailable"
+
+    # R2 storage credentials are required to persist downloaded content.
+    r2_credentials = (
+        settings.r2.access_key_id,
+        settings.r2.secret_access_key,
+        settings.r2.bucket_name,
+        settings.r2.account_id,
+    )
+    r2_ok = all(bool(value) for value in r2_credentials)
+    r2_status = "configured" if r2_ok else "missing_credentials"
+
+    ready = douyin_ok and container_ok and operation_store_ok and r2_ok
     readiness_status_code = (
         status.HTTP_200_OK if ready else status.HTTP_503_SERVICE_UNAVAILABLE
     )
@@ -473,16 +512,10 @@ async def readiness_probe(request: Request) -> JSONResponse:
         content={
             "status": "ready" if ready else "not_ready",
             "dependencies": {
-                "douyin_api": (
-                    "configured"
-                    if settings.douyin.cookie
-                    else "missing_credentials"
-                ),
-                "service_container": (
-                    "initialized"
-                    if hasattr(app.state, "container")
-                    else "missing"
-                ),
+                "douyin_api": douyin_status,
+                "service_container": container_status,
+                "operation_store": operation_store_status,
+                "r2_storage": r2_status,
             },
             "correlation_id": correlation_id,
         },

--- a/src/dyvine/main.py
+++ b/src/dyvine/main.py
@@ -493,14 +493,11 @@ async def readiness_probe(request: Request) -> JSONResponse:
             operation_store_ok = False
             operation_store_status = "unavailable"
 
-    # R2 storage credentials are required to persist downloaded content.
-    r2_credentials = (
-        settings.r2.access_key_id,
-        settings.r2.secret_access_key,
-        settings.r2.bucket_name,
-        settings.r2.account_id,
-    )
-    r2_ok = all(bool(value) for value in r2_credentials)
+    # R2 storage credentials, bucket, and endpoint are all required to
+    # persist downloaded content. Delegate to ``R2Settings.is_configured``
+    # so ``/readyz`` and ``R2StorageService`` stay in lockstep on the
+    # exact fields a real upload needs.
+    r2_ok = settings.r2.is_configured
     r2_status = "configured" if r2_ok else "missing_credentials"
 
     ready = douyin_ok and container_ok and operation_store_ok and r2_ok

--- a/src/dyvine/services/livestreams.py
+++ b/src/dyvine/services/livestreams.py
@@ -53,6 +53,10 @@ class LivestreamService:
             "proxies": base_config["proxies"],
         }
         self.download_jobs: dict[str, asyncio.Task[Any]] = {}
+        # Serializes the dedupe-check / job-registration window so concurrent
+        # callers cannot both observe an empty ``download_jobs`` across the
+        # metadata await in ``download_stream``.
+        self._dedupe_lock: asyncio.Lock | None = None
         self.user_service = user_service
         self.operation_store = operation_store
         self.douyin_handler = douyin_handler
@@ -422,6 +426,19 @@ class LivestreamService:
     # Main download orchestrator
     # ------------------------------------------------------------------
 
+    def _get_dedupe_lock(self) -> asyncio.Lock:
+        """Return the dedupe lock, creating it lazily on first use.
+
+        ``asyncio.Lock`` binds to the running event loop, so constructing it on
+        first access keeps the service usable from bare ``object.__new__``
+        stubs in unit tests and avoids tying initialization to a specific loop.
+        """
+        lock = getattr(self, "_dedupe_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._dedupe_lock = lock
+        return lock
+
     async def download_stream(
         self, url: str, output_path: str | None = None
     ) -> LiveStreamDownloadResponse:
@@ -472,9 +489,6 @@ class LivestreamService:
         )
         room_id = str(room_info.get("room_id", webcast_id) or webcast_id)
 
-        if room_id in self.download_jobs:
-            raise LivestreamError("Already downloading this stream")
-
         status_code = room_info.get("status")
         if status_code != 2:
             raise LivestreamError(
@@ -524,31 +538,41 @@ class LivestreamService:
         }
 
         target_file = output_dir / f"{room_id}_live.flv"
-        operation = self.operation_store.create_operation(
-            operation_type="livestream_download",
-            subject_id=room_id,
-            status="pending",
-            message="Livestream download scheduled",
-            progress=0.0,
-            download_path=str(target_file),
-            metadata={
-                "source_url": normalized,
-                "webcast_id": webcast_id,
-                "room_id": room_id,
-            },
-        )
 
-        job = asyncio.create_task(
-            self._run_stream_download(
-                operation.operation_id,
-                room_id,
-                download_kwargs,
-                webcast_payload,
-                output_dir,
-                target_file,
+        # Hold the dedupe lock across the check/register window so two
+        # concurrent callers for the same ``room_id`` cannot both observe an
+        # empty ``download_jobs`` and double-schedule a background task that
+        # writes to the same target file.
+        async with self._get_dedupe_lock():
+            if room_id in self.download_jobs:
+                raise LivestreamError("Already downloading this stream")
+
+            operation = self.operation_store.create_operation(
+                operation_type="livestream_download",
+                subject_id=room_id,
+                status="pending",
+                message="Livestream download scheduled",
+                progress=0.0,
+                download_path=str(target_file),
+                metadata={
+                    "source_url": normalized,
+                    "webcast_id": webcast_id,
+                    "room_id": room_id,
+                },
             )
-        )
-        self.download_jobs[room_id] = job
+
+            job = asyncio.create_task(
+                self._run_stream_download(
+                    operation.operation_id,
+                    room_id,
+                    download_kwargs,
+                    webcast_payload,
+                    output_dir,
+                    target_file,
+                )
+            )
+            self.download_jobs[room_id] = job
+
         return LiveStreamDownloadResponse(**operation.to_response())
 
     async def _run_stream_download(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,7 @@ if str(SRC_DIR) not in sys.path:
 
 
 @pytest.fixture(autouse=True)
-def reset_singletons(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def reset_singletons(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Reset cached state and isolate operation storage between tests."""
     from dyvine.core.dependencies import get_service_container
     from dyvine.core.settings import settings

--- a/tests/core/test_error_handlers.py
+++ b/tests/core/test_error_handlers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -152,6 +153,20 @@ async def test_http_exception_handler_preserves_headers() -> None:
     )
     assert resp.status_code == 405
     assert resp.headers["Allow"] == "GET"
+
+
+@pytest.mark.asyncio
+async def test_http_exception_handler_handles_none_detail() -> None:
+    req = _make_request("cid-8")
+    exc = HTTPException(status_code=500, detail=None)
+    # Starlette substitutes a default HTTP phrase when ``detail`` is ``None``;
+    # override it to exercise the genuine ``None`` branch in the handler.
+    exc.detail = None
+    resp = await http_exception_handler(req, exc)
+    assert resp.status_code == 500
+    payload = json.loads(resp.body)
+    assert payload["message"] == ""
+    assert payload["error_code"] == "HTTP_500"
 
 
 # ── register_error_handlers ─────────────────────────────────────────────

--- a/tests/core/test_error_handlers.py
+++ b/tests/core/test_error_handlers.py
@@ -43,17 +43,13 @@ def test_error_response_basic() -> None:
 
 
 def test_error_response_includes_details() -> None:
-    resp = ErrorResponse.create_response(
-        400, "bad", details={"field": "name"}
-    )
+    resp = ErrorResponse.create_response(400, "bad", details={"field": "name"})
     body = resp.body.decode()
     assert "name" in body
 
 
 def test_error_response_includes_correlation_id() -> None:
-    resp = ErrorResponse.create_response(
-        400, "bad", correlation_id="abc-123"
-    )
+    resp = ErrorResponse.create_response(400, "bad", correlation_id="abc-123")
     body = resp.body.decode()
     assert "abc-123" in body
 

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -156,7 +156,7 @@ def test_operation_store_healthcheck_fails_when_path_unwritable(tmp_path) -> Non
     os.chmod(readonly_dir, 0o555)
 
     try:
-        with pytest.raises(Exception):
+        with pytest.raises(sqlite3.OperationalError):
             store.healthcheck()
     finally:
         os.chmod(readonly_dir, 0o755)

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+from contextlib import closing
 
 import pytest
 
@@ -113,7 +114,11 @@ def test_operation_store_get_latest_operation_for_subject(tmp_path) -> None:
 def test_operation_store_enables_wal(tmp_path) -> None:
     store = OperationStore(str(tmp_path / "operations.db"))
 
-    with sqlite3.connect(store.db_path) as connection:
+    # ``sqlite3.connect`` in a ``with`` block only commits/rollbacks — it does
+    # not close the connection. Wrap it in ``closing`` so ``-W error`` does
+    # not trip the ResourceWarning emitted when the connection is garbage
+    # collected.
+    with closing(sqlite3.connect(store.db_path)) as connection:
         mode = connection.execute("PRAGMA journal_mode;").fetchone()[0]
 
     assert mode.lower() == "wal"
@@ -122,7 +127,7 @@ def test_operation_store_enables_wal(tmp_path) -> None:
 def test_operation_store_creates_lookup_index(tmp_path) -> None:
     store = OperationStore(str(tmp_path / "operations.db"))
 
-    with sqlite3.connect(store.db_path) as connection:
+    with closing(sqlite3.connect(store.db_path)) as connection:
         row = connection.execute(
             """
             SELECT name FROM sqlite_master

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import sqlite3
+
 import pytest
 
 from dyvine.core.exceptions import DownloadError
@@ -105,3 +108,68 @@ def test_operation_store_get_latest_operation_for_subject(tmp_path) -> None:
 
     assert latest.operation_id == second.operation_id
     assert latest.operation_id != first.operation_id
+
+
+def test_operation_store_enables_wal(tmp_path) -> None:
+    store = OperationStore(str(tmp_path / "operations.db"))
+
+    with sqlite3.connect(store.db_path) as connection:
+        mode = connection.execute("PRAGMA journal_mode;").fetchone()[0]
+
+    assert mode.lower() == "wal"
+
+
+def test_operation_store_creates_lookup_index(tmp_path) -> None:
+    store = OperationStore(str(tmp_path / "operations.db"))
+
+    with sqlite3.connect(store.db_path) as connection:
+        row = connection.execute(
+            """
+            SELECT name FROM sqlite_master
+            WHERE type = 'index' AND name = 'idx_operations_subject_type_updated'
+            """
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] == "idx_operations_subject_type_updated"
+
+
+def test_operation_store_healthcheck_succeeds(tmp_path) -> None:
+    store = OperationStore(str(tmp_path / "operations.db"))
+
+    store.healthcheck()
+
+
+def test_operation_store_healthcheck_fails_when_path_unwritable(tmp_path) -> None:
+    readonly_dir = tmp_path / "readonly"
+    readonly_dir.mkdir()
+    store = OperationStore(str(readonly_dir / "operations.db"))
+
+    # Drop write permissions on both the database file and its parent directory
+    # so BEGIN IMMEDIATE cannot acquire a RESERVED lock.
+    os.chmod(store.db_path, 0o444)
+    os.chmod(readonly_dir, 0o555)
+
+    try:
+        with pytest.raises(Exception):
+            store.healthcheck()
+    finally:
+        os.chmod(readonly_dir, 0o755)
+        os.chmod(store.db_path, 0o644)
+
+
+def test_operation_store_reads_back_empty_strings_as_empty(tmp_path) -> None:
+    store = OperationStore(str(tmp_path / "operations.db"))
+
+    created = store.create_operation(
+        operation_type="user_content_download",
+        subject_id="user-empty",
+        status="pending",
+        message="scheduled",
+        download_path="",
+        error="",
+    )
+
+    loaded = store.get_operation(created.operation_id)
+    assert loaded.download_path == ""
+    assert loaded.error == ""

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -64,6 +64,7 @@ def test_r2_settings_is_configured_true() -> None:
         access_key_id="key",
         secret_access_key="secret",
         bucket_name="bucket",
+        endpoint="https://example.r2.cloudflarestorage.com",
     )
     assert s.is_configured is True
 
@@ -74,6 +75,18 @@ def test_r2_settings_is_configured_false_missing_field() -> None:
         access_key_id="",
         secret_access_key="secret",
         bucket_name="bucket",
+        endpoint="https://example.r2.cloudflarestorage.com",
+    )
+    assert s.is_configured is False
+
+
+def test_r2_settings_is_configured_false_missing_endpoint() -> None:
+    s = R2Settings(
+        account_id="acc",
+        access_key_id="key",
+        secret_access_key="secret",
+        bucket_name="bucket",
+        endpoint="",
     )
     assert s.is_configured is False
 

--- a/tests/routers/test_livestreams_router.py
+++ b/tests/routers/test_livestreams_router.py
@@ -41,9 +41,7 @@ async def test_download_livestream_success(
         updated_at="2026-04-17T00:00:00+00:00",
     )
 
-    result = await download_livestream(
-        service=mock_livestream_service, user_id="u1"
-    )
+    result = await download_livestream(service=mock_livestream_service, user_id="u1")
     assert result.status == "pending"
     assert result.download_path == "/path"
 
@@ -57,9 +55,7 @@ async def test_download_livestream_user_not_found(
     mock_livestream_service.download_stream.side_effect = UserNotFoundError("nf")
 
     with pytest.raises(HTTPException) as exc_info:
-        await download_livestream(
-            service=mock_livestream_service, user_id="bad"
-        )
+        await download_livestream(service=mock_livestream_service, user_id="bad")
     assert exc_info.value.status_code == 404
 
 
@@ -72,9 +68,7 @@ async def test_download_livestream_download_error(
     mock_livestream_service.download_stream.side_effect = DownloadError("fail")
 
     with pytest.raises(HTTPException) as exc_info:
-        await download_livestream(
-            service=mock_livestream_service, user_id="u1"
-        )
+        await download_livestream(service=mock_livestream_service, user_id="u1")
     assert exc_info.value.status_code == 500
 
 
@@ -87,9 +81,7 @@ async def test_download_livestream_livestream_error(
     mock_livestream_service.download_stream.side_effect = LivestreamError("no stream")
 
     with pytest.raises(HTTPException) as exc_info:
-        await download_livestream(
-            service=mock_livestream_service, user_id="u1"
-        )
+        await download_livestream(service=mock_livestream_service, user_id="u1")
     assert exc_info.value.status_code == 404
 
 
@@ -102,9 +94,7 @@ async def test_download_livestream_unexpected_error(
     mock_livestream_service.download_stream.side_effect = RuntimeError("boom")
 
     with pytest.raises(HTTPException) as exc_info:
-        await download_livestream(
-            service=mock_livestream_service, user_id="u1"
-        )
+        await download_livestream(service=mock_livestream_service, user_id="u1")
     assert exc_info.value.status_code == 500
 
 
@@ -145,9 +135,7 @@ async def test_download_livestream_url_livestream_error(
     request = LiveStreamURLDownloadRequest(url="https://live.douyin.com/123")
 
     with pytest.raises(HTTPException) as exc_info:
-        await download_livestream_url(
-            request=request, service=mock_livestream_service
-        )
+        await download_livestream_url(request=request, service=mock_livestream_service)
     assert exc_info.value.status_code == 404
 
 
@@ -189,7 +177,5 @@ async def test_get_download_status_not_found(
     mock_livestream_service.get_download_status.side_effect = DownloadError("nf")
 
     with pytest.raises(HTTPException) as exc_info:
-        await get_download_status(
-            service=mock_livestream_service, operation_id="bad"
-        )
+        await get_download_status(service=mock_livestream_service, operation_id="bad")
     assert exc_info.value.status_code == 404

--- a/tests/routers/test_posts_router.py
+++ b/tests/routers/test_posts_router.py
@@ -33,9 +33,7 @@ def mock_post_service() -> MagicMock:
 async def test_get_post_success(mock_post_service: MagicMock) -> None:
     from dyvine.routers.posts import get_post
 
-    detail = PostDetail(
-        aweme_id="123", create_time=0, post_type=PostType.VIDEO
-    )
+    detail = PostDetail(aweme_id="123", create_time=0, post_type=PostType.VIDEO)
     mock_post_service.get_post_detail.return_value = detail
 
     result = await get_post(service=mock_post_service, post_id="123")
@@ -146,7 +144,5 @@ async def test_download_user_posts_download_error(
     mock_post_service.download_all_user_posts.side_effect = DownloadError("fail")
 
     with pytest.raises(HTTPException) as exc_info:
-        await download_user_posts(
-            service=mock_post_service, user_id="u1", max_cursor=0
-        )
+        await download_user_posts(service=mock_post_service, user_id="u1", max_cursor=0)
     assert exc_info.value.status_code == 500

--- a/tests/routers/test_users_router.py
+++ b/tests/routers/test_users_router.py
@@ -85,9 +85,7 @@ async def test_download_user_content_success(
     from dyvine.routers.users import download_user_content
 
     mock_user_service.start_download.return_value = _download_response()
-    result = await download_user_content(
-        user_id="u1", service=mock_user_service
-    )
+    result = await download_user_content(user_id="u1", service=mock_user_service)
     assert result.operation_id == "t1"
 
 
@@ -100,9 +98,7 @@ async def test_download_user_content_not_found(
     mock_user_service.start_download.side_effect = UserNotFoundError("nf")
 
     with pytest.raises(HTTPException) as exc_info:
-        await download_user_content(
-            user_id="bad", service=mock_user_service
-        )
+        await download_user_content(user_id="bad", service=mock_user_service)
     assert exc_info.value.status_code == 404
 
 
@@ -114,9 +110,7 @@ async def test_get_operation_success(mock_user_service: MagicMock) -> None:
     from dyvine.routers.users import get_operation
 
     mock_user_service.get_download_status.return_value = _download_response()
-    result = await get_operation(
-        operation_id="op1", service=mock_user_service
-    )
+    result = await get_operation(operation_id="op1", service=mock_user_service)
     assert result.status == "pending"
 
 
@@ -127,7 +121,5 @@ async def test_get_operation_not_found(mock_user_service: MagicMock) -> None:
     mock_user_service.get_download_status.side_effect = DownloadError("nf")
 
     with pytest.raises(HTTPException) as exc_info:
-        await get_operation(
-            operation_id="bad", service=mock_user_service
-        )
+        await get_operation(operation_id="bad", service=mock_user_service)
     assert exc_info.value.status_code == 404

--- a/tests/services/test_lifecycle_service.py
+++ b/tests/services/test_lifecycle_service.py
@@ -9,25 +9,27 @@ import pytest
 
 from dyvine.services.lifecycle import LifecycleError, LifecycleManager
 
-CONFIG_JSON = json.dumps({
-    "version": "1.0",
-    "rules": [
-        {
-            "content_type": "livestream",
-            "retention_days": 180,
-            "transition": {"days": 30, "storage_class": "ARCHIVE"},
-        }
-    ],
-    "audit": {
-        "enabled": True,
-        "log_format": (
-            "{timestamp} user={user} action={action} "
-            "object_key={object_key} "
-            "metadata_size={metadata_size} status={status}"
-        ),
-        "log_retention_days": 90,
-    },
-})
+CONFIG_JSON = json.dumps(
+    {
+        "version": "1.0",
+        "rules": [
+            {
+                "content_type": "livestream",
+                "retention_days": 180,
+                "transition": {"days": 30, "storage_class": "ARCHIVE"},
+            }
+        ],
+        "audit": {
+            "enabled": True,
+            "log_format": (
+                "{timestamp} user={user} action={action} "
+                "object_key={object_key} "
+                "metadata_size={metadata_size} status={status}"
+            ),
+            "log_retention_days": 90,
+        },
+    }
+)
 
 
 def _build_manager(
@@ -166,18 +168,14 @@ def test_write_audit_log_format() -> None:
         audit_config={
             "enabled": True,
             "log_format": (
-            "{timestamp} user={user} action={action} "
-            "object_key={object_key} "
-            "metadata_size={metadata_size} status={status}"
-        ),
+                "{timestamp} user={user} action={action} "
+                "object_key={object_key} "
+                "metadata_size={metadata_size} status={status}"
+            ),
             "log_retention_days": 90,
         }
     )
-    summary = {
-        "details": [
-            {"action": "delete", "object_key": "test/obj.mp4"}
-        ]
-    }
+    summary = {"details": [{"action": "delete", "object_key": "test/obj.mp4"}]}
     m = mock_open()
     with patch("builtins.open", m), patch.object(mgr, "_rotate_audit_logs"):
         mgr._write_audit_log(summary)
@@ -221,8 +219,10 @@ def test_rotate_audit_logs_removes_old_files() -> None:
     old_file.stem = "r2_lifecycle_audit.20230101"
     old_file.unlink = MagicMock()
 
-    with patch("pathlib.Path.exists", return_value=True), \
-         patch("pathlib.Path.glob", return_value=[old_file]):
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.glob", return_value=[old_file]),
+    ):
         mgr._rotate_audit_logs()
 
     old_file.unlink.assert_called_once()

--- a/tests/services/test_livestream_service.py
+++ b/tests/services/test_livestream_service.py
@@ -4,6 +4,7 @@ These tests cover the static/class methods that don't require network
 access or the f2 runtime, making them fast and deterministic.
 """
 
+import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -456,3 +457,109 @@ async def test_get_download_status_rejects_non_livestream_operation(tmp_path) ->
 
     with pytest.raises(livestreams_mod.DownloadError):
         await service.get_download_status(operation.operation_id)
+
+
+@pytest.mark.asyncio
+async def test_download_stream_serializes_concurrent_requests_same_room(
+    tmp_path,
+) -> None:
+    """Two concurrent callers for the same room must not both schedule a job.
+
+    Simulates the race where both coroutines reach the metadata await before
+    either has registered an entry in ``download_jobs``. Exactly one call must
+    succeed, the other must raise ``LivestreamError``, and only a single
+    operation record must exist for the room.
+    """
+    store = OperationStore(str(tmp_path / "operations.db"))
+    service = object.__new__(LivestreamService)
+    service.settings = SimpleNamespace(douyin_cookie="cookie")
+    service.downloader_config = {"headers": {}, "proxies": {}, "cookie": "cookie"}
+    service.download_jobs = {}
+    service.user_service = None
+    service.operation_store = store
+    service.douyin_handler = None
+    service._dedupe_lock = asyncio.Lock()
+
+    service._parse_url = lambda url: ("live.douyin.com", "/abc", "abc")  # type: ignore[method-assign]
+
+    async def resolve_webcast_id(*args, **kwargs):
+        return "webcast-1", {"room_id": "room-77", "status": 2}
+
+    async def load_live_filter(*args, **kwargs):
+        # Yield control once so both callers enter the await before either
+        # reaches the dedupe-check / registration section.
+        await asyncio.sleep(0)
+        return None
+
+    service._resolve_webcast_id = resolve_webcast_id  # type: ignore[method-assign]
+    service._load_live_filter = load_live_filter  # type: ignore[method-assign]
+    service._resolve_streams = lambda live_filter, profile: (  # type: ignore[method-assign]
+        {"HD1": "https://stream"},
+        {},
+    )
+    service._select_stream_url = lambda stream_map: "https://stream"  # type: ignore[method-assign]
+
+    # Prevent the background task from performing a real download.
+    class NoopDownloader:
+        def __init__(self, kwargs: dict[str, Any]) -> None:
+            pass
+
+        async def __aenter__(self) -> "NoopDownloader":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def create_stream_tasks(
+            self,
+            download_kwargs: dict[str, Any],
+            webcast_payload: dict[str, Any],
+            output_dir: Path,
+        ) -> None:
+            return None
+
+    original_downloader = livestreams_mod.DouyinDownloader
+    livestreams_mod.DouyinDownloader = NoopDownloader
+    try:
+        results = await asyncio.gather(
+            service.download_stream(
+                "https://live.douyin.com/abc",
+                output_path=str(tmp_path / "dl"),
+            ),
+            service.download_stream(
+                "https://live.douyin.com/abc",
+                output_path=str(tmp_path / "dl"),
+            ),
+            return_exceptions=True,
+        )
+    finally:
+        livestreams_mod.DouyinDownloader = original_downloader
+        # Await the scheduled background task so it settles before teardown.
+        job = service.download_jobs.get("room-77")
+        if job is not None:
+            await job
+
+    successes = [r for r in results if not isinstance(r, BaseException)]
+    failures = [r for r in results if isinstance(r, BaseException)]
+
+    assert len(successes) == 1, f"Expected exactly one success, got {results!r}"
+    assert len(failures) == 1, f"Expected exactly one failure, got {results!r}"
+    assert isinstance(failures[0], LivestreamError)
+    assert str(failures[0]) == "Already downloading this stream"
+
+    # Only one operation record should exist for the room.
+    latest = store.get_latest_operation_for_subject(
+        "room-77", operation_type="livestream_download"
+    )
+    assert latest is not None
+    assert latest.subject_id == "room-77"
+    connection = store._connect()  # type: ignore[attr-defined]
+    try:
+        count = connection.execute(
+            "SELECT COUNT(*) FROM operations WHERE subject_id = ? "
+            "AND operation_type = ?",
+            ("room-77", "livestream_download"),
+        ).fetchone()[0]
+    finally:
+        connection.close()
+    assert count == 1

--- a/tests/services/test_post_service.py
+++ b/tests/services/test_post_service.py
@@ -361,9 +361,7 @@ async def test_download_post_content_success() -> None:
     from pathlib import Path
 
     svc = _build_service(handler)
-    await svc._download_post_content(
-        {"aweme_id": "123"}, PostType.VIDEO, Path("/tmp")
-    )
+    await svc._download_post_content({"aweme_id": "123"}, PostType.VIDEO, Path("/tmp"))
     handler.downloader.create_download_tasks.assert_awaited_once()
 
 

--- a/tests/services/test_storage_service_extended.py
+++ b/tests/services/test_storage_service_extended.py
@@ -13,9 +13,7 @@ from dyvine.services.storage import (
 )
 
 
-def _build_service(
-    *, with_client: bool = False
-) -> R2StorageService:
+def _build_service(*, with_client: bool = False) -> R2StorageService:
     """Create R2StorageService without boto3 initialization."""
     svc = object.__new__(R2StorageService)
     if with_client:
@@ -49,8 +47,10 @@ def test_generate_livestream_path_varying_inputs() -> None:
 def test_generate_metadata_default_language_and_version() -> None:
     svc = _build_service()
     md = svc.generate_metadata(
-        author="a", category=ContentType.POSTS,
-        content_type="video/mp4", source="test",
+        author="a",
+        category=ContentType.POSTS,
+        content_type="video/mp4",
+        source="test",
     )
     assert md["language"] == "zh-CN"
     assert md["version"] == "1.0.0"
@@ -59,9 +59,12 @@ def test_generate_metadata_default_language_and_version() -> None:
 def test_generate_metadata_custom_language_and_version() -> None:
     svc = _build_service()
     md = svc.generate_metadata(
-        author="a", category=ContentType.LIVESTREAM,
-        content_type="video/mp4", source="test",
-        language="ja-JP", version="2.0.0",
+        author="a",
+        category=ContentType.LIVESTREAM,
+        content_type="video/mp4",
+        source="test",
+        language="ja-JP",
+        version="2.0.0",
     )
     assert md["language"] == "ja-JP"
     assert md["version"] == "2.0.0"
@@ -70,8 +73,10 @@ def test_generate_metadata_custom_language_and_version() -> None:
 def test_generate_metadata_file_format_from_content_type() -> None:
     svc = _build_service()
     md = svc.generate_metadata(
-        author="a", category=ContentType.POSTS,
-        content_type="image/png", source="test",
+        author="a",
+        category=ContentType.POSTS,
+        content_type="image/png",
+        source="test",
     )
     assert md["file-format"] == "png"
 
@@ -128,8 +133,10 @@ async def test_upload_file_success(tmp_path: Path) -> None:
     svc.client.generate_presigned_url.return_value = "https://signed.url"  # type: ignore[union-attr]
 
     result = await svc.upload_file(
-        f, "videos/u/test.mp4",
-        {"category": "posts"}, "video/mp4",
+        f,
+        "videos/u/test.mp4",
+        {"category": "posts"},
+        "video/mp4",
     )
     assert result["storage_path"] == "videos/u/test.mp4"
     assert result["presigned_url"] == "https://signed.url"
@@ -211,7 +218,5 @@ async def test_upload_file_guesses_content_type(tmp_path: Path) -> None:
 
     svc.client.generate_presigned_url.return_value = "https://url"  # type: ignore[union-attr]
 
-    result = await svc.upload_file(
-        f, "images/u/image.jpg", {"category": "posts"}
-    )
+    result = await svc.upload_file(f, "images/u/image.jpg", {"category": "posts"})
     assert "image" in result["content_type"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,6 +24,7 @@ def prime_ready_dependencies(
         "access_key_id": settings.r2.access_key_id,
         "secret_access_key": settings.r2.secret_access_key,
         "bucket_name": settings.r2.bucket_name,
+        "endpoint": settings.r2.endpoint,
     }
 
     settings.douyin.cookie = "dummy-cookie"
@@ -31,6 +32,7 @@ def prime_ready_dependencies(
     settings.r2.access_key_id = "key"
     settings.r2.secret_access_key = "secret"
     settings.r2.bucket_name = "bucket"
+    settings.r2.endpoint = "https://example.r2.cloudflarestorage.com"
 
     try:
         with TestClient(app) as client:
@@ -45,6 +47,7 @@ def prime_ready_dependencies(
         settings.r2.access_key_id = original_r2["access_key_id"]
         settings.r2.secret_access_key = original_r2["secret_access_key"]
         settings.r2.bucket_name = original_r2["bucket_name"]
+        settings.r2.endpoint = original_r2["endpoint"]
 
 
 def test_read_main():
@@ -116,6 +119,7 @@ def test_readiness_probe_returns_not_ready_when_operation_store_broken(
         "access_key_id": settings.r2.access_key_id,
         "secret_access_key": settings.r2.secret_access_key,
         "bucket_name": settings.r2.bucket_name,
+        "endpoint": settings.r2.endpoint,
     }
 
     settings.douyin.cookie = "dummy-cookie"
@@ -123,6 +127,7 @@ def test_readiness_probe_returns_not_ready_when_operation_store_broken(
     settings.r2.access_key_id = "key"
     settings.r2.secret_access_key = "secret"
     settings.r2.bucket_name = "bucket"
+    settings.r2.endpoint = "https://example.r2.cloudflarestorage.com"
 
     def _raise() -> None:
         raise sqlite3.OperationalError("disk I/O error")
@@ -143,6 +148,7 @@ def test_readiness_probe_returns_not_ready_when_operation_store_broken(
         settings.r2.access_key_id = original_r2["access_key_id"]
         settings.r2.secret_access_key = original_r2["secret_access_key"]
         settings.r2.bucket_name = original_r2["bucket_name"]
+        settings.r2.endpoint = original_r2["endpoint"]
 
 
 def test_readiness_probe_returns_not_ready_when_r2_missing(
@@ -154,6 +160,7 @@ def test_readiness_probe_returns_not_ready_when_r2_missing(
         "access_key_id": settings.r2.access_key_id,
         "secret_access_key": settings.r2.secret_access_key,
         "bucket_name": settings.r2.bucket_name,
+        "endpoint": settings.r2.endpoint,
     }
 
     settings.douyin.cookie = "dummy-cookie"
@@ -161,6 +168,7 @@ def test_readiness_probe_returns_not_ready_when_r2_missing(
     settings.r2.access_key_id = ""
     settings.r2.secret_access_key = ""
     settings.r2.bucket_name = ""
+    settings.r2.endpoint = ""
 
     try:
         with TestClient(app) as client:
@@ -180,6 +188,50 @@ def test_readiness_probe_returns_not_ready_when_r2_missing(
         settings.r2.access_key_id = original_r2["access_key_id"]
         settings.r2.secret_access_key = original_r2["secret_access_key"]
         settings.r2.bucket_name = original_r2["bucket_name"]
+        settings.r2.endpoint = original_r2["endpoint"]
+
+
+def test_readiness_probe_returns_not_ready_when_r2_endpoint_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Covers the bug where /readyz passed while ``settings.r2.endpoint`` was
+    empty, even though ``R2StorageService`` disables itself in that state.
+    """
+    original_cookie = settings.douyin.cookie
+    original_r2 = {
+        "account_id": settings.r2.account_id,
+        "access_key_id": settings.r2.access_key_id,
+        "secret_access_key": settings.r2.secret_access_key,
+        "bucket_name": settings.r2.bucket_name,
+        "endpoint": settings.r2.endpoint,
+    }
+
+    settings.douyin.cookie = "dummy-cookie"
+    settings.r2.account_id = "acc"
+    settings.r2.access_key_id = "key"
+    settings.r2.secret_access_key = "secret"
+    settings.r2.bucket_name = "bucket"
+    settings.r2.endpoint = ""
+
+    try:
+        with TestClient(app) as client:
+            container = app.state.container
+            monkeypatch.setattr(
+                container.operation_store, "healthcheck", lambda: None
+            )
+            response = client.get("/readyz")
+
+            assert response.status_code == 503
+            data = response.json()
+            assert data["status"] == "not_ready"
+            assert data["dependencies"]["r2_storage"] == "missing_credentials"
+    finally:
+        settings.douyin.cookie = original_cookie
+        settings.r2.account_id = original_r2["account_id"]
+        settings.r2.access_key_id = original_r2["access_key_id"]
+        settings.r2.secret_access_key = original_r2["secret_access_key"]
+        settings.r2.bucket_name = original_r2["bucket_name"]
+        settings.r2.endpoint = original_r2["endpoint"]
 
 
 def test_invalid_request_id_is_regenerated():
@@ -203,6 +255,7 @@ def test_health_check_degraded_when_r2_missing():
             "access_key_id": settings.r2.access_key_id,
             "secret_access_key": settings.r2.secret_access_key,
             "bucket_name": settings.r2.bucket_name,
+            "endpoint": settings.r2.endpoint,
         }
 
         try:
@@ -211,6 +264,7 @@ def test_health_check_degraded_when_r2_missing():
             settings.r2.access_key_id = ""
             settings.r2.secret_access_key = ""
             settings.r2.bucket_name = ""
+            settings.r2.endpoint = ""
 
             response = client.get("/health")
 
@@ -226,6 +280,7 @@ def test_health_check_degraded_when_r2_missing():
             settings.r2.access_key_id = original_r2["access_key_id"]
             settings.r2.secret_access_key = original_r2["secret_access_key"]
             settings.r2.bucket_name = original_r2["bucket_name"]
+            settings.r2.endpoint = original_r2["endpoint"]
 
 
 def test_metrics_endpoint_exposed() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,50 @@
+import sqlite3
 import uuid
+from collections.abc import Iterator
 
+import pytest
 from fastapi.testclient import TestClient
 
 from dyvine.core.settings import settings
 from dyvine.main import app
+
+
+@pytest.fixture
+def prime_ready_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[TestClient]:
+    """Yield a TestClient with all readiness dependencies configured to pass.
+
+    The fixture restores the original settings on exit and exposes the
+    running client so individual tests can further tweak the environment.
+    """
+    original_cookie = settings.douyin.cookie
+    original_r2 = {
+        "account_id": settings.r2.account_id,
+        "access_key_id": settings.r2.access_key_id,
+        "secret_access_key": settings.r2.secret_access_key,
+        "bucket_name": settings.r2.bucket_name,
+    }
+
+    settings.douyin.cookie = "dummy-cookie"
+    settings.r2.account_id = "acc"
+    settings.r2.access_key_id = "key"
+    settings.r2.secret_access_key = "secret"
+    settings.r2.bucket_name = "bucket"
+
+    try:
+        with TestClient(app) as client:
+            container = app.state.container
+            monkeypatch.setattr(
+                container.operation_store, "healthcheck", lambda: None
+            )
+            yield client
+    finally:
+        settings.douyin.cookie = original_cookie
+        settings.r2.account_id = original_r2["account_id"]
+        settings.r2.access_key_id = original_r2["access_key_id"]
+        settings.r2.secret_access_key = original_r2["secret_access_key"]
+        settings.r2.bucket_name = original_r2["bucket_name"]
 
 
 def test_read_main():
@@ -20,40 +61,38 @@ def test_read_main():
         assert data["features"] == ["users", "posts", "livestreams"]
 
 
-def test_health_check_healthy_response():
-    with TestClient(app) as client:
-        original_cookie = settings.douyin.cookie
-        original_r2 = {
-            "account_id": settings.r2.account_id,
-            "access_key_id": settings.r2.access_key_id,
-            "secret_access_key": settings.r2.secret_access_key,
-            "bucket_name": settings.r2.bucket_name,
-        }
+def test_readiness_probe_returns_ready_when_all_dependencies_ok(
+    prime_ready_dependencies: TestClient,
+) -> None:
+    response = prime_ready_dependencies.get("/readyz")
 
-        try:
-            settings.douyin.cookie = "dummy-cookie"
-            settings.r2.account_id = "acc"
-            settings.r2.access_key_id = "key"
-            settings.r2.secret_access_key = "secret"
-            settings.r2.bucket_name = "bucket"
-
-            request_id = str(uuid.uuid4())
-            response = client.get("/readyz", headers={"X-Request-ID": request_id})
-
-            assert response.status_code == 200
-            data = response.json()
-            assert data["status"] == "ready"
-            assert data["correlation_id"] == request_id
-            assert response.headers["X-Correlation-ID"] == request_id
-        finally:
-            settings.douyin.cookie = original_cookie
-            settings.r2.account_id = original_r2["account_id"]
-            settings.r2.access_key_id = original_r2["access_key_id"]
-            settings.r2.secret_access_key = original_r2["secret_access_key"]
-            settings.r2.bucket_name = original_r2["bucket_name"]
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ready"
+    assert data["dependencies"] == {
+        "douyin_api": "configured",
+        "service_container": "initialized",
+        "operation_store": "available",
+        "r2_storage": "configured",
+    }
 
 
-def test_health_check_missing_douyin_cookie_is_unhealthy():
+def test_readiness_probe_returns_ready_with_request_id(
+    prime_ready_dependencies: TestClient,
+) -> None:
+    request_id = str(uuid.uuid4())
+    response = prime_ready_dependencies.get(
+        "/readyz", headers={"X-Request-ID": request_id}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ready"
+    assert data["correlation_id"] == request_id
+    assert response.headers["X-Correlation-ID"] == request_id
+
+
+def test_readiness_probe_returns_not_ready_when_douyin_cookie_missing() -> None:
     with TestClient(app) as client:
         original_cookie = settings.douyin.cookie
         try:
@@ -63,8 +102,84 @@ def test_health_check_missing_douyin_cookie_is_unhealthy():
             assert response.status_code == 503
             data = response.json()
             assert data["status"] == "not_ready"
+            assert data["dependencies"]["douyin_api"] == "missing_credentials"
         finally:
             settings.douyin.cookie = original_cookie
+
+
+def test_readiness_probe_returns_not_ready_when_operation_store_broken(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_cookie = settings.douyin.cookie
+    original_r2 = {
+        "account_id": settings.r2.account_id,
+        "access_key_id": settings.r2.access_key_id,
+        "secret_access_key": settings.r2.secret_access_key,
+        "bucket_name": settings.r2.bucket_name,
+    }
+
+    settings.douyin.cookie = "dummy-cookie"
+    settings.r2.account_id = "acc"
+    settings.r2.access_key_id = "key"
+    settings.r2.secret_access_key = "secret"
+    settings.r2.bucket_name = "bucket"
+
+    def _raise() -> None:
+        raise sqlite3.OperationalError("disk I/O error")
+
+    try:
+        with TestClient(app) as client:
+            container = app.state.container
+            monkeypatch.setattr(container.operation_store, "healthcheck", _raise)
+            response = client.get("/readyz")
+
+            assert response.status_code == 503
+            data = response.json()
+            assert data["status"] == "not_ready"
+            assert data["dependencies"]["operation_store"] == "unavailable"
+    finally:
+        settings.douyin.cookie = original_cookie
+        settings.r2.account_id = original_r2["account_id"]
+        settings.r2.access_key_id = original_r2["access_key_id"]
+        settings.r2.secret_access_key = original_r2["secret_access_key"]
+        settings.r2.bucket_name = original_r2["bucket_name"]
+
+
+def test_readiness_probe_returns_not_ready_when_r2_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_cookie = settings.douyin.cookie
+    original_r2 = {
+        "account_id": settings.r2.account_id,
+        "access_key_id": settings.r2.access_key_id,
+        "secret_access_key": settings.r2.secret_access_key,
+        "bucket_name": settings.r2.bucket_name,
+    }
+
+    settings.douyin.cookie = "dummy-cookie"
+    settings.r2.account_id = ""
+    settings.r2.access_key_id = ""
+    settings.r2.secret_access_key = ""
+    settings.r2.bucket_name = ""
+
+    try:
+        with TestClient(app) as client:
+            container = app.state.container
+            monkeypatch.setattr(
+                container.operation_store, "healthcheck", lambda: None
+            )
+            response = client.get("/readyz")
+
+            assert response.status_code == 503
+            data = response.json()
+            assert data["status"] == "not_ready"
+            assert data["dependencies"]["r2_storage"] == "missing_credentials"
+    finally:
+        settings.douyin.cookie = original_cookie
+        settings.r2.account_id = original_r2["account_id"]
+        settings.r2.access_key_id = original_r2["access_key_id"]
+        settings.r2.secret_access_key = original_r2["secret_access_key"]
+        settings.r2.bucket_name = original_r2["bucket_name"]
 
 
 def test_invalid_request_id_is_regenerated():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,9 +37,7 @@ def prime_ready_dependencies(
     try:
         with TestClient(app) as client:
             container = app.state.container
-            monkeypatch.setattr(
-                container.operation_store, "healthcheck", lambda: None
-            )
+            monkeypatch.setattr(container.operation_store, "healthcheck", lambda: None)
             yield client
     finally:
         settings.douyin.cookie = original_cookie
@@ -173,9 +171,7 @@ def test_readiness_probe_returns_not_ready_when_r2_missing(
     try:
         with TestClient(app) as client:
             container = app.state.container
-            monkeypatch.setattr(
-                container.operation_store, "healthcheck", lambda: None
-            )
+            monkeypatch.setattr(container.operation_store, "healthcheck", lambda: None)
             response = client.get("/readyz")
 
             assert response.status_code == 503
@@ -216,9 +212,7 @@ def test_readiness_probe_returns_not_ready_when_r2_endpoint_missing(
     try:
         with TestClient(app) as client:
             container = app.state.container
-            monkeypatch.setattr(
-                container.operation_store, "healthcheck", lambda: None
-            )
+            monkeypatch.setattr(container.operation_store, "healthcheck", lambda: None)
             response = client.get("/readyz")
 
             assert response.status_code == 503


### PR DESCRIPTION
## Summary
Follow-up to #35: replace the pod-local `emptyDir` for operation state with an RWO PVC, broaden the `/readyz` probe to cover SQLite and R2, enable SQLite WAL plus a lookup index, add an `asyncio.Lock` around the livestream dedupe window, and normalize `HTTPException(detail=None)` in the error envelope.

## Related
- Follow-up to #35 (review comments)

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| Operation state volume | `emptyDir` (reset on Pod recreate) | `ReadWriteOnce` PVC `dyvine-operation-state` (1Gi) at `/app/data` | Restores the persistence claim that #35 made |
| `/readyz` dependencies | `douyin_api`, `service_container` | Adds `operation_store.healthcheck()` and `r2_storage` credential check | Prevents routing traffic to Pods that cannot serve downloads |
| SQLite backing store | `journal_mode=DELETE`, no indexes | WAL, `synchronous=NORMAL`, `busy_timeout=5000`, composite index `(subject_id, operation_type, updated_at DESC)` | Lowers write latency and eliminates the full scan in `get_latest_operation_for_subject` |
| Livestream dedupe | Unlocked check after the metadata `await` | Lazy `asyncio.Lock` covers check → `create_operation` → `create_task` → registration | Defensive: keeps the invariant from regressing if an `await` is ever added to the critical section |
| `HTTPException` envelope | `str(None) == "None"` leaked into `message` | Empty string when `detail is None` | Prevents misleading error payloads |
| HPA | `min=max=1` without context | Same values with an inline rationale comment | Makes the pinned scaling intentional, documents the single-writer PVC constraint |
| Docs | Persistence claim, `/health` 503 semantics change, probe split all undocumented | README covers persistent storage, probe split, and the `/health` breaking change | Keeps ops-facing docs truthful |

## Details
### Updates Operation state volume from `emptyDir` to RWO PVC
- Design/Spec: Add `k8s/base/core/pvc.yaml` (`ReadWriteOnce`, 1Gi, default StorageClass) and mount it at `/app/data` in `deployment.yaml`. `runtime-logs` and `runtime-temp` stay `emptyDir`.
- Implementation notes: The base kustomization now includes `core/pvc.yaml`. The overlay still pins `replicas: 1` because SQLite is single-writer.
- Reviewer focus: Volume wiring in `deployment.yaml` and ordering in `k8s/base/kustomization.yaml`.

### Updates `/readyz` dependencies
- Design/Spec: Four dependency keys (`douyin_api`, `service_container`, `operation_store`, `r2_storage`). Any failure returns `503 Not Ready`.
- Implementation notes: The `operation_store` key calls `OperationStore.healthcheck()`, which runs `SELECT 1` and `BEGIN IMMEDIATE; ROLLBACK;` to prove the file is reachable and writable without mutating rows. All exceptions map to `unavailable` without escaping the handler.
- Reviewer focus: Confirm the probe never 500s and that existing `/health` rendering is unaffected.

### Updates SQLite backing store
- Design/Spec: Enable WAL in `_initialize()`, reapply `synchronous` and `busy_timeout` per connection, add `idx_operations_subject_type_updated`.
- Implementation notes: `_from_row` preserves empty strings for `download_path`/`error`. `healthcheck()` acquires a `RESERVED` lock only.
- Reviewer focus: PRAGMA re-application on every connection and backward compatibility of the new index against existing databases.

### Updates Livestream dedupe
- Design/Spec: Lazy `asyncio.Lock` on `LivestreamService` binds to the running event loop on first use.
- Implementation notes: Critical section now covers the full check → `create_operation` → `create_task` → registration window. Added a concurrent-request regression test that asserts exactly one caller wins.
- Reviewer focus: Lock lifetime and that `object.__new__`-based test stubs remain compatible.

### Updates `HTTPException` envelope
- Design/Spec: The `else` branch returns an empty `message` instead of the literal string `"None"`.
- Implementation notes: Dict branch and header forwarding unchanged.
- Reviewer focus: Dedicated regression test that constructs `HTTPException(detail=None)`.

## Testing
- `uv run pytest -q --no-cov` -- 251 passed
- `kubectl kustomize k8s/base` -- succeeds (208 lines of rendered YAML). The existing overlay build failure (`patchesJson6902` deprecation + `configMapGenerator behavior: merge`) predates this PR and is not addressed here.
- Manual steps: Not run.

## Screenshots / Notes
- Not applicable.

## Breaking changes
- `/health` now returns `200` for `degraded` (for example, when R2 credentials are missing); only `unhealthy` returns `503`. Monitoring pipelines that rely on `/health` to page on `degraded` should migrate to `/readyz`, which fails closed when any dependency is missing or unreachable.

## Risks and rollout
- PVC provisioning depends on the cluster's default StorageClass. Clusters without a default StorageClass must set `storageClassName` via an overlay before the Pod can schedule.
- Upgrading from `emptyDir` to the PVC discards the existing in-flight operation state once (the volumes are distinct). This is consistent with the #35 assumption that state was already non-durable across Pod recreations.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted
