### PR TITLE
perf(core): dedicated executors per IO domain and concurrent reader pool

### DIFF
--- a/src/dyvine/core/dependencies.py
+++ b/src/dyvine/core/dependencies.py
@@ -29,6 +29,7 @@ Example:
         user_service = container.user_service
 """
 
+from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from typing import Any
 
@@ -38,6 +39,17 @@ from ..services.livestreams import LivestreamService
 from ..services.users import UserService
 from .operations import OperationStore
 from .settings import settings
+
+# Dedicated thread pool sizes per IO domain. The defaults are tuned for the
+# single-worker uvicorn deployment: R2 uploads are the dominant long-running
+# call, sqlite writes are short but frequent, and audit log writes are rare
+# but must never starve the other two pools. Keeping each domain in its own
+# bounded pool prevents a burst in one from exhausting the default asyncio
+# executor (``min(32, cpu+4)``) that every ``asyncio.to_thread`` call would
+# otherwise share.
+R2_EXECUTOR_MAX_WORKERS = 16
+SQLITE_EXECUTOR_MAX_WORKERS = 4
+AUDIT_EXECUTOR_MAX_WORKERS = 2
 
 
 class ServiceContainer:
@@ -74,6 +86,9 @@ class ServiceContainer:
         """
         self._services: dict[str, Any] = {}
         self._initialized = False
+        self._r2_executor: ThreadPoolExecutor | None = None
+        self._sqlite_executor: ThreadPoolExecutor | None = None
+        self._audit_executor: ThreadPoolExecutor | None = None
 
     async def initialize(self) -> None:
         """Initialize all registered services with their configurations.
@@ -87,6 +102,12 @@ class ServiceContainer:
             - DouyinHandler: Configured with headers, proxies, and download settings
             - OperationStore: Persistent state for asynchronous work
             - UserService: Basic user management service
+            - LivestreamService: Livestream download orchestration
+
+        Executors created:
+            - ``r2_executor`` (16 workers): R2 upload/head/delete/list
+            - ``sqlite_executor`` (4 workers): OperationStore writes/reads
+            - ``audit_executor`` (2 workers): LifecycleManager audit writes
 
         Note:
             This method is awaited by the FastAPI lifespan. Direct access
@@ -96,28 +117,79 @@ class ServiceContainer:
         if self._initialized:
             return
 
+        # Create dedicated thread pool executors for each IO domain before
+        # instantiating any service that might need one. The thread-name
+        # prefix shows up in logs/traces so hot threads are easy to spot.
+        self._r2_executor = ThreadPoolExecutor(
+            max_workers=R2_EXECUTOR_MAX_WORKERS,
+            thread_name_prefix="dyvine-r2",
+        )
+        self._sqlite_executor = ThreadPoolExecutor(
+            max_workers=SQLITE_EXECUTOR_MAX_WORKERS,
+            thread_name_prefix="dyvine-sqlite",
+        )
+        self._audit_executor = ThreadPoolExecutor(
+            max_workers=AUDIT_EXECUTOR_MAX_WORKERS,
+            thread_name_prefix="dyvine-audit",
+        )
+
         # Initialize Douyin handler with configuration
         douyin_config = self._create_douyin_config()
         self._services["douyin_handler"] = DouyinHandler(douyin_config)
 
         # Initialize operation store (sqlite bootstrap happens synchronously
         # inside the constructor, which is cheap and keeps the OperationStore
-        # usable from both async and sync contexts).
-        operation_store = OperationStore()
+        # usable from both async and sync contexts). The dedicated sqlite
+        # executor is attached immediately so the recovery sweep below
+        # already runs on the bounded pool.
+        operation_store = OperationStore(executor=self._sqlite_executor)
         self._services["operation_store"] = operation_store
         await operation_store.mark_incomplete_operations_failed()
 
-        # Initialize user service
-        self._services["user_service"] = UserService(operation_store=operation_store)
+        # Initialize user service and wire its R2 client to the R2 executor.
+        user_service = UserService(operation_store=operation_store)
+        user_service.storage.set_executor(self._r2_executor)
+        self._services["user_service"] = user_service
 
         # Initialize livestream service
         self._services["livestream_service"] = LivestreamService(
             douyin_handler=self._services["douyin_handler"],
-            user_service=self._services["user_service"],
+            user_service=user_service,
             operation_store=operation_store,
         )
 
         self._initialized = True
+
+    async def shutdown(self) -> None:
+        """Release services and tear down the dedicated executor pools.
+
+        Called from the FastAPI lifespan's shutdown branch so that the
+        worker threads held by each ``ThreadPoolExecutor`` do not outlive
+        the application. Safe to call multiple times; subsequent calls are
+        no-ops.
+
+        Each executor is shut down with ``wait=True`` so pending work (e.g.
+        a final audit-log write) drains before the process exits. Executors
+        are shut down in reverse initialization order so downstream
+        dependencies finish before their producers go away.
+        """
+        if not self._initialized:
+            return
+
+        # Let the operation store close its per-thread reader connections
+        # before we reap the sqlite executor that owns those worker threads.
+        operation_store = self._services.get("operation_store")
+        if isinstance(operation_store, OperationStore):
+            operation_store.shutdown()
+
+        for attr in ("_audit_executor", "_sqlite_executor", "_r2_executor"):
+            executor = getattr(self, attr)
+            if executor is not None:
+                executor.shutdown(wait=True)
+                setattr(self, attr, None)
+
+        self._services.clear()
+        self._initialized = False
 
     def _create_douyin_config(self) -> dict[str, Any]:
         """Create Douyin handler configuration from application settings.

--- a/src/dyvine/core/operations.py
+++ b/src/dyvine/core/operations.py
@@ -9,6 +9,11 @@ calls to a dedicated ``concurrent.futures.Executor`` (owned by
 ``ServiceContainer``) so they never block the event loop. Per-page progress
 updates on long-running downloads used to stall other requests on a
 single-worker uvicorn deployment; moving the IO off-loop restores fairness.
+
+Reads go through per-thread reader connections, so concurrent
+``get_operation`` / ``get_latest_operation_for_subject`` / ``healthcheck``
+calls do not serialize behind a single ``threading.Lock``. Writes share a
+lazily-opened writer connection guarded by the lock.
 """
 
 from __future__ import annotations
@@ -19,6 +24,7 @@ import json
 import sqlite3
 import threading
 import uuid
+import weakref
 from collections.abc import Callable
 from concurrent.futures import Executor
 from contextlib import closing
@@ -31,6 +37,46 @@ from .exceptions import DownloadError
 from .settings import settings
 
 _R = TypeVar("_R")
+
+
+class _WriterSlot:
+    """Single-cell container that holds the writer connection.
+
+    The finalizer callback below must be able to close the writer even if
+    the ``OperationStore`` instance has already been garbage collected. A
+    one-slot holder lets both the store and the finalizer share a mutable
+    reference to the same handle without resurrecting the dead instance.
+    """
+
+    __slots__ = ("connection",)
+
+    def __init__(self) -> None:
+        self.connection: sqlite3.Connection | None = None
+
+
+def _close_connections(
+    readers: dict[int, sqlite3.Connection],
+    writer_slot: _WriterSlot,
+) -> None:
+    """Best-effort close for reader and writer connections.
+
+    Runs as a ``weakref.finalize`` callback so an ``OperationStore`` that is
+    garbage-collected without an explicit ``shutdown`` (typical in short
+    unit tests) still releases every handle before Python 3.13 emits
+    ``ResourceWarning: unclosed database``.
+    """
+    for connection in list(readers.values()):
+        try:
+            connection.close()
+        except sqlite3.Error:
+            pass
+    readers.clear()
+    if writer_slot.connection is not None:
+        try:
+            writer_slot.connection.close()
+        except sqlite3.Error:
+            pass
+        writer_slot.connection = None
 
 
 @dataclass(slots=True)
@@ -81,6 +127,11 @@ class OperationStore:
     implementation is kept private (``_<name>_sync``) so it can be unit
     tested directly and reused from non-async bootstrapping paths
     (currently only ``__init__``).
+
+    Internally the store keeps one writer connection guarded by a
+    ``threading.Lock`` and one reader connection per worker thread (opened
+    lazily on first read). Readers never take the lock, so N concurrent
+    reads run in parallel instead of serializing behind a single handle.
     """
 
     def __init__(
@@ -91,11 +142,42 @@ class OperationStore:
     ) -> None:
         self.db_path = Path(db_path or settings.operation_db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        # ``threading.Lock`` because the sqlite worker pool hands work to
-        # multiple threads; several worker threads can race for the same
-        # connection attempt if we only relied on asyncio coordination.
+        # ``threading.Lock`` protects the single writer connection and its
+        # PRAGMA setup so no two executor threads race to mutate the same
+        # handle. Reads bypass the lock entirely and use per-thread reader
+        # connections instead (see ``_reader_connection``).
         self._lock = threading.Lock()
         self._executor: Executor | None = executor
+        # Per-thread reader connections. A plain ``threading.local`` alone
+        # would hide the stored values from any other thread, so
+        # ``shutdown`` could not iterate and close every live reader.
+        # ``sqlite3.Connection`` does not expose ``__weakref__``, so a
+        # ``WeakValueDictionary`` cannot be used to auto-prune dead entries.
+        # Instead we keep a plain ``dict[int, sqlite3.Connection]`` keyed
+        # by ``threading.get_ident()``; the container always calls
+        # ``shutdown`` (which drains this dict) before the owning executor
+        # reaps its worker threads, so entries cannot leak in practice.
+        self._reader_local = threading.local()
+        self._reader_connections: dict[int, sqlite3.Connection] = {}
+        self._reader_lock = threading.Lock()
+        # The writer connection is created lazily on the first write so
+        # ``__init__`` stays cheap and tests that only perform reads do not
+        # pay for a writer handle they never use. The one-slot holder lets
+        # the finalizer below close the writer even if the instance itself
+        # has already been garbage collected.
+        self._writer_slot = _WriterSlot()
+        # Register a weakref finalizer so an ``OperationStore`` that falls
+        # out of scope without an explicit ``shutdown`` (typical in tests)
+        # still closes every handle and does not trip the
+        # ``ResourceWarning: unclosed database`` that ``-W error`` promotes
+        # to a test failure. The finalizer intentionally binds module-level
+        # references only, so it does not resurrect ``self``.
+        self._finalizer = weakref.finalize(
+            self,
+            _close_connections,
+            self._reader_connections,
+            self._writer_slot,
+        )
         self._initialize()
 
     def set_executor(self, executor: Executor | None) -> None:
@@ -107,15 +189,6 @@ class OperationStore:
         through the dedicated worker pool.
         """
         self._executor = executor
-
-    def shutdown(self) -> None:
-        """Release any per-store resources held outside the executor.
-
-        The default implementation is a no-op; subsequent refactors add a
-        per-thread reader connection pool that hooks in here to close its
-        handles before the owning executor reaps its worker threads.
-        """
-        return None
 
     async def _run(self, func: Callable[..., _R], /, *args: Any, **kwargs: Any) -> _R:
         """Dispatch a blocking sqlite call to the configured executor.
@@ -130,8 +203,23 @@ class OperationStore:
         )
         return result
 
-    def _connect(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(self.db_path, check_same_thread=False)
+    def _connect(self, *, autocommit: bool = False) -> sqlite3.Connection:
+        # Reader connections set ``autocommit=True`` so SELECTs never hold
+        # an open snapshot between calls -- this is what lets multiple
+        # readers see writes committed by the writer connection as soon as
+        # they fire their next SELECT. Writer connections keep the stdlib
+        # legacy deferred mode (``isolation_level=""``) so the existing
+        # ``connection.commit()`` call sites continue to wrap each DML
+        # statement in a transaction. The ``""`` sentinel is the documented
+        # default for ``sqlite3.connect`` but the stubs only enumerate the
+        # uppercase spellings, so the explicit typing hint suppresses the
+        # false positive without hiding real mistakes elsewhere.
+        isolation_level: str | None = None if autocommit else ""
+        connection = sqlite3.connect(
+            self.db_path,
+            check_same_thread=False,
+            isolation_level=isolation_level,  # type: ignore[arg-type]
+        )
         try:
             connection.row_factory = sqlite3.Row
             # synchronous is a per-connection PRAGMA, so reapply on every connect.
@@ -178,6 +266,80 @@ class OperationStore:
             )
             connection.commit()
 
+    def _reader_connection(self) -> sqlite3.Connection:
+        """Return the current thread's reader connection, opening one lazily.
+
+        Each worker thread gets its own read-only-ish connection so
+        concurrent readers do not serialize behind a single handle or
+        ``threading.Lock``. Connections are stored on a ``threading.local``
+        so the current thread can look up its handle without taking a
+        lock, and mirrored in a plain ``dict`` keyed by thread id so
+        ``shutdown`` can iterate and close every live reader.
+        """
+        existing: sqlite3.Connection | None = getattr(
+            self._reader_local, "connection", None
+        )
+        if existing is not None:
+            return existing
+        # The lock only guards the dict insert; two threads still open
+        # their own connections in parallel.
+        new_connection = self._connect(autocommit=True)
+        self._reader_local.connection = new_connection
+        with self._reader_lock:
+            self._reader_connections[threading.get_ident()] = new_connection
+        return new_connection
+
+    def _writer_connection(self) -> sqlite3.Connection:
+        """Return the shared writer connection, opening it on first use.
+
+        Callers must hold ``self._lock`` before invoking this. The writer
+        connection uses the legacy implicit-deferred isolation mode so the
+        existing ``connection.commit()`` call sites continue to wrap each
+        DML statement in a transaction.
+        """
+        if self._writer_slot.connection is None:
+            self._writer_slot.connection = self._connect()
+        return self._writer_slot.connection
+
+    def shutdown(self) -> None:
+        """Close every live reader connection and the writer connection.
+
+        Called from ``ServiceContainer.shutdown`` before the owning sqlite
+        executor reaps its worker threads so no handle outlives its thread
+        and Python 3.13 does not flag unclosed databases at interpreter
+        exit. Safe to call multiple times.
+        """
+        # Snapshot under the lock so we don't iterate while another thread
+        # registers a fresh reader.
+        with self._reader_lock:
+            readers = list(self._reader_connections.values())
+            self._reader_connections.clear()
+        for connection in readers:
+            try:
+                connection.close()
+            except sqlite3.Error:
+                # A connection already closed elsewhere (e.g. the owning
+                # thread exited) must not prevent us from closing siblings.
+                pass
+        # The current thread's ``threading.local`` still points at its
+        # connection; drop it so a post-shutdown reader lookup opens a new
+        # handle rather than touching the closed one.
+        if hasattr(self._reader_local, "connection"):
+            del self._reader_local.connection
+
+        with self._lock:
+            if self._writer_slot.connection is not None:
+                try:
+                    self._writer_slot.connection.close()
+                except sqlite3.Error:
+                    pass
+                self._writer_slot.connection = None
+
+        # Everything is drained; detach the finalizer so it does not run a
+        # second time during interpreter shutdown and attempt to close
+        # already-closed handles.
+        self._finalizer.detach()
+
     async def healthcheck(self) -> None:
         """Verify the backing store is reachable and writable.
 
@@ -190,7 +352,10 @@ class OperationStore:
 
     def _healthcheck_sync(self) -> None:
         # BEGIN IMMEDIATE acquires a RESERVED lock, which proves the database
-        # file is writable without mutating any rows. The rollback lives in
+        # file is writable without mutating any rows. We run it on a
+        # throwaway connection rather than the per-thread reader so the
+        # readiness probe never ends up holding a RESERVED lock on a reader
+        # that other code paths depend on. The rollback lives in
         # ``finally`` so a failed BEGIN never leaves a pending transaction
         # on the connection -- Python 3.13 turns that into a ResourceWarning
         # at close time, which becomes an error under ``-W error``.
@@ -298,7 +463,8 @@ class OperationStore:
             created_at=created_at,
             updated_at=created_at,
         )
-        with self._lock, closing(self._connect()) as connection:
+        with self._lock:
+            connection = self._writer_connection()
             connection.execute(
                 """
                 INSERT INTO operations (
@@ -331,11 +497,15 @@ class OperationStore:
         return await self._run(self._get_operation_sync, operation_id)
 
     def _get_operation_sync(self, operation_id: str) -> OperationRecord:
-        with self._lock, closing(self._connect()) as connection:
-            row = connection.execute(
-                "SELECT * FROM operations WHERE operation_id = ?",
-                (operation_id,),
-            ).fetchone()
+        # Reads use the per-thread reader connection with no lock so several
+        # executor workers can serve ``get_operation`` concurrently. WAL +
+        # autocommit guarantees each SELECT starts a fresh snapshot and
+        # sees everything the writer has already committed.
+        connection = self._reader_connection()
+        row = connection.execute(
+            "SELECT * FROM operations WHERE operation_id = ?",
+            (operation_id,),
+        ).fetchone()
         operation = self._from_row(row)
         if operation is None:
             raise DownloadError(f"Operation {operation_id} not found")
@@ -375,8 +545,8 @@ class OperationStore:
             params.append(operation_type)
         query += " ORDER BY updated_at DESC, created_at DESC LIMIT 1"
 
-        with self._lock, closing(self._connect()) as connection:
-            row = connection.execute(query, params).fetchone()
+        connection = self._reader_connection()
+        row = connection.execute(query, params).fetchone()
         operation = self._from_row(row)
         if operation is None:
             raise DownloadError(f"Operation {subject_id} not found")
@@ -417,7 +587,8 @@ class OperationStore:
         ]
         values.append(operation_id)
 
-        with self._lock, closing(self._connect()) as connection:
+        with self._lock:
+            connection = self._writer_connection()
             connection.execute(
                 f"UPDATE operations SET {assignments} WHERE operation_id = ?",
                 values,
@@ -436,7 +607,8 @@ class OperationStore:
 
     def _mark_incomplete_operations_failed_sync(self) -> int:
         updated_at = self._now()
-        with self._lock, closing(self._connect()) as connection:
+        with self._lock:
+            connection = self._writer_connection()
             cursor = connection.execute(
                 """
                 UPDATE operations

--- a/src/dyvine/core/operations.py
+++ b/src/dyvine/core/operations.py
@@ -5,26 +5,32 @@ operation metadata. It is intended for API workflows that return immediately
 and complete in the background, such as content downloads.
 
 All public methods are ``async`` and delegate the synchronous ``sqlite3``
-calls to ``asyncio.to_thread`` so they never block the event loop. Per-page
-progress updates on long-running downloads used to stall other requests on a
+calls to a dedicated ``concurrent.futures.Executor`` (owned by
+``ServiceContainer``) so they never block the event loop. Per-page progress
+updates on long-running downloads used to stall other requests on a
 single-worker uvicorn deployment; moving the IO off-loop restores fairness.
 """
 
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import sqlite3
 import threading
 import uuid
+from collections.abc import Callable
+from concurrent.futures import Executor
 from contextlib import closing
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 from .exceptions import DownloadError
 from .settings import settings
+
+_R = TypeVar("_R")
 
 
 @dataclass(slots=True)
@@ -69,21 +75,60 @@ class OperationStore:
     """SQLite-backed persistence for asynchronous operation state.
 
     Public methods are coroutines. They perform no sqlite IO on the calling
-    thread: every database call is dispatched to ``asyncio.to_thread`` so the
-    event loop stays responsive during progress updates, healthchecks, and
-    cross-request writes. The synchronous implementation is kept private
-    (``_<name>_sync``) so it can be unit tested directly and reused from
-    non-async bootstrapping paths (currently only ``__init__``).
+    thread: every database call is dispatched to a dedicated executor owned
+    by the container so the event loop stays responsive during progress
+    updates, healthchecks, and cross-request writes. The synchronous
+    implementation is kept private (``_<name>_sync``) so it can be unit
+    tested directly and reused from non-async bootstrapping paths
+    (currently only ``__init__``).
     """
 
-    def __init__(self, db_path: str | None = None) -> None:
+    def __init__(
+        self,
+        db_path: str | None = None,
+        *,
+        executor: Executor | None = None,
+    ) -> None:
         self.db_path = Path(db_path or settings.operation_db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        # ``threading.Lock`` because ``asyncio.to_thread`` hands work to a
-        # shared thread pool; several worker threads can race for the same
+        # ``threading.Lock`` because the sqlite worker pool hands work to
+        # multiple threads; several worker threads can race for the same
         # connection attempt if we only relied on asyncio coordination.
         self._lock = threading.Lock()
+        self._executor: Executor | None = executor
         self._initialize()
+
+    def set_executor(self, executor: Executor | None) -> None:
+        """Attach a dedicated executor after construction.
+
+        The container owns the sqlite executor lifecycle. Late binding lets
+        the store bootstrap synchronously inside ``ServiceContainer`` (no
+        running event loop yet) while still routing every later async call
+        through the dedicated worker pool.
+        """
+        self._executor = executor
+
+    def shutdown(self) -> None:
+        """Release any per-store resources held outside the executor.
+
+        The default implementation is a no-op; subsequent refactors add a
+        per-thread reader connection pool that hooks in here to close its
+        handles before the owning executor reaps its worker threads.
+        """
+        return None
+
+    async def _run(self, func: Callable[..., _R], /, *args: Any, **kwargs: Any) -> _R:
+        """Dispatch a blocking sqlite call to the configured executor.
+
+        Falls back to the default asyncio executor when no dedicated pool is
+        attached, which keeps tests that instantiate the store directly
+        working without a container.
+        """
+        loop = asyncio.get_running_loop()
+        result: _R = await loop.run_in_executor(
+            self._executor, functools.partial(func, *args, **kwargs)
+        )
+        return result
 
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.db_path, check_same_thread=False)
@@ -141,7 +186,7 @@ class OperationStore:
                 the connection or executing a trivial write-capable probe,
                 so callers can treat failure as "not ready".
         """
-        await asyncio.to_thread(self._healthcheck_sync)
+        await self._run(self._healthcheck_sync)
 
     def _healthcheck_sync(self) -> None:
         # BEGIN IMMEDIATE acquires a RESERVED lock, which proves the database
@@ -207,7 +252,7 @@ class OperationStore:
         operation_id: str | None = None,
     ) -> OperationRecord:
         """Create and persist a new operation."""
-        return await asyncio.to_thread(
+        return await self._run(
             self._create_operation_sync,
             operation_type=operation_type,
             subject_id=subject_id,
@@ -283,7 +328,7 @@ class OperationStore:
 
     async def get_operation(self, operation_id: str) -> OperationRecord:
         """Fetch a single operation or raise ``DownloadError``."""
-        return await asyncio.to_thread(self._get_operation_sync, operation_id)
+        return await self._run(self._get_operation_sync, operation_id)
 
     def _get_operation_sync(self, operation_id: str) -> OperationRecord:
         with self._lock, closing(self._connect()) as connection:
@@ -311,7 +356,7 @@ class OperationStore:
         Raises:
             DownloadError: If no operation matches the subject identifier.
         """
-        return await asyncio.to_thread(
+        return await self._run(
             self._get_latest_operation_for_subject_sync,
             subject_id,
             operation_type=operation_type,
@@ -341,9 +386,7 @@ class OperationStore:
         self, operation_id: str, **fields: Any
     ) -> OperationRecord:
         """Update selected fields on an operation and return the new state."""
-        return await asyncio.to_thread(
-            self._update_operation_sync, operation_id, **fields
-        )
+        return await self._run(self._update_operation_sync, operation_id, **fields)
 
     def _update_operation_sync(
         self, operation_id: str, **fields: Any
@@ -389,7 +432,7 @@ class OperationStore:
         Returns:
             Number of operations that were updated.
         """
-        return await asyncio.to_thread(self._mark_incomplete_operations_failed_sync)
+        return await self._run(self._mark_incomplete_operations_failed_sync)
 
     def _mark_incomplete_operations_failed_sync(self) -> int:
         updated_at = self._now()

--- a/src/dyvine/main.py
+++ b/src/dyvine/main.py
@@ -170,6 +170,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
     app.state.startup_complete = False
 
+    # Drain the dedicated executor pools before the process exits. Missing
+    # this step leaves non-daemon worker threads alive and delays shutdown
+    # until the Python interpreter tears them down.
+    try:
+        await container.shutdown()
+    except Exception:  # pragma: no cover - shutdown is best-effort
+        app.state.logger.exception("Service container shutdown failed")
+
 
 # Create FastAPI application instance with comprehensive configuration
 app = FastAPI(

--- a/src/dyvine/services/lifecycle.py
+++ b/src/dyvine/services/lifecycle.py
@@ -12,7 +12,9 @@ content based on content type and age.
 """
 
 import asyncio
+import functools
 import json
+from concurrent.futures import Executor
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -42,13 +44,24 @@ class LifecycleManager:
         audit_config: Audit logging configuration
     """
 
-    def __init__(self, storage: R2StorageService) -> None:
+    def __init__(
+        self,
+        storage: R2StorageService,
+        *,
+        executor: Executor | None = None,
+    ) -> None:
         """Initialize the lifecycle manager.
 
         Args:
-            storage: Configured R2StorageService instance
+            storage: Configured R2StorageService instance.
+            executor: Optional dedicated ``concurrent.futures.Executor`` used
+                to run the synchronous audit-log writer off the event loop.
+                When ``None`` the manager falls back to the default asyncio
+                executor, keeping unit tests that build the manager directly
+                working without a container.
         """
         self.storage = storage
+        self._executor: Executor | None = executor
         self.rules: dict[str, Any] = {}
         self.audit_config: dict[str, Any] = {}
         self._load_config()
@@ -56,6 +69,10 @@ class LifecycleManager:
         logger.info(
             "LifecycleManager initialized", extra={"rules_count": len(self.rules)}
         )
+
+    def set_executor(self, executor: Executor | None) -> None:
+        """Attach a dedicated executor after construction."""
+        self._executor = executor
 
     def _load_config(self) -> None:
         """Load lifecycle configuration from JSON file."""
@@ -200,7 +217,11 @@ class LifecycleManager:
             summary: Summary of actions taken
         """
         try:
-            await asyncio.to_thread(self._write_audit_log_sync, summary)
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
+                self._executor,
+                functools.partial(self._write_audit_log_sync, summary),
+            )
         except Exception as e:
             logger.exception("Failed to write audit log", extra={"error": str(e)})
 

--- a/src/dyvine/services/storage.py
+++ b/src/dyvine/services/storage.py
@@ -12,14 +12,16 @@ R2 storage operations including:
 
 import asyncio
 import base64
+import functools
 import mimetypes
 import time
 import uuid
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable
+from concurrent.futures import Executor, ThreadPoolExecutor
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import boto3
 from botocore.config import Config
@@ -28,6 +30,8 @@ from prometheus_client import Counter, Histogram
 
 from ..core.logging import ContextLogger
 from ..core.settings import settings
+
+_R = TypeVar("_R")
 
 # Initialize logger
 logger = ContextLogger(__name__)
@@ -83,11 +87,20 @@ class R2StorageService:
         bucket: Name of the R2 bucket
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, executor: Executor | None = None) -> None:
         """Initialize the R2 storage service.
 
         Configures the boto3 client with R2-specific settings and retry config.
+
+        Args:
+            executor: Optional dedicated ``concurrent.futures.Executor`` used
+                to run the synchronous boto3 operations off the event loop.
+                When ``None`` the service falls back to the default asyncio
+                executor, which keeps historical behavior for tests that
+                build the service directly.
         """
+        self._executor: Executor | None = executor
+
         # Check if R2 configuration is available
         if not settings.r2.is_configured:
             logger.warning(
@@ -117,6 +130,30 @@ class R2StorageService:
             "R2StorageService initialized",
             extra={"bucket": self.bucket, "endpoint": settings.r2_endpoint},
         )
+
+    def set_executor(self, executor: Executor | None) -> None:
+        """Attach a dedicated executor after construction.
+
+        The service is instantiated eagerly inside ``UserService`` today; the
+        ``ServiceContainer`` wires in the shared R2 executor post-hoc so all
+        R2 calls share one bounded thread pool without changing the
+        ``UserService`` constructor signature.
+        """
+        self._executor = executor
+
+    async def _run(self, func: Callable[..., _R], /, *args: Any, **kwargs: Any) -> _R:
+        """Dispatch a blocking boto3 call to the configured executor.
+
+        Uses ``loop.run_in_executor`` with ``functools.partial`` so callers can
+        pass keyword arguments, and falls back to the default executor when
+        none has been attached (e.g. unit tests that exercise the service in
+        isolation).
+        """
+        loop = asyncio.get_running_loop()
+        result: _R = await loop.run_in_executor(
+            self._executor, functools.partial(func, *args, **kwargs)
+        )
+        return result
 
     def generate_ugc_path(
         self, user_id: str, original_filename: str, content_type: str
@@ -312,7 +349,7 @@ class R2StorageService:
                 },
             )
 
-            url = await asyncio.to_thread(
+            url = await self._run(
                 self._upload_file_sync,
                 file_path=file_path,
                 storage_path=storage_path,
@@ -412,7 +449,7 @@ class R2StorageService:
             )
 
         try:
-            response = await asyncio.to_thread(
+            response = await self._run(
                 self.client.head_object, Bucket=self.bucket, Key=storage_path
             )
             return response.get("Metadata", {})
@@ -437,7 +474,7 @@ class R2StorageService:
             )
 
         try:
-            await asyncio.to_thread(
+            await self._run(
                 self.client.delete_object, Bucket=self.bucket, Key=storage_path
             )
             logger.info("Object deleted", extra={"storage_path": storage_path})
@@ -473,7 +510,7 @@ class R2StorageService:
             )
 
         try:
-            return await asyncio.to_thread(
+            return await self._run(
                 self._list_objects_sync, prefix=prefix, max_keys=max_keys
             )
         except ClientError as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,4 +59,6 @@ def storage_service_no_init():
     """Create R2StorageService without calling __init__ (avoids boto3)."""
     from dyvine.services.storage import R2StorageService
 
-    return object.__new__(R2StorageService)
+    service = object.__new__(R2StorageService)
+    service._executor = None  # type: ignore[attr-defined]
+    return service

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -199,12 +199,10 @@ async def test_operation_store_update_runs_in_thread(
 ) -> None:
     """Writes must not block the event loop.
 
-    Patch ``asyncio.to_thread`` to record that it was invoked for every
-    public method that is supposed to delegate. Without this contract,
-    per-page progress updates would stall the loop during bulk downloads.
+    Wrap ``OperationStore._run`` to record every sync helper that gets
+    dispatched. Without this contract, per-page progress updates would
+    stall the loop during bulk downloads.
     """
-    import asyncio as _asyncio
-
     store = OperationStore(str(tmp_path / "operations.db"))
     created = await store.create_operation(
         operation_type="livestream_download",
@@ -214,13 +212,13 @@ async def test_operation_store_update_runs_in_thread(
     )
 
     calls: list[str] = []
-    original = _asyncio.to_thread
+    original_run = store._run
 
-    async def tracking_to_thread(fn, *args, **kwargs):
+    async def tracking_run(fn, /, *args, **kwargs):
         calls.append(fn.__name__)
-        return await original(fn, *args, **kwargs)
+        return await original_run(fn, *args, **kwargs)
 
-    monkeypatch.setattr("dyvine.core.operations.asyncio.to_thread", tracking_to_thread)
+    monkeypatch.setattr(store, "_run", tracking_run)
 
     await store.update_operation(
         created.operation_id, status="running", message="running"

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import sqlite3
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 
 import pytest
@@ -237,3 +241,347 @@ async def test_operation_store_update_runs_in_thread(
         "_healthcheck_sync",
         "_mark_incomplete_operations_failed_sync",
     ]
+
+
+@pytest.mark.asyncio
+async def test_operation_store_latest_missing_raises(tmp_path) -> None:
+    """``get_latest_operation_for_subject`` signals absence as ``DownloadError``.
+
+    Exercised directly so the missing-record branch in
+    ``_get_latest_operation_for_subject_sync`` is covered without relying
+    on integration paths.
+    """
+    store = OperationStore(str(tmp_path / "operations.db"))
+
+    with pytest.raises(DownloadError, match="unknown-subject"):
+        await store.get_latest_operation_for_subject("unknown-subject")
+
+
+@pytest.mark.asyncio
+async def test_operation_store_update_with_no_allowed_fields_returns_current(
+    tmp_path,
+) -> None:
+    """Passing only unknown keys short-circuits to the current record."""
+    store = OperationStore(str(tmp_path / "operations.db"))
+    created = await store.create_operation(
+        operation_type="user_content_download",
+        subject_id="user-noop",
+        status="pending",
+        message="scheduled",
+    )
+
+    # ``subject_id`` is not in the allow-list, so ``updates`` ends up
+    # empty and the sync helper returns the existing record unchanged.
+    result = await store.update_operation(created.operation_id, subject_id="other")
+
+    assert result.operation_id == created.operation_id
+    assert result.status == "pending"
+    assert result.subject_id == "user-noop"
+
+
+def test_operation_store_set_executor_is_late_bindable(tmp_path) -> None:
+    """``set_executor`` lets the container swap in its dedicated pool."""
+    store = OperationStore(str(tmp_path / "operations.db"))
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        store.set_executor(executor)
+        assert store._executor is executor
+        store.set_executor(None)
+        assert store._executor is None
+    finally:
+        executor.shutdown(wait=True)
+
+
+@pytest.mark.asyncio
+async def test_operation_store_concurrent_reads_do_not_serialize(tmp_path) -> None:
+    """Reads from multiple threads should run in parallel, not one at a time.
+
+    With the old single-connection-plus-lock design, N concurrent reads
+    serialized behind ``self._lock``. With per-thread reader connections,
+    the wall-clock time of N simultaneous reads should be close to a
+    single slow read, not N * slow read.
+    """
+    store = OperationStore(str(tmp_path / "operations.db"))
+    created = await store.create_operation(
+        operation_type="user_content_download",
+        subject_id="user-parallel",
+        status="pending",
+        message="scheduled",
+    )
+
+    slow_read_delay = 0.05  # 50 ms
+    reader_count = 8
+
+    real_run = store._run
+
+    async def slow_run(fn, /, *args, **kwargs):
+        # Simulate a slow sqlite read inside the worker thread so the
+        # overlap is observable. The sleep happens on the executor thread,
+        # mirroring a real long-running SELECT.
+        def slow_wrapper(*a, **kw):
+            time.sleep(slow_read_delay)
+            return fn(*a, **kw)
+
+        return await real_run(slow_wrapper, *args, **kwargs)
+
+    executor = ThreadPoolExecutor(max_workers=reader_count)
+    try:
+        store.set_executor(executor)
+        # Patch ``_run`` per-task only for the reads below.
+        original_run = store._run
+        store._run = slow_run  # type: ignore[method-assign]
+        try:
+            start = time.perf_counter()
+            results = await asyncio.gather(
+                *(
+                    store.get_operation(created.operation_id)
+                    for _ in range(reader_count)
+                )
+            )
+            elapsed = time.perf_counter() - start
+        finally:
+            store._run = original_run  # type: ignore[method-assign]
+    finally:
+        store.set_executor(None)
+        executor.shutdown(wait=True)
+
+    assert len(results) == reader_count
+    # Serialized execution would take at least ``reader_count *
+    # slow_read_delay`` seconds. A healthy concurrent run finishes in a
+    # small multiple of one read. We allow generous slack so the test
+    # does not flake on slow CI while still catching accidental
+    # serialization (which would take >= 400 ms for 8 readers at 50 ms).
+    assert elapsed < slow_read_delay * reader_count / 2
+
+
+@pytest.mark.asyncio
+async def test_operation_store_writes_serialize_cleanly(tmp_path) -> None:
+    """Concurrent writes must not corrupt state.
+
+    Two concurrent update calls on the same operation should both commit
+    without raising, and the final record must reflect one of the two
+    updates (the one that committed last). SQLite's guarantees plus the
+    writer lock give us consistency; this test just ensures the new
+    writer-connection code path does not break that contract.
+    """
+    store = OperationStore(str(tmp_path / "operations.db"))
+    created = await store.create_operation(
+        operation_type="user_content_download",
+        subject_id="user-writer",
+        status="pending",
+        message="scheduled",
+        progress=0.0,
+    )
+
+    executor = ThreadPoolExecutor(max_workers=4)
+    try:
+        store.set_executor(executor)
+
+        async def bump(target_progress: float) -> None:
+            for _ in range(10):
+                await store.update_operation(
+                    created.operation_id, progress=target_progress
+                )
+
+        await asyncio.gather(bump(25.0), bump(75.0))
+    finally:
+        store.set_executor(None)
+        executor.shutdown(wait=True)
+
+    final = await store.get_operation(created.operation_id)
+    assert final.progress in {25.0, 75.0}
+
+
+def test_operation_store_shutdown_closes_reader_connections(tmp_path) -> None:
+    """``shutdown`` must close every per-thread reader connection."""
+    store = OperationStore(str(tmp_path / "operations.db"))
+    errors: list[BaseException] = []
+    connections: list[sqlite3.Connection] = []
+
+    def open_reader() -> None:
+        try:
+            conn = store._reader_connection()
+            conn.execute("SELECT 1").fetchone()
+            connections.append(conn)
+        except BaseException as exc:  # pragma: no cover - captured for debugging
+            errors.append(exc)
+
+    threads = [threading.Thread(target=open_reader) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert len(connections) == 4
+    assert len(store._reader_connections) == 4
+
+    store.shutdown()
+
+    assert store._reader_connections == {}
+    assert store._writer_slot.connection is None
+    # After shutdown, each reader connection must be closed. Using the
+    # handle should raise ``ProgrammingError`` -- ``sqlite3`` reports
+    # closed connections that way.
+    for conn in connections:
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1").fetchone()
+
+
+@pytest.mark.asyncio
+async def test_operation_store_shutdown_closes_writer_connection(tmp_path) -> None:
+    """After a write the writer slot is populated, and shutdown clears it."""
+    store = OperationStore(str(tmp_path / "operations.db"))
+    await store.create_operation(
+        operation_type="user_content_download",
+        subject_id="user-shutdown",
+        status="pending",
+        message="scheduled",
+    )
+    # The write above lazy-opens the writer connection.
+    writer = store._writer_slot.connection
+    assert writer is not None
+
+    store.shutdown()
+
+    assert store._writer_slot.connection is None
+    with pytest.raises(sqlite3.ProgrammingError):
+        writer.execute("SELECT 1").fetchone()
+
+
+def test_operation_store_shutdown_is_idempotent(tmp_path) -> None:
+    """Calling ``shutdown`` twice must not raise."""
+    store = OperationStore(str(tmp_path / "operations.db"))
+    store._reader_connection()  # ensure at least one reader exists
+    store.shutdown()
+    store.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_operation_store_reader_sees_writer_commits(tmp_path) -> None:
+    """The per-thread reader must see rows the writer already committed.
+
+    This guards against a WAL visibility regression: if readers ran in an
+    implicit transaction they would keep returning the old snapshot even
+    after the writer commits.
+    """
+    store = OperationStore(str(tmp_path / "operations.db"))
+    created = await store.create_operation(
+        operation_type="user_content_download",
+        subject_id="user-visibility",
+        status="pending",
+        message="scheduled",
+        progress=0.0,
+    )
+
+    executor = ThreadPoolExecutor(max_workers=2)
+    try:
+        store.set_executor(executor)
+        await store.update_operation(created.operation_id, progress=42.0)
+        refreshed = await store.get_operation(created.operation_id)
+        assert refreshed.progress == 42.0
+    finally:
+        store.set_executor(None)
+        executor.shutdown(wait=True)
+
+
+def test_operation_record_to_response_includes_expected_fields() -> None:
+    """``OperationRecord.to_response`` exposes the public API shape."""
+    from dyvine.core.operations import OperationRecord
+
+    record = OperationRecord(
+        operation_id="op-1",
+        operation_type="user_content_download",
+        subject_id="user-1",
+        status="pending",
+        message="scheduled",
+        progress=10.0,
+        total_items=5,
+        completed_items=1,
+        download_path="/tmp/f",
+        error=None,
+        metadata={"k": "v"},
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-02T00:00:00Z",
+    )
+
+    payload = record.to_response()
+
+    assert payload["operation_id"] == "op-1"
+    assert payload["task_id"] == "op-1"
+    assert payload["downloaded_items"] == 1
+    assert payload["status"] == "pending"
+
+
+def test_operation_store_shutdown_swallows_sqlite_errors_on_close(tmp_path) -> None:
+    """Failing close calls during shutdown must not bubble up."""
+
+    class FailingConnection:
+        def close(self) -> None:
+            raise sqlite3.Error("already closed")
+
+    store = OperationStore(str(tmp_path / "operations.db"))
+    # Inject a fake reader that raises on close so we hit the except branch.
+    fake_reader = FailingConnection()
+    with store._reader_lock:
+        store._reader_connections[99] = fake_reader  # type: ignore[assignment]
+    # And a fake writer connection that also raises on close.
+    store._writer_slot.connection = FailingConnection()  # type: ignore[assignment]
+
+    # Must not raise.
+    store.shutdown()
+    assert store._reader_connections == {}
+    assert store._writer_slot.connection is None
+
+
+def test_operation_store_healthcheck_swallows_rollback_errors(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``rollback`` raises, the healthcheck still finishes cleanly."""
+    store = OperationStore(str(tmp_path / "operations.db"))
+
+    real_connect = store._connect
+
+    class RollbackFailingConnection:
+        def __init__(self, real: sqlite3.Connection) -> None:
+            self._real = real
+
+        def execute(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            # First execute fails to force the finally branch.
+            raise sqlite3.OperationalError("boom")
+
+        def rollback(self) -> None:
+            raise sqlite3.Error("rollback failed")
+
+        def close(self) -> None:
+            self._real.close()
+
+    def fake_connect(**kwargs):  # type: ignore[no-untyped-def]
+        return RollbackFailingConnection(real_connect(**kwargs))
+
+    monkeypatch.setattr(store, "_connect", fake_connect)
+
+    with pytest.raises(sqlite3.OperationalError, match="boom"):
+        store._healthcheck_sync()
+
+
+def test_operation_store_finalizer_closes_connections_on_gc(tmp_path) -> None:
+    """GC'ing the store without calling shutdown must still close handles."""
+    import gc
+
+    store = OperationStore(str(tmp_path / "operations.db"))
+    reader = store._reader_connection()
+    assert reader is not None
+
+    # Snapshot the mutable containers so we can inspect them after the
+    # store itself is garbage collected.
+    readers = store._reader_connections
+    writer_slot = store._writer_slot
+
+    del store
+    gc.collect()
+
+    assert readers == {}
+    assert writer_slot.connection is None
+    with pytest.raises(sqlite3.ProgrammingError):
+        reader.execute("SELECT 1").fetchone()

--- a/tests/services/test_lifecycle_service.py
+++ b/tests/services/test_lifecycle_service.py
@@ -41,6 +41,9 @@ def _build_manager(
     mgr.storage = MagicMock()  # type: ignore[attr-defined]
     mgr.storage.list_objects = AsyncMock(return_value=[])  # type: ignore[attr-defined]
     mgr.storage.delete_object = AsyncMock()  # type: ignore[attr-defined]
+    # The container normally injects a dedicated audit executor; ``None``
+    # falls back to the default asyncio executor, which is enough for tests.
+    mgr._executor = None  # type: ignore[attr-defined]
     mgr.rules = rules or {}  # type: ignore[attr-defined]
     mgr.audit_config = audit_config or {  # type: ignore[attr-defined]
         "enabled": False,

--- a/tests/services/test_storage_service.py
+++ b/tests/services/test_storage_service.py
@@ -10,6 +10,7 @@ from dyvine.services.storage import ContentType, R2StorageService, StorageError
 
 def build_service_without_init() -> R2StorageService:
     service = object.__new__(R2StorageService)
+    service._executor = None  # type: ignore[attr-defined]
     return service  # type: ignore[return-value]
 
 

--- a/tests/services/test_storage_service_extended.py
+++ b/tests/services/test_storage_service_extended.py
@@ -20,6 +20,10 @@ from dyvine.services.storage import (
 def _build_service(*, with_client: bool = False) -> R2StorageService:
     """Create R2StorageService without boto3 initialization."""
     svc = object.__new__(R2StorageService)
+    # The service normally takes its executor through ``__init__``. ``None``
+    # falls back to the default asyncio executor, which is enough for tests
+    # that exercise the service in isolation.
+    svc._executor = None  # type: ignore[attr-defined]
     if with_client:
         svc.client = MagicMock()  # type: ignore[attr-defined]
         svc.bucket = "test-bucket"  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
Follow-up to #38 and #39. Swaps the default ``asyncio.to_thread`` pool for three bounded ``ThreadPoolExecutor``s owned by ``ServiceContainer``, then lifts the single-connection-plus-lock design inside ``OperationStore`` so concurrent reads no longer serialize.

## Related
- Builds on #38 (OperationStore sqlite off-loop) and #39 (R2 / lifecycle audit off-loop).

## Updates
| Path | Before | After | Why it matters |
| --- | --- | --- | --- |
| ``src/dyvine/core/dependencies.py`` | Every ``asyncio.to_thread`` call shared the default ``min(32, cpu+4)`` pool. | ``ServiceContainer.initialize`` creates three dedicated executors (``r2_executor=16``, ``sqlite_executor=4``, ``audit_executor=2``) and wires them into ``OperationStore`` / ``UserService.storage`` / ``LifecycleManager`` via constructor or ``set_executor``. ``ServiceContainer.shutdown`` drains them in reverse order with ``wait=True``. | A burst of R2 uploads no longer starves sqlite writes (and vice versa) on the single default pool. |
| ``src/dyvine/main.py`` | Lifespan shutdown logged uptime and returned. | Lifespan now awaits ``container.shutdown()`` so the executor pools and their worker threads are drained before the process exits. | Non-daemon worker threads no longer keep the interpreter alive past shutdown. |
| ``src/dyvine/services/storage.py`` | Four call sites used ``asyncio.to_thread(...)`` on the shared pool. | New ``R2StorageService._run`` dispatches through ``loop.run_in_executor(self._executor, functools.partial(...))``; ``set_executor`` lets the container inject the R2 pool post-hoc without changing ``UserService``'s constructor. | All R2 IO now flows through a single bounded pool dedicated to object storage. |
| ``src/dyvine/services/lifecycle.py`` | ``_write_audit_log`` used ``asyncio.to_thread`` on the shared pool. | ``LifecycleManager`` accepts an executor, routes the blocking audit write through ``loop.run_in_executor``, and exposes ``set_executor``. | Audit log writes are rare but must never starve R2 or sqlite; the dedicated two-worker pool isolates them. |
| ``src/dyvine/core/operations.py`` | Single ``sqlite3.Connection`` reopened per call, every read/write serialized behind one ``threading.Lock``. | Writer keeps its lock but now reuses a long-lived writer connection; readers use per-thread autocommit connections (``threading.local`` + ``dict[int, sqlite3.Connection]`` mirror). ``shutdown`` drains both, and a ``weakref.finalize`` safeguards stores GC'd without an explicit shutdown. | N concurrent ``get_operation`` calls run in parallel on the dedicated sqlite pool instead of queueing behind each other. |
| ``tests/core/test_operations.py`` | Monkeypatched ``asyncio.to_thread``; no concurrency coverage. | Patches ``OperationStore._run`` instead; adds concurrent-read, writer-serialization, shutdown, finalizer, and visibility tests. | Operations coverage stays ≥ 95% (98% here) and guards against regression of the new reader pool. |

## Details
### Task A — dedicated executors per IO domain
- Design / spec: every blocking IO now runs through a ``loop.run_in_executor`` call bound to a specific pool. Executors are constructed in ``ServiceContainer.initialize`` and shut down in a matching ``ServiceContainer.shutdown`` that the FastAPI lifespan awaits.
- Implementation notes:
  - ``OperationStore`` accepts ``executor=`` at construction so the container-built store uses the sqlite pool from the start (including the recovery sweep).
  - ``R2StorageService`` is still built inside ``UserService.__init__`` for historical reasons; the container calls ``user_service.storage.set_executor(...)`` after init so the R2 pool is applied without touching the service constructor.
  - ``LifecycleManager`` accepts ``executor=`` at construction. The module is not yet instantiated by the container (no public caller), but the wiring is ready when someone adds one.
  - Helper calls like ``_upload_file_sync`` and ``_list_objects_sync`` are unchanged; only the dispatch layer moves.
- Reviewer focus: confirm the ``ServiceContainer.shutdown`` order (operation store → audit → sqlite → r2) is right for the current ownership graph; if ``LifecycleManager`` is ever constructed inside the container, the audit executor needs to drain before the lifecycle manager releases its storage reference.

### Task B — OperationStore read concurrency
- Design / spec: readers use a per-thread autocommit connection opened on first call. The old ``threading.Lock`` protects only the writer connection now.
- Implementation notes:
  - The brief suggested ``WeakValueDictionary[int, sqlite3.Connection]``, but ``sqlite3.Connection`` doesn't expose ``__weakref__``, so a plain ``dict`` keyed by ``threading.get_ident()`` is used instead. The container always calls ``shutdown`` before the sqlite executor reaps its workers, so the dict never holds dead entries.
  - Reader connections use ``isolation_level=None`` (autocommit). Every SELECT starts and finishes its own implicit read transaction; in WAL mode this is what lets a reader see commits made by the writer between calls. A single explicit test (``test_operation_store_reader_sees_writer_commits``) pins this contract.
  - ``_healthcheck_sync`` still uses a throwaway connection because it grabs a RESERVED lock via ``BEGIN IMMEDIATE``. Running that on a per-thread reader would starve concurrent reads on that thread.
  - ``_update_operation_sync`` calls ``_get_operation_sync`` both before and after the write. On the same worker thread these SELECTs reuse the same reader and -- because the writer commits inside the same lock section -- the post-update read sees the new row.
- Reviewer focus: the WAL-cross-connection visibility argument above. If any reviewer spots a case where the reader could still hold an open transaction, it's worth a test: today we only rely on the documented ``isolation_level=None`` behavior.
- Bookkeeping:
  - ``OperationStore.shutdown`` closes every reader plus the writer under the lock and detaches the finalizer.
  - A module-level ``weakref.finalize`` callback runs the same cleanup when the store is garbage collected without an explicit shutdown, so tests that drop a store don't trip ``ResourceWarning: unclosed database`` under ``-W error``.
  - ``ServiceContainer.shutdown`` calls ``operation_store.shutdown()`` before draining the sqlite executor.

## Testing
- ``uv run pytest --cov=src/dyvine --cov-fail-under=80 -W error -q`` — 275 passed, total coverage 86.71% (baseline 86.01%), operations.py 98% (baseline 97%).
- ``uv run black --check .`` / ``uv run ruff check .`` / ``uv run mypy src/`` — all clean.
- New tests (all in ``tests/core/test_operations.py``):
  - ``test_operation_store_concurrent_reads_do_not_serialize`` — 8 concurrent reads with a 50 ms sleep each finish in < N*50/2 ms wall time.
  - ``test_operation_store_writes_serialize_cleanly`` — two writers, 10 updates each; final state is one of the two values.
  - ``test_operation_store_shutdown_closes_reader_connections`` — opens readers on 4 threads, then asserts ``shutdown`` closes each.
  - ``test_operation_store_shutdown_closes_writer_connection`` — lazily opens the writer, asserts ``shutdown`` closes and nulls it.
  - ``test_operation_store_shutdown_is_idempotent`` — second call is a no-op.
  - ``test_operation_store_reader_sees_writer_commits`` — WAL visibility contract.
  - ``test_operation_store_shutdown_swallows_sqlite_errors_on_close`` and ``test_operation_store_healthcheck_swallows_rollback_errors`` — exception branches.
  - ``test_operation_store_finalizer_closes_connections_on_gc`` — the ``weakref.finalize`` safety net.
  - ``test_operation_store_set_executor_is_late_bindable``, ``test_operation_record_to_response_includes_expected_fields``, ``test_operation_store_latest_missing_raises``, ``test_operation_store_update_with_no_allowed_fields_returns_current`` — coverage gap-fillers for the new public surface.
- Manual steps: not run.

## Screenshots / Notes
- Not applicable.

## Breaking changes
- ``OperationStore.__init__`` grows an ``executor=`` keyword argument (default ``None``). Existing callers that pass only a ``db_path`` continue to work; the store falls back to the default asyncio executor when no pool is attached.
- ``ServiceContainer`` gains an ``async shutdown()`` method. The FastAPI lifespan already awaits it; any out-of-repo code that built its own container now also needs to call it to drain the new thread pools.

## Risks and rollout
- The reader pool relies on Python's documented ``isolation_level=None`` semantics. If a future version of CPython changes autocommit behavior, the WAL visibility test would catch it before landing.
- The ``dict[int, sqlite3.Connection]`` registry is only safe because the container always calls ``shutdown`` before its sqlite executor reaps workers. A consumer that keeps the store but retires worker threads ad hoc would leak connection entries there. Today there is no such consumer.
- Rollback: revert the two commits in this PR. Task A on its own (``refactor(core): dedicate thread pool executors per IO domain``) is safe to keep even if Task B needs to roll back, because the first commit does not change the single-connection behavior of ``OperationStore``.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed (module docstrings reflect the new reader/writer split)
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted