### PR TITLE
perf(services): parallelize R2 list_objects head fan-out with bounded concurrency

### DIFF
--- a/src/dyvine/services/storage.py
+++ b/src/dyvine/services/storage.py
@@ -15,6 +15,7 @@ import base64
 import mimetypes
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -49,6 +50,12 @@ r2_upload_duration = Histogram(
 r2_upload_failures = Counter(
     "r2_upload_failures_total", "Total number of R2 upload failures", ["error_type"]
 )
+
+# Upper bound on concurrent ``head_object`` calls issued while hydrating
+# object metadata inside ``_list_objects_sync``. Capped to keep a single
+# listing from exhausting the boto3 connection pool (default 10) by too
+# much; the pool is still resized on demand per request.
+LIST_OBJECTS_HEAD_MAX_WORKERS = 16
 
 
 class StorageError(Exception):
@@ -476,37 +483,56 @@ class R2StorageService:
             raise StorageError(f"List objects failed: {str(e)}") from e
 
     def _list_objects_sync(self, *, prefix: str, max_keys: int) -> list[dict[str, Any]]:
-        """Run one ``list_objects_v2`` plus the per-object ``head_object`` fan-out.
+        """Run one ``list_objects_v2`` plus a bounded parallel ``head_object`` fan-out.
 
         Kept in a private sync method so the whole listing -- including the
         N follow-up ``head_object`` calls that carry object metadata -- runs
-        in a single worker thread rather than bouncing every call back to
-        the event loop. ``max_keys`` caps the single page; callers that need
-        more than one page are expected to paginate themselves. The N+1
-        shape is tracked as a separate optimization item.
+        off the event loop. ``list_objects_v2`` returns objects in
+        lexicographic order; this method preserves that ordering in its
+        output. The ``head_object`` fan-out is dispatched to a short-lived
+        ``ThreadPoolExecutor`` with worker count capped at
+        :data:`LIST_OBJECTS_HEAD_MAX_WORKERS` to avoid saturating the
+        boto3 connection pool on large pages. ``max_keys`` caps the single
+        page; callers that need more than one page are expected to
+        paginate themselves.
         """
         assert self.client is not None and self.bucket is not None
-        response = self.client.list_objects_v2(
-            Bucket=self.bucket, Prefix=prefix, MaxKeys=max_keys
+        client = self.client
+        bucket = self.bucket
+        response = client.list_objects_v2(
+            Bucket=bucket, Prefix=prefix, MaxKeys=max_keys
         )
 
         objects = response.get("Contents", [])
-        results: list[dict[str, Any]] = []
-        for obj in objects:
-            obj_data: dict[str, Any] = {
+        if not objects:
+            return []
+
+        results: list[dict[str, Any]] = [
+            {
                 "Key": obj.get("Key"),
                 "LastModified": obj.get("LastModified"),
                 "ETag": obj.get("ETag"),
                 "Size": obj.get("Size"),
                 "StorageClass": obj.get("StorageClass"),
             }
+            for obj in objects
+        ]
+
+        def _fetch_metadata(key: str | None) -> dict[str, str]:
+            if not key:
+                return {}
             try:
-                if "Key" in obj and obj["Key"]:
-                    head = self.client.head_object(Bucket=self.bucket, Key=obj["Key"])
-                    obj_data["Metadata"] = head.get("Metadata", {})
-                else:
-                    obj_data["Metadata"] = {}
+                head = client.head_object(Bucket=bucket, Key=key)
             except ClientError:
-                obj_data["Metadata"] = {}
-            results.append(obj_data)
+                return {}
+            return head.get("Metadata", {}) or {}
+
+        keys: list[str | None] = [obj.get("Key") for obj in objects]
+        workers = min(LIST_OBJECTS_HEAD_MAX_WORKERS, len(keys))
+        with ThreadPoolExecutor(
+            max_workers=workers, thread_name_prefix="r2-head"
+        ) as executor:
+            metadata_iter = executor.map(_fetch_metadata, keys)
+            for obj_data, metadata in zip(results, metadata_iter, strict=True):
+                obj_data["Metadata"] = metadata
         return results

--- a/tests/services/test_storage_service_extended.py
+++ b/tests/services/test_storage_service_extended.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import re
+import threading
+import time
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 from dyvine.services.storage import (
+    LIST_OBJECTS_HEAD_MAX_WORKERS,
     ContentType,
     R2StorageService,
     StorageError,
@@ -225,25 +229,36 @@ async def test_delete_object_client_error_surfaces_as_storage_error() -> None:
 
 @pytest.mark.asyncio
 async def test_list_objects_per_item_head_error_returns_empty_metadata() -> None:
+    """A per-item ``head_object`` failure is tolerated and ordering is preserved.
+
+    The fan-out is parallel, so the test dispatches ``head_object`` by key
+    rather than by call index to stay deterministic regardless of thread
+    scheduling. A mid-list failure still yields ``Metadata: {}`` for that
+    item while neighbors retain their metadata.
+    """
     from botocore.exceptions import ClientError
 
     svc = _build_service(with_client=True)
+    keys = [f"videos/u1/{c}.mp4" for c in ("a", "b", "c", "d", "e")]
     svc.client.list_objects_v2.return_value = {  # type: ignore[union-attr]
-        "Contents": [
-            {"Key": "videos/u1/a.mp4", "Size": 1},
-            {"Key": "videos/u1/b.mp4", "Size": 2},
-        ]
+        "Contents": [{"Key": k, "Size": i + 1} for i, k in enumerate(keys)]
     }
-    svc.client.head_object.side_effect = [  # type: ignore[union-attr]
-        {"Metadata": {"author": "one"}},
-        ClientError({"Error": {"Code": "AccessDenied"}}, "HeadObject"),
-    ]
+
+    def head_by_key(**kwargs: Any) -> dict[str, Any]:
+        if kwargs["Key"] == "videos/u1/c.mp4":
+            raise ClientError({"Error": {"Code": "AccessDenied"}}, "HeadObject")
+        return {"Metadata": {"author": Path(kwargs["Key"]).stem}}
+
+    svc.client.head_object.side_effect = head_by_key  # type: ignore[union-attr]
 
     results = await svc.list_objects("videos/u1/")
 
-    assert [r["Key"] for r in results] == ["videos/u1/a.mp4", "videos/u1/b.mp4"]
-    assert results[0]["Metadata"] == {"author": "one"}
-    assert results[1]["Metadata"] == {}
+    assert [r["Key"] for r in results] == keys
+    assert results[0]["Metadata"] == {"author": "a"}
+    assert results[1]["Metadata"] == {"author": "b"}
+    assert results[2]["Metadata"] == {}  # mid-list failure
+    assert results[3]["Metadata"] == {"author": "d"}
+    assert results[4]["Metadata"] == {"author": "e"}
 
 
 @pytest.mark.asyncio
@@ -269,3 +284,119 @@ async def test_upload_file_guesses_content_type(tmp_path: Path) -> None:
 
     result = await svc.upload_file(f, "images/u/image.jpg", {"category": "posts"})
     assert "image" in result["content_type"]
+
+
+# ── list_objects parallel fan-out behavior ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_objects_preserves_order_under_variable_latency() -> None:
+    """``list_objects`` returns items in ``Contents`` order regardless of
+    how long each per-item ``head_object`` takes.
+
+    Early keys are made slow and later keys fast so that, under a parallel
+    fan-out, results would arrive out of order if ``_list_objects_sync``
+    naively yielded in completion order.
+    """
+    svc = _build_service(with_client=True)
+    keys = [f"videos/u1/{i:02d}.mp4" for i in range(10)]
+    svc.client.list_objects_v2.return_value = {  # type: ignore[union-attr]
+        "Contents": [{"Key": k, "Size": i} for i, k in enumerate(keys)]
+    }
+
+    # Early keys sleep longer than later keys; parallel execution would
+    # otherwise let the fast ones finish first.
+    delays = {k: (len(keys) - i) * 0.01 for i, k in enumerate(keys)}
+
+    def head_by_key(**kwargs: Any) -> dict[str, Any]:
+        key = kwargs["Key"]
+        time.sleep(delays[key])
+        return {"Metadata": {"k": key}}
+
+    svc.client.head_object.side_effect = head_by_key  # type: ignore[union-attr]
+
+    results = await svc.list_objects("videos/u1/")
+
+    assert [r["Key"] for r in results] == keys
+    assert [r["Metadata"]["k"] for r in results] == keys
+
+
+@pytest.mark.asyncio
+async def test_list_objects_bounded_concurrency() -> None:
+    """``head_object`` fan-out never exceeds :data:`LIST_OBJECTS_HEAD_MAX_WORKERS`.
+
+    A counter tracks in-flight calls; the peak must not exceed the cap
+    even when the listing contains many more objects than workers.
+    """
+    svc = _build_service(with_client=True)
+    # Use comfortably more than the cap so the bound is actually hit.
+    keys = [f"videos/u1/{i:03d}.mp4" for i in range(LIST_OBJECTS_HEAD_MAX_WORKERS * 3)]
+    svc.client.list_objects_v2.return_value = {  # type: ignore[union-attr]
+        "Contents": [{"Key": k, "Size": 1} for k in keys]
+    }
+
+    lock = threading.Lock()
+    in_flight = 0
+    peak = 0
+
+    def head_counting(**_: Any) -> dict[str, Any]:
+        nonlocal in_flight, peak
+        with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        try:
+            time.sleep(0.01)
+        finally:
+            with lock:
+                in_flight -= 1
+        return {"Metadata": {}}
+
+    svc.client.head_object.side_effect = head_counting  # type: ignore[union-attr]
+
+    results = await svc.list_objects("videos/u1/")
+
+    assert len(results) == len(keys)
+    assert peak <= LIST_OBJECTS_HEAD_MAX_WORKERS
+    # Sanity check: with this many keys the cap really was exercised.
+    assert peak >= 2
+
+
+@pytest.mark.asyncio
+async def test_list_objects_workers_capped_for_small_listings() -> None:
+    """For small listings, worker count is capped by item count, not the max.
+
+    Exercises the ``min(max, len(objects))`` sizing behavior so a small
+    page does not spin up a needlessly large pool.
+    """
+    svc = _build_service(with_client=True)
+    keys = ["videos/u1/only.mp4"]
+    svc.client.list_objects_v2.return_value = {  # type: ignore[union-attr]
+        "Contents": [{"Key": k, "Size": 1} for k in keys]
+    }
+
+    lock = threading.Lock()
+    seen_threads: set[str] = set()
+
+    def head_record_thread(**_: Any) -> dict[str, Any]:
+        with lock:
+            seen_threads.add(threading.current_thread().name)
+        return {"Metadata": {}}
+
+    svc.client.head_object.side_effect = head_record_thread  # type: ignore[union-attr]
+
+    results = await svc.list_objects("videos/u1/")
+
+    assert len(results) == 1
+    assert len(seen_threads) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_objects_empty_returns_no_results() -> None:
+    """An empty ``Contents`` list short-circuits without launching a pool."""
+    svc = _build_service(with_client=True)
+    svc.client.list_objects_v2.return_value = {"Contents": []}  # type: ignore[union-attr]
+
+    results = await svc.list_objects("videos/u1/")
+
+    assert results == []
+    svc.client.head_object.assert_not_called()  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary
Follow-up to #39. `_list_objects_sync` now runs inside one `asyncio.to_thread` hand-off, but its N follow-up `head_object` calls still execute serially on that worker thread, so listing latency grows linearly with page size. This PR dispatches the per-object `head_object` fan-out onto a short-lived bounded `ThreadPoolExecutor` so the N round-trips run in parallel while still preserving ordering, per-item error tolerance, and the existing async lifecycle.

## Related
- Follow-up to #39 (which moved the whole sweep onto a worker thread but kept the N+1 shape).

## Updates
| Path | Before | After | Why it matters |
| --- | --- | --- | --- |
| `R2StorageService._list_objects_sync` | `list_objects_v2` plus a serial for-loop calling `head_object` one key at a time on the worker thread | `list_objects_v2` plus a `ThreadPoolExecutor.map` fan-out with `max_workers = min(16, len(objects))` | A 500-key listing now issues up to 16 concurrent `head_object` calls instead of 500 serial ones; listing latency drops from O(N x RTT) toward O(ceil(N / 16) x RTT). |
| `src/dyvine/services/storage.py` | No exposed cap constant | New module-level `LIST_OBJECTS_HEAD_MAX_WORKERS = 16` | Reviewer-visible knob; bound chosen to stay well clear of the default boto3 connection-pool size so one listing cannot starve concurrent R2 calls from the same worker. |

## Details
### Parallel fan-out inside `_list_objects_sync`
- Design/Spec: Keep the `async def list_objects` signature and its `ClientError` -> `StorageError` mapping unchanged. Keep the private sync helper as the single worker-thread entry point -- `asyncio.to_thread(self._list_objects_sync, ...)` is untouched. Move the per-key `head_object` calls inside that helper onto a short-lived `ThreadPoolExecutor` constructed with `max_workers = min(LIST_OBJECTS_HEAD_MAX_WORKERS, len(objects))` inside a `with` block so worker threads get joined on exit and no module-level pool is introduced.
- Implementation notes:
  - Results are materialized from `Contents` first (preserving the lexicographic order `list_objects_v2` guarantees), then `executor.map` yields per-key metadata in the same input order and is zipped back onto the result rows. Ordering therefore does not depend on thread scheduling.
  - An empty `Contents` short-circuits with `return []` before any pool is constructed, so empty listings pay no thread-startup cost.
  - The inner `_fetch_metadata` closure swallows `ClientError` per key and returns `{}`, matching the previous single-threaded behavior -- neighbor keys keep their metadata when one `head_object` 403s.
  - The cap of 16 is deliberately below default boto3 connection pool sizes (S3 defaults to 10, but our client uses adaptive retry mode and a dynamic pool); this leaves headroom for concurrent unrelated calls and prevents a single listing from monopolizing sockets.
- Reviewer focus:
  - The list-level `except ClientError` in `list_objects` remains outside the executor block; any exception raised by the executor surfaces out of `_list_objects_sync`, propagates through `asyncio.to_thread`, and is caught by the same mapper that `main` used.
  - `_fetch_metadata` captures the boto3 `client` and `bucket` through locals rather than `self` so mypy's `Optional[S3Client]` is narrowed exactly once at the top of the method.

## Testing
- `uv run pytest --cov=src/dyvine --cov-fail-under=80 -W error -q` -- 266 passed, coverage 86.09%.
- `uv run black --check .` / `uv run ruff check .` / `uv run mypy src/` -- all clean.
- New tests (`tests/services/test_storage_service_extended.py`):
  - `test_list_objects_preserves_order_under_variable_latency` -- 10 keys with decreasing per-key `time.sleep` delays so naive completion-order results would be inverted; asserts result order matches `Contents` order.
  - `test_list_objects_bounded_concurrency` -- counter-based mock tracks in-flight `head_object` calls; asserts peak concurrency <= `LIST_OBJECTS_HEAD_MAX_WORKERS` (measured peak = 16 with 48 keys locally).
  - `test_list_objects_workers_capped_for_small_listings` -- single-key listing runs on exactly one worker thread, exercising the `min(max, len)` sizing.
  - `test_list_objects_empty_returns_no_results` -- empty `Contents` short-circuits without invoking `head_object`.
  - `test_list_objects_per_item_head_error_returns_empty_metadata` -- extended to a 5-object listing with a mid-list `ClientError`; asserts ordering and the empty-metadata fallback both hold.
- Manual steps: Not run.

## Screenshots / Notes
- Not applicable.

## Breaking changes
- None. Public API, coroutine signatures, returned list shape, and error mapping are unchanged. Ordering of returned rows is the same lexicographic order `list_objects_v2` already produced.

## Risks and rollout
- The executor is constructed and torn down per call. Thread-startup cost (roughly 100 microseconds times up to 16 threads, i.e. single-digit ms) is negligible against per-key HTTP RTTs of tens of ms, and is bounded by the listing page size.
- boto3 S3 clients are documented as thread-safe for independent operations; concurrent `head_object` calls through the same client are expected to share the underlying urllib3 pool. The 16-worker cap keeps simultaneous socket use below reasonable pool-size defaults.
- The per-item `ClientError` fallback is preserved, so a prefix with a sprinkling of 403 objects still yields a best-effort result rather than failing the whole listing.
- Rollback: revert the single commit on this branch to restore the previous serial fan-out.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed (no external docs changed; behavior on the wire is unchanged)
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted
