### PR TITLE
perf(services): run R2 storage and lifecycle audit IO off the event loop

### DIFF
--- a/src/dyvine/services/lifecycle.py
+++ b/src/dyvine/services/lifecycle.py
@@ -11,6 +11,7 @@ The service reads rules from storage_lifecycle.json and applies them to stored
 content based on content type and age.
 """
 
+import asyncio
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -133,7 +134,7 @@ class LifecycleManager:
 
             # Generate audit log
             if self.audit_config["enabled"]:
-                self._write_audit_log(summary)
+                await self._write_audit_log(summary)
 
             return summary
 
@@ -192,34 +193,42 @@ class LifecycleManager:
 
         return None
 
-    def _write_audit_log(self, summary: dict[str, Any]) -> None:
+    async def _write_audit_log(self, summary: dict[str, Any]) -> None:
         """Write lifecycle actions to audit log.
 
         Args:
             summary: Summary of actions taken
         """
         try:
-            now = datetime.now(UTC)
-            log_path = Path("logs/r2_lifecycle_audit.log")
-            log_path.parent.mkdir(exist_ok=True)
-
-            with open(log_path, "a") as f:
-                for action in summary["details"]:
-                    log_entry = self.audit_config["log_format"].format(
-                        timestamp=now.isoformat(),
-                        user="system",
-                        action=action["action"],
-                        object_key=action["object_key"],
-                        metadata_size="0B",
-                        status="success",
-                    )
-                    f.write(log_entry + "\n")
-
-            # Rotate old logs
-            self._rotate_audit_logs()
-
+            await asyncio.to_thread(self._write_audit_log_sync, summary)
         except Exception as e:
             logger.exception("Failed to write audit log", extra={"error": str(e)})
+
+    def _write_audit_log_sync(self, summary: dict[str, Any]) -> None:
+        """Perform the blocking file write and log rotation off the loop.
+
+        Keeping ``open``/``write`` together with ``_rotate_audit_logs`` in a
+        single sync helper means the caller pays for exactly one thread
+        hand-off instead of one per IO operation.
+        """
+        now = datetime.now(UTC)
+        log_path = Path("logs/r2_lifecycle_audit.log")
+        log_path.parent.mkdir(exist_ok=True)
+
+        with open(log_path, "a") as f:
+            for action in summary["details"]:
+                log_entry = self.audit_config["log_format"].format(
+                    timestamp=now.isoformat(),
+                    user="system",
+                    action=action["action"],
+                    object_key=action["object_key"],
+                    metadata_size="0B",
+                    status="success",
+                )
+                f.write(log_entry + "\n")
+
+        # Rotate old logs within the same worker thread.
+        self._rotate_audit_logs()
 
     def _rotate_audit_logs(self) -> None:
         """Rotate audit logs based on retention policy."""

--- a/src/dyvine/services/storage.py
+++ b/src/dyvine/services/storage.py
@@ -476,13 +476,14 @@ class R2StorageService:
             raise StorageError(f"List objects failed: {str(e)}") from e
 
     def _list_objects_sync(self, *, prefix: str, max_keys: int) -> list[dict[str, Any]]:
-        """Paginate object listings and fan out per-object ``head_object``.
+        """Run one ``list_objects_v2`` plus the per-object ``head_object`` fan-out.
 
         Kept in a private sync method so the whole listing -- including the
         N follow-up ``head_object`` calls that carry object metadata -- runs
         in a single worker thread rather than bouncing every call back to
-        the event loop. The N+1 shape is still present and is tracked as a
-        separate optimization item.
+        the event loop. ``max_keys`` caps the single page; callers that need
+        more than one page are expected to paginate themselves. The N+1
+        shape is tracked as a separate optimization item.
         """
         assert self.client is not None and self.bucket is not None
         response = self.client.list_objects_v2(

--- a/src/dyvine/services/storage.py
+++ b/src/dyvine/services/storage.py
@@ -10,6 +10,7 @@ R2 storage operations including:
 
 """
 
+import asyncio
 import base64
 import mimetypes
 import time
@@ -304,14 +305,13 @@ class R2StorageService:
                 },
             )
 
-            with open(file_path, "rb") as f:
-                self.client.put_object(
-                    Bucket=self.bucket,
-                    Key=storage_path,
-                    Body=f,
-                    ContentType=content_type,
-                    Metadata=metadata,
-                )
+            url = await asyncio.to_thread(
+                self._upload_file_sync,
+                file_path=file_path,
+                storage_path=storage_path,
+                content_type=content_type,
+                metadata=metadata,
+            )
 
             duration = time.time() - start_time
 
@@ -329,13 +329,6 @@ class R2StorageService:
             r2_upload_requests.labels(type=metadata["category"], status="success").inc()
             r2_upload_bytes.labels(category=metadata["category"]).inc(file_size)
             r2_upload_duration.observe(duration)
-
-            # Generate presigned URL for temporary access (default 1 hour)
-            url = self.client.generate_presigned_url(
-                "get_object",
-                Params={"Bucket": self.bucket, "Key": storage_path},
-                ExpiresIn=3600,  # 1 hour
-            )
 
             logger.info(
                 "File uploaded successfully",
@@ -364,6 +357,36 @@ class R2StorageService:
             )
             raise StorageError(f"Upload failed: {str(e)}") from e
 
+    def _upload_file_sync(
+        self,
+        *,
+        file_path: Path,
+        storage_path: str,
+        content_type: str,
+        metadata: dict[str, str],
+    ) -> str:
+        """Run the blocking upload + presign pair on a worker thread.
+
+        ``put_object`` needs the file handle to stay open for the duration of
+        the request, so the file read and the upload live together. The
+        presigned URL is generated in the same thread to keep the entire
+        boto3 interaction off the event loop.
+        """
+        assert self.client is not None and self.bucket is not None
+        with open(file_path, "rb") as f:
+            self.client.put_object(
+                Bucket=self.bucket,
+                Key=storage_path,
+                Body=f,
+                ContentType=content_type,
+                Metadata=metadata,
+            )
+        return self.client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self.bucket, "Key": storage_path},
+            ExpiresIn=3600,  # 1 hour
+        )
+
     async def get_object_metadata(self, storage_path: str) -> dict[str, str]:
         """Get metadata for an object in R2 storage.
 
@@ -382,7 +405,9 @@ class R2StorageService:
             )
 
         try:
-            response = self.client.head_object(Bucket=self.bucket, Key=storage_path)
+            response = await asyncio.to_thread(
+                self.client.head_object, Bucket=self.bucket, Key=storage_path
+            )
             return response.get("Metadata", {})
 
         except ClientError as e:
@@ -405,7 +430,9 @@ class R2StorageService:
             )
 
         try:
-            self.client.delete_object(Bucket=self.bucket, Key=storage_path)
+            await asyncio.to_thread(
+                self.client.delete_object, Bucket=self.bucket, Key=storage_path
+            )
             logger.info("Object deleted", extra={"storage_path": storage_path})
 
         except ClientError as e:
@@ -439,35 +466,46 @@ class R2StorageService:
             )
 
         try:
-            response = self.client.list_objects_v2(
-                Bucket=self.bucket, Prefix=prefix, MaxKeys=max_keys
+            return await asyncio.to_thread(
+                self._list_objects_sync, prefix=prefix, max_keys=max_keys
             )
-
-            objects = response.get("Contents", [])
-            results: list[dict[str, Any]] = []
-            for obj in objects:
-                obj_data: dict[str, Any] = {
-                    "Key": obj.get("Key"),
-                    "LastModified": obj.get("LastModified"),
-                    "ETag": obj.get("ETag"),
-                    "Size": obj.get("Size"),
-                    "StorageClass": obj.get("StorageClass"),
-                }
-                try:
-                    if "Key" in obj and obj["Key"]:
-                        head = self.client.head_object(
-                            Bucket=self.bucket, Key=obj["Key"]
-                        )
-                        obj_data["Metadata"] = head.get("Metadata", {})
-                    else:
-                        obj_data["Metadata"] = {}
-                except ClientError:
-                    obj_data["Metadata"] = {}
-                results.append(obj_data)
-            return results
-
         except ClientError as e:
             logger.exception(
                 "List objects failed", extra={"prefix": prefix, "error": str(e)}
             )
             raise StorageError(f"List objects failed: {str(e)}") from e
+
+    def _list_objects_sync(self, *, prefix: str, max_keys: int) -> list[dict[str, Any]]:
+        """Paginate object listings and fan out per-object ``head_object``.
+
+        Kept in a private sync method so the whole listing -- including the
+        N follow-up ``head_object`` calls that carry object metadata -- runs
+        in a single worker thread rather than bouncing every call back to
+        the event loop. The N+1 shape is still present and is tracked as a
+        separate optimization item.
+        """
+        assert self.client is not None and self.bucket is not None
+        response = self.client.list_objects_v2(
+            Bucket=self.bucket, Prefix=prefix, MaxKeys=max_keys
+        )
+
+        objects = response.get("Contents", [])
+        results: list[dict[str, Any]] = []
+        for obj in objects:
+            obj_data: dict[str, Any] = {
+                "Key": obj.get("Key"),
+                "LastModified": obj.get("LastModified"),
+                "ETag": obj.get("ETag"),
+                "Size": obj.get("Size"),
+                "StorageClass": obj.get("StorageClass"),
+            }
+            try:
+                if "Key" in obj and obj["Key"]:
+                    head = self.client.head_object(Bucket=self.bucket, Key=obj["Key"])
+                    obj_data["Metadata"] = head.get("Metadata", {})
+                else:
+                    obj_data["Metadata"] = {}
+            except ClientError:
+                obj_data["Metadata"] = {}
+            results.append(obj_data)
+        return results

--- a/tests/services/test_lifecycle_service.py
+++ b/tests/services/test_lifecycle_service.py
@@ -163,7 +163,8 @@ async def test_apply_lifecycle_rules_skips_current() -> None:
 # ── _write_audit_log ────────────────────────────────────────────────────
 
 
-def test_write_audit_log_format() -> None:
+@pytest.mark.asyncio
+async def test_write_audit_log_format() -> None:
     mgr = _build_manager(
         audit_config={
             "enabled": True,
@@ -178,7 +179,7 @@ def test_write_audit_log_format() -> None:
     summary = {"details": [{"action": "delete", "object_key": "test/obj.mp4"}]}
     m = mock_open()
     with patch("builtins.open", m), patch.object(mgr, "_rotate_audit_logs"):
-        mgr._write_audit_log(summary)
+        await mgr._write_audit_log(summary)
     written = m().write.call_args[0][0]
     assert "delete" in written
     assert "test/obj.mp4" in written

--- a/tests/services/test_storage_service_extended.py
+++ b/tests/services/test_storage_service_extended.py
@@ -211,6 +211,55 @@ async def test_delete_object_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_delete_object_client_error_surfaces_as_storage_error() -> None:
+    from botocore.exceptions import ClientError
+
+    svc = _build_service(with_client=True)
+    svc.client.delete_object.side_effect = ClientError(  # type: ignore[union-attr]
+        {"Error": {"Code": "AccessDenied"}}, "DeleteObject"
+    )
+
+    with pytest.raises(StorageError, match="Deletion failed"):
+        await svc.delete_object("videos/u1/clip.mp4")
+
+
+@pytest.mark.asyncio
+async def test_list_objects_per_item_head_error_returns_empty_metadata() -> None:
+    from botocore.exceptions import ClientError
+
+    svc = _build_service(with_client=True)
+    svc.client.list_objects_v2.return_value = {  # type: ignore[union-attr]
+        "Contents": [
+            {"Key": "videos/u1/a.mp4", "Size": 1},
+            {"Key": "videos/u1/b.mp4", "Size": 2},
+        ]
+    }
+    svc.client.head_object.side_effect = [  # type: ignore[union-attr]
+        {"Metadata": {"author": "one"}},
+        ClientError({"Error": {"Code": "AccessDenied"}}, "HeadObject"),
+    ]
+
+    results = await svc.list_objects("videos/u1/")
+
+    assert [r["Key"] for r in results] == ["videos/u1/a.mp4", "videos/u1/b.mp4"]
+    assert results[0]["Metadata"] == {"author": "one"}
+    assert results[1]["Metadata"] == {}
+
+
+@pytest.mark.asyncio
+async def test_list_objects_client_error_surfaces_as_storage_error() -> None:
+    from botocore.exceptions import ClientError
+
+    svc = _build_service(with_client=True)
+    svc.client.list_objects_v2.side_effect = ClientError(  # type: ignore[union-attr]
+        {"Error": {"Code": "AccessDenied"}}, "ListObjectsV2"
+    )
+
+    with pytest.raises(StorageError, match="List objects failed"):
+        await svc.list_objects("videos/u1/")
+
+
+@pytest.mark.asyncio
 async def test_upload_file_guesses_content_type(tmp_path: Path) -> None:
     svc = _build_service(with_client=True)
     f = tmp_path / "image.jpg"


### PR DESCRIPTION
## Summary
Continues the async-IO work that closed A-P0-1 in #38 by offloading the remaining synchronous calls that still ran on the event loop: four boto3 paths in `R2StorageService` and the audit-log writer in `LifecycleManager`.

## Related
- Follow-up to #38 (OperationStore sqlite off-loop).

## Updates
| Path | Before | After | Why it matters |
| --- | --- | --- | --- |
| `R2StorageService.upload_file` | `open(...)` + `put_object(Body=f)` + `generate_presigned_url` on the awaiting thread | Private `_upload_file_sync` runs the full file-open + `put_object` + presign sequence in one worker thread dispatched via `asyncio.to_thread` | A single multi-megabyte upload no longer stalls the rest of the worker's requests. |
| `R2StorageService.get_object_metadata` / `.delete_object` | Direct `self.client.head_object` / `delete_object` on the loop | `asyncio.to_thread(self.client.<op>, ...)` | Each call blocked for a full round-trip to R2. |
| `R2StorageService.list_objects` | `list_objects_v2` + N follow-up `head_object` calls on the loop | `_list_objects_sync` keeps the full N+1 sweep inside one worker thread | The list plus per-object metadata fan-out now costs one hand-off instead of N+1. |
| `LifecycleManager._write_audit_log` | Synchronous `open` + per-action `write` + `_rotate_audit_logs` scan on the loop | Coroutine that dispatches `_write_audit_log_sync`; caller awaits it | A large summary or slow volume no longer blocks other coroutines through the loop. |

## Details
### R2 storage operations
- Design/Spec: Keep the module-level async signatures unchanged. Boto3 calls now either go through `asyncio.to_thread(self.client.<op>, ...)` for single-call paths or through a private `_*_sync` helper for paths that need to coordinate several calls in the same thread.
- Implementation notes: `_upload_file_sync` must hold the file handle across `put_object`; `_list_objects_sync` intentionally performs the per-object `head_object` fan-out inside the same worker thread so the whole N+1 never crosses the event-loop boundary.
- Exception handling is unchanged from `main`:
  - `upload_file` keeps its broad `except Exception` guard, so both `ClientError` and `BotoCoreError` (and any other boto3 failure) are wrapped in `StorageError`.
  - `get_object_metadata` / `delete_object` / `list_objects` still only catch `ClientError` (mapped to `StorageError`); a `BotoCoreError` surfaces to the caller as-is, matching pre-PR behavior.
- Reviewer focus: the presigned URL is generated inside the same thread as the upload; both calls are synchronous boto3 ops, so HEAD + presign transactional semantics are preserved.

### Lifecycle audit log
- Design/Spec: `_write_audit_log` becomes a coroutine. A private `_write_audit_log_sync` keeps `open`, the write loop, and `_rotate_audit_logs` together so the thread hand-off cost is paid once.
- Implementation notes: `_rotate_audit_logs` remains synchronous because it is only ever invoked through the new sync helper.
- Reviewer focus: `test_write_audit_log_format` now awaits the coroutine; `mock_open` still works because the patch site is unchanged.

## Testing
- `uv run pytest --cov=src/dyvine --cov-fail-under=80 -W error -q` — 262 passed, coverage 86.01%.
- `uv run black --check .` / `uv run ruff check .` / `uv run mypy src/` — all clean.
- New tests: `delete_object` and `list_objects` both verify `ClientError` surfaces as `StorageError` through the `asyncio.to_thread` boundary, plus the per-item `head_object` failure path in `_list_objects_sync`.
- Manual steps: Not run.

## Screenshots / Notes
- Not applicable.

## Breaking changes
- `LifecycleManager._write_audit_log` is now `async def`. Anything outside this repo that called it synchronously would need an `await`. No callers exist outside `apply_lifecycle_rules`.

## Risks and rollout
- `asyncio.to_thread` adds ~0.5 ms per dispatch. For upload / list operations, which themselves take tens to hundreds of milliseconds over the network, this is negligible; the gain is that concurrent requests on the same worker now keep their latency during long uploads.
- The default `ThreadPoolExecutor` is shared with the SQLite offload from #38. A burst of concurrent uploads could queue behind each other, but both code paths are bounded by I/O, not CPU, so saturation is unlikely on the current single-replica deployment.
- Rollback: revert the three commits in this PR (`326c5dc`, `d56c0d7`, `e0bc546`) to restore the previous sync behavior.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed (probe/contract docs unchanged; behavior identical on the wire)
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted
