### PR TITLE
chore(k8s): add baseline NetworkPolicy for api pods

### DIFF
--- a/k8s/base/core/networkpolicy.yaml
+++ b/k8s/base/core/networkpolicy.yaml
@@ -1,0 +1,108 @@
+---
+# Ingress policy for the dyvine-api Pods.
+#
+# Allows traffic on the container's HTTP port (8000) from:
+#   * Pods in the ``ingress-nginx`` namespace so the ingress controller can
+#     proxy external requests to the API. Selection is based on the
+#     ``kubernetes.io/metadata.name`` label that the kubelet sets
+#     automatically on every namespace from Kubernetes 1.22 onward.
+#   * Pods in the ``kube-system`` namespace so kubelet/apiserver-side
+#     probes (liveness, readiness, startup) keep working on clusters that
+#     route probes through a namespace-scoped identity rather than the
+#     node IP.
+#
+# All other ingress traffic is implicitly denied because declaring an
+# ingress rule on a NetworkPolicy switches the pod into allowlist mode
+# for ingress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dyvine-api-ingress
+  namespace: dyvine
+  labels:
+    app.kubernetes.io/name: dyvine
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: dyvine
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: dyvine
+      app.kubernetes.io/component: api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 8000
+---
+# Egress policy for the dyvine-api Pods.
+#
+# Allows only the outbound traffic the service actually needs:
+#   * DNS (UDP/TCP 53) to the ``kube-system`` namespace so CoreDNS can
+#     resolve both in-cluster Services and the external hosts listed
+#     below.
+#   * HTTPS (TCP 443) to every destination outside the cluster so the
+#     API can reach the Cloudflare R2 endpoint and the public Douyin
+#     APIs. The ``except`` block removes the RFC1918/carrier-grade NAT
+#     ranges that are used by the cluster CNI; this keeps the rule from
+#     accidentally granting in-cluster east-west access beyond the DNS
+#     exception above.
+#
+# The service does not currently connect to a PostgreSQL (or other
+# database) server: runtime state is persisted in a SQLite file stored
+# on the ``dyvine-operation-state`` PVC (see
+# ``API_OPERATION_DB_PATH=/app/data/douyin/state/operations.db`` in the
+# Deployment), so no database egress rule is required.
+#
+# All other egress traffic is implicitly denied because declaring an
+# egress rule on a NetworkPolicy switches the pod into allowlist mode
+# for egress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dyvine-api-egress
+  namespace: dyvine
+  labels:
+    app.kubernetes.io/name: dyvine
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: dyvine
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: dyvine
+      app.kubernetes.io/component: api
+  policyTypes:
+    - Egress
+  egress:
+    # Cluster DNS (CoreDNS in kube-system).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Outbound HTTPS to the public internet for Cloudflare R2 and
+    # Douyin SDK calls. Private RFC1918/CG-NAT ranges are excluded so
+    # this rule does not become a back door into other cluster
+    # workloads.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 100.64.0.0/10
+      ports:
+        - protocol: TCP
+          port: 443

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - core/deployment.yaml
   - core/service.yaml
   - core/pvc.yaml
+  - core/networkpolicy.yaml
 # The ``dyvine-secrets`` Secret is intentionally excluded from the base so
 # the deploy workflows can create it from GitHub Secrets before applying
 # this kustomization. Including an empty Secret here would cause the


### PR DESCRIPTION
## Summary
Adds two CNI-agnostic (Cilium/Calico compatible) `NetworkPolicy` objects to the k8s base so the `dyvine-api` Pods default to an allowlist for both ingress and egress. No changes to `src/`, overlays, or docs.

## Related
- No related issue; companion hardening to the runtime work landed in #37 / #38 / #39.

## Updates
| Path | Before | After | Why it matters |
| --- | --- | --- | --- |
| `k8s/base/core/networkpolicy.yaml` | (absent) | `dyvine-api-ingress` + `dyvine-api-egress` | Pods no longer accept arbitrary in-cluster ingress, and can only reach DNS + HTTPS-outbound on the paths the service actually uses. |
| `k8s/base/kustomization.yaml` | 6 resources | +`core/networkpolicy.yaml` | `kubectl apply -k k8s/base` now includes the policies by default; overlays inherit them automatically. |

## Details
### `dyvine-api-ingress`
- `podSelector`: `app.kubernetes.io/name=dyvine` + `app.kubernetes.io/component=api` (matches the Deployment's pod template labels; kustomize `commonLabels` are propagated into both sides of the selector so the policy still binds after rendering).
- Ingress allowed on `TCP/8000` (the container's `http` port) from Pods in two namespaces:
  - `ingress-nginx` (the Ingress Controller's default namespace; matches the existing `ingressClassName: nginx` in `k8s/overlays/production/ingress.yaml`).
  - `kube-system` (for kubelet-/apiserver-sourced probes that some clusters route through a namespace-scoped identity rather than the node IP).
- Both are selected via the auto-applied `kubernetes.io/metadata.name` namespace label that the kubelet sets on every namespace from Kubernetes 1.22 onward; no cluster-specific labeling is required.

### `dyvine-api-egress`
- DNS: `UDP` + `TCP 53` to the `kube-system` namespace so CoreDNS keeps resolving both in-cluster Services and the external hosts below.
- External HTTPS: `TCP 443` to `0.0.0.0/0` with `except` blocks for `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, and `100.64.0.0/10` so the public-internet allowance does not accidentally become east-west access to other cluster workloads. This covers Cloudflare R2 (`R2_ENDPOINT=https://...r2.cloudflarestorage.com`) and the public Douyin API endpoints.
- No PostgreSQL egress rule. The service persists operation state in a local SQLite file at `API_OPERATION_DB_PATH=/app/data/douyin/state/operations.db` (backed by the `dyvine-operation-state` PVC) and `src/dyvine/core/settings.py` does not define any database settings.
- Declaring `policyTypes: [Egress]` with explicit rules switches the Pod to deny-by-default for all other outbound traffic.

## Cluster-label decisions
- Used `kubernetes.io/metadata.name` rather than a custom `name=` label on `ingress-nginx`/`kube-system` because it is set automatically by the kubelet and works on any cluster running Kubernetes 1.22+ without manual namespace labeling.
- No CNI-specific CRDs (e.g. `CiliumNetworkPolicy`) were used so the manifest is portable between Calico, Cilium, and other upstream-compatible NetworkPolicy implementations.

## Testing
- `kubectl kustomize k8s/base` - renders cleanly; both policies appear with the expected `podSelector` and rule set.
- `kubectl kustomize k8s/overlays/production` - returns a pre-existing `configMapGenerator` merge error (`id resid.ResId{...Kind:"ConfigMap"...Name:"dyvine-config"...} does not exist; cannot merge or replace`) that also reproduces on `main@131a72a` without this change. It is unrelated to the NetworkPolicy and out of scope for this PR.
- `uv run pytest --cov=src/dyvine --cov-fail-under=80 -W error -q` - 262 passed, coverage 86.01%.
- `uv run black --check .` / `uv run ruff check .` / `uv run mypy src/` - all clean.
- Manual steps: Not run (no live cluster available in the worktree).

## Docs refresh
- Task B skipped: `grep -rilE 'last.?updated|updated:|last modified' docs/` identifies six files under `docs/architecture/`, each stamped `2026-04-17`. `git log -1 --format=%cs` returns `2026-04-17` for every one of them, so no timestamp is more than 14 days older than the last non-trivial commit that touched the file.

## Screenshots / Notes
- Not applicable.

## Breaking changes
- On clusters that enforce NetworkPolicy (Cilium, Calico, etc.) the `dyvine-api` Pods will reject any ingress that is not sourced from `ingress-nginx` or `kube-system`, and any egress other than cluster DNS or public HTTPS. Operators who currently rely on other in-cluster namespaces reaching the API (for example, a bespoke observability scraper) will need to extend the policy before applying this change.
- On clusters without a NetworkPolicy controller the manifests are inert (stored in the API server but never enforced), so there is no behavioral change.

## Risks and rollout
- The egress allowlist is intentionally narrow. If a future service addition introduces a new outbound dependency (e.g. Redis, an external PostgreSQL, a webhook sink), it will silently fail until the egress policy is extended. Reviewers should treat any new network call in `src/` as a signal to revisit this file.
- Rollback: `kubectl delete networkpolicy -n dyvine dyvine-api-ingress dyvine-api-egress` restores the previous default-allow behavior without any other manifest change.

## Checklist
- [x] Tests added/updated if needed (existing pytest suite still green; policy changes are manifest-only)
- [x] Docs updated if needed (Task B audit confirmed no stale timestamps in `docs/`)
- [x] Backward compatibility considered (noted under Breaking changes)
- [x] Rollout/monitoring considerations noted