### PR TITLE
fix(runtime): post-merge hardening — secrets validator, R2 config, task drain, loop cap

### DIFF
--- a/k8s/base/core/configmap.yaml
+++ b/k8s/base/core/configmap.yaml
@@ -11,7 +11,12 @@ data:
   API_DEBUG: "false"
   API_HOST: "0.0.0.0"
   API_PORT: "8000"
-  R2_ENDPOINT: "https://b619b24f5068c8260d6e3782f29e497d.r2.cloudflarestorage.com"
+  # R2_ENDPOINT is a template. ``{account_id}`` is interpolated at runtime
+  # by ``R2StorageService.__init__`` with ``settings.r2_account_id`` (sourced
+  # from the ``dyvine-secrets`` Secret). Keeping the account id out of the
+  # ConfigMap avoids leaking the Cloudflare account identifier in a public
+  # repository.
+  R2_ENDPOINT: "https://{account_id}.r2.cloudflarestorage.com"
   R2_BUCKET_NAME: "mmn-dev-data"
   DOUYIN_USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
   DOUYIN_REFERER: "https://www.douyin.com/"

--- a/src/dyvine/core/background.py
+++ b/src/dyvine/core/background.py
@@ -1,0 +1,93 @@
+"""Registry for tracking long-lived asyncio background tasks.
+
+FastAPI's ``BackgroundTasks`` runs after the response is sent but before the
+endpoint coroutine returns, so it is unsuitable for fire-and-forget downloads
+that must outlive a single request. Previously those downloads were spawned
+with bare ``asyncio.create_task`` and tracked nowhere. On a graceful shutdown
+the FastAPI lifespan tore down ``ServiceContainer`` executors before the
+tasks drained, which produced ``RuntimeError: cannot schedule new futures
+after shutdown`` inside active R2 uploads / audit writes.
+
+``BackgroundTaskRegistry`` centralizes spawn and drain so the lifespan can
+wait for active downloads before reaping the executor pools.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+from .logging import ContextLogger
+
+logger = ContextLogger(__name__)
+
+
+class BackgroundTaskRegistry:
+    """Track long-lived ``asyncio.Task`` handles so the lifespan can drain them.
+
+    Tasks are registered via :meth:`spawn`, auto-removed from the tracking set
+    on completion, and drained by :meth:`drain` during shutdown.
+
+    Attributes:
+        drain_timeout: Maximum seconds ``drain`` waits for tasks to finish
+            gracefully before cancelling anything still outstanding.
+    """
+
+    def __init__(self, *, drain_timeout: float = 30.0) -> None:
+        self._tasks: set[asyncio.Task[Any]] = set()
+        self.drain_timeout = drain_timeout
+
+    def spawn(
+        self,
+        coro: Coroutine[Any, Any, Any],
+        *,
+        name: str | None = None,
+    ) -> asyncio.Task[Any]:
+        """Schedule ``coro`` on the running loop and track the resulting task.
+
+        The task is auto-removed from the registry on completion via a
+        done-callback, so the registry never retains a handle to a finished
+        task.
+        """
+        task = asyncio.create_task(coro, name=name)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    async def drain(self) -> None:
+        """Wait for tracked tasks to finish, cancelling anything that overruns.
+
+        Returns once every tracked task has terminated -- successfully, with an
+        exception, or via cancellation. Called from
+        :meth:`ServiceContainer.shutdown` before the executor pools are torn
+        down so in-flight dispatches can resolve.
+        """
+        if not self._tasks:
+            return
+
+        # Snapshot so we don't iterate a set that the done-callbacks are
+        # concurrently shrinking.
+        pending = set(self._tasks)
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*pending, return_exceptions=True),
+                timeout=self.drain_timeout,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Background tasks did not finish before drain timeout; cancelling",
+                extra={
+                    "timeout_seconds": self.drain_timeout,
+                    "outstanding": len(pending),
+                },
+            )
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    @property
+    def active_count(self) -> int:
+        """Number of tasks currently tracked (not yet completed)."""
+        return len(self._tasks)

--- a/src/dyvine/core/dependencies.py
+++ b/src/dyvine/core/dependencies.py
@@ -37,6 +37,7 @@ from f2.apps.douyin.handler import DouyinHandler  # type: ignore
 
 from ..services.livestreams import LivestreamService
 from ..services.users import UserService
+from .background import BackgroundTaskRegistry
 from .operations import OperationStore
 from .settings import settings
 
@@ -89,6 +90,11 @@ class ServiceContainer:
         self._r2_executor: ThreadPoolExecutor | None = None
         self._sqlite_executor: ThreadPoolExecutor | None = None
         self._audit_executor: ThreadPoolExecutor | None = None
+        # Shared registry for long-lived background downloads. Services
+        # retrieve this via dependency injection and call ``spawn`` instead
+        # of bare ``asyncio.create_task`` so the lifespan can drain them
+        # before the executor pools are reaped.
+        self._background_tasks = BackgroundTaskRegistry()
 
     async def initialize(self) -> None:
         """Initialize all registered services with their configurations.
@@ -147,7 +153,10 @@ class ServiceContainer:
         await operation_store.mark_incomplete_operations_failed()
 
         # Initialize user service and wire its R2 client to the R2 executor.
-        user_service = UserService(operation_store=operation_store)
+        user_service = UserService(
+            operation_store=operation_store,
+            task_registry=self._background_tasks,
+        )
         user_service.storage.set_executor(self._r2_executor)
         self._services["user_service"] = user_service
 
@@ -156,6 +165,7 @@ class ServiceContainer:
             douyin_handler=self._services["douyin_handler"],
             user_service=user_service,
             operation_store=operation_store,
+            task_registry=self._background_tasks,
         )
 
         self._initialized = True
@@ -175,6 +185,12 @@ class ServiceContainer:
         """
         if not self._initialized:
             return
+
+        # Drain fire-and-forget downloads before tearing down the executor
+        # pools they dispatch onto. Any task still running after the
+        # registry's drain timeout is cancelled so the shutdown cannot hang
+        # on a stuck upstream request.
+        await self._background_tasks.drain()
 
         # Let the operation store close its per-thread reader connections
         # before we reap the sqlite executor that owns those worker threads.

--- a/src/dyvine/core/settings.py
+++ b/src/dyvine/core/settings.py
@@ -123,7 +123,7 @@ class SecuritySettings(BaseSettings):
 
         if (
             v == "change-me-in-production"
-            and os.getenv("API_DEBUG", "true").lower() != "true"
+            and os.getenv("API_DEBUG", "false").lower() != "true"
         ):
             raise ValueError(f"{info.field_name} must be changed in production")
         return v

--- a/src/dyvine/services/livestreams.py
+++ b/src/dyvine/services/livestreams.py
@@ -9,6 +9,7 @@ from f2.apps.douyin.handler import DouyinHandler  # type: ignore
 from f2.apps.douyin.utils import WebCastIdFetcher  # type: ignore
 from f2.exceptions.api_exceptions import APIResponseError  # type: ignore
 
+from ..core.background import BackgroundTaskRegistry
 from ..core.exceptions import (
     DownloadError,
     LivestreamError,
@@ -37,14 +38,27 @@ class LivestreamService:
     the necessary operations.
     """
 
+    # Class-level default so tests that instantiate via ``object.__new__``
+    # (bypassing ``__init__``) still see a ``None`` registry and fall through
+    # to the bare-``create_task`` branch rather than raising ``AttributeError``.
+    _task_registry: BackgroundTaskRegistry | None = None
+
     def __init__(
         self,
         *,
         douyin_handler: DouyinHandler,
         user_service: UserService,
         operation_store: OperationStore,
+        task_registry: BackgroundTaskRegistry | None = None,
     ) -> None:
-        """Initialize the livestream service using injected dependencies."""
+        """Initialize the livestream service using injected dependencies.
+
+        Args:
+            task_registry: Optional registry that owns long-lived stream
+                downloads. When omitted the service falls back to
+                ``asyncio.create_task`` so unit tests need not build the
+                full service container.
+        """
         self.settings = settings
         base_config = self._build_douyin_config()
         self.downloader_config = {
@@ -58,6 +72,7 @@ class LivestreamService:
         # metadata await in ``download_stream``.
         self._dedupe_lock: asyncio.Lock | None = None
         self.user_service = user_service
+        self._task_registry = task_registry
         self.operation_store = operation_store
         self.douyin_handler = douyin_handler
         # f2's Bark push notifications are meant for interactive CLI use;
@@ -561,16 +576,24 @@ class LivestreamService:
                 },
             )
 
-            job = asyncio.create_task(
-                self._run_stream_download(
-                    operation.operation_id,
-                    room_id,
-                    download_kwargs,
-                    webcast_payload,
-                    output_dir,
-                    target_file,
-                )
+            coro = self._run_stream_download(
+                operation.operation_id,
+                room_id,
+                download_kwargs,
+                webcast_payload,
+                output_dir,
+                target_file,
             )
+            # Route through the shared registry so the FastAPI lifespan can
+            # drain in-flight recordings before the R2 / audit executors
+            # are reaped. Fall back to ``create_task`` for isolated unit
+            # tests that bypass the container.
+            if self._task_registry is not None:
+                job = self._task_registry.spawn(
+                    coro, name=f"livestream-download-{room_id}"
+                )
+            else:
+                job = asyncio.create_task(coro)
             self.download_jobs[room_id] = job
 
         return LiveStreamDownloadResponse(**operation.to_response())

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -69,6 +69,7 @@ from typing import Any
 
 from f2.apps.douyin.handler import DouyinHandler  # type: ignore
 
+from ..core.background import BackgroundTaskRegistry
 from ..core.exceptions import DownloadError, ServiceError, UserNotFoundError
 from ..core.logging import ContextLogger
 from ..core.operations import OperationStore
@@ -146,10 +147,26 @@ class UserService:
     initiating content downloads, and tracking download progress.
     """
 
-    def __init__(self, operation_store: OperationStore | None = None) -> None:
-        """Initialize the user service."""
+    def __init__(
+        self,
+        operation_store: OperationStore | None = None,
+        *,
+        task_registry: BackgroundTaskRegistry | None = None,
+    ) -> None:
+        """Initialize the user service.
+
+        Args:
+            operation_store: Persistent operation record store. A private
+                ``OperationStore`` is created when not provided, which is the
+                path unit tests take.
+            task_registry: Optional registry that owns long-lived
+                background downloads. When omitted (e.g. in tests) the
+                service falls back to ``asyncio.create_task`` so the public
+                API remains testable without a full service container.
+        """
         self.operation_store = operation_store or OperationStore()
         self.storage = R2StorageService()
+        self._task_registry = task_registry
 
     async def get_user_info(self, user_id: str) -> UserResponse:
         """Retrieve user information from Douyin.
@@ -236,15 +253,24 @@ class UserService:
                 "max_items": max_items,
             },
         )
-        asyncio.create_task(
-            self._process_download(
-                operation.operation_id,
-                user_id=user_id,
-                include_posts=include_posts,
-                include_likes=include_likes,
-                max_items=max_items,
-            )
+        coro = self._process_download(
+            operation.operation_id,
+            user_id=user_id,
+            include_posts=include_posts,
+            include_likes=include_likes,
+            max_items=max_items,
         )
+        # Track the task through the shared registry when the container
+        # provided one so the lifespan can drain it on graceful shutdown.
+        # Fall back to a bare ``create_task`` for unit tests that
+        # instantiate ``UserService`` directly without going through the
+        # container.
+        if self._task_registry is not None:
+            self._task_registry.spawn(
+                coro, name=f"user-download-{operation.operation_id}"
+            )
+        else:
+            asyncio.create_task(coro)
         return DownloadResponse(**operation.to_response())
 
     async def get_download_status(self, task_id: str) -> DownloadResponse:
@@ -397,6 +423,23 @@ class UserService:
             has_more = True
             downloaded_count = 0
 
+            # Guard against an unbounded outer loop. ``max_cursor += 1`` in
+            # the "cursor stuck" branch below can spin indefinitely if the
+            # upstream API returns a sticky cursor or if every page's
+            # uploads fail, because ``downloaded_count`` never catches up
+            # to ``total_posts``. ``page_counts=100`` is the request size
+            # below, so the expected page count is ``total_posts / 100``;
+            # we double that and add slack for API quirks. Likes-only runs
+            # don't report a total, so use a generous ceiling tied to
+            # ``max_items`` when available, otherwise a conservative cap.
+            if max_items is not None:
+                max_pages = (max_items // 100) + 20
+            elif total_posts > 0:
+                max_pages = (total_posts // 100) * 2 + 20
+            else:
+                max_pages = 500
+            page_count = 0
+
             # ``fetch_user_like_videos`` has no ``min_cursor`` parameter,
             # so only include it for the posts fetcher.
             if downloading_likes_only:
@@ -407,6 +450,19 @@ class UserService:
                 fetcher_extra = {"min_cursor": 0}
 
             while has_more and (max_items is None or downloaded_count < max_items):
+                page_count += 1
+                if page_count > max_pages:
+                    logger.warning(
+                        "Download loop exceeded max_pages; stopping",
+                        extra={
+                            "task_id": task_id,
+                            "user_id": user_id,
+                            "max_pages": max_pages,
+                            "downloaded_count": downloaded_count,
+                            "total_posts": total_posts,
+                        },
+                    )
+                    break
                 iterated = False
                 async for aweme_data in fetcher(
                     user_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,21 @@ modules with side effects at import time (e.g. Prometheus metrics in storage.py)
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+# Flag the test runtime as "debug" before any ``dyvine.core.settings`` import
+# so the production-only validator in ``SecuritySettings.validate_not_default``
+# does not reject the default ``change-me-in-production`` sentinel values that
+# pydantic-settings supplies when no real env vars are present. Production
+# deployments set ``API_DEBUG=false`` explicitly; leaving this unset in tests
+# used to silently skip the validator, which was the bug fixed alongside this
+# conftest change.
+os.environ.setdefault("API_DEBUG", "true")
 
 SRC_DIR = Path(__file__).resolve().parents[1] / "src"
 if str(SRC_DIR) not in sys.path:

--- a/tests/core/test_background.py
+++ b/tests/core/test_background.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from dyvine.core.background import BackgroundTaskRegistry
+
+
+@pytest.mark.asyncio
+async def test_spawn_tracks_then_discards_completed_tasks() -> None:
+    registry = BackgroundTaskRegistry()
+
+    async def quick() -> int:
+        await asyncio.sleep(0)
+        return 42
+
+    task = registry.spawn(quick())
+    assert registry.active_count == 1
+
+    result = await task
+    assert result == 42
+    # The done-callback shrinks the tracking set without an explicit drain.
+    await asyncio.sleep(0)
+    assert registry.active_count == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_outstanding_tasks() -> None:
+    registry = BackgroundTaskRegistry(drain_timeout=2.0)
+    done_marker: list[str] = []
+
+    async def slow() -> None:
+        await asyncio.sleep(0.05)
+        done_marker.append("finished")
+
+    registry.spawn(slow())
+    await registry.drain()
+
+    assert done_marker == ["finished"]
+    assert registry.active_count == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_cancels_tasks_that_overrun_timeout() -> None:
+    registry = BackgroundTaskRegistry(drain_timeout=0.05)
+    cancelled: list[str] = []
+
+    async def hang() -> None:
+        try:
+            await asyncio.sleep(5.0)
+        except asyncio.CancelledError:
+            cancelled.append("hang")
+            raise
+
+    task = registry.spawn(hang())
+    await registry.drain()
+
+    assert task.cancelled()
+    assert cancelled == ["hang"]
+    assert registry.active_count == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_is_noop_when_nothing_is_tracked() -> None:
+    registry = BackgroundTaskRegistry(drain_timeout=0.01)
+    # No tasks registered; drain must return immediately without attempting
+    # to ``asyncio.wait_for(asyncio.gather(*[]))`` (which would hit the
+    # timeout branch on some event loops).
+    await registry.drain()
+    assert registry.active_count == 0
+
+
+@pytest.mark.asyncio
+async def test_spawn_propagates_exceptions_to_awaiters() -> None:
+    registry = BackgroundTaskRegistry()
+
+    async def boom() -> None:
+        raise RuntimeError("planned failure")
+
+    task = registry.spawn(boom(), name="boom")
+    with pytest.raises(RuntimeError, match="planned failure"):
+        await task
+    await asyncio.sleep(0)
+    assert registry.active_count == 0

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -15,7 +15,12 @@ from dyvine.core.settings import (
 # ── APISettings ──────────────────────────────────────────────────────────
 
 
-def test_api_settings_defaults() -> None:
+def test_api_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The shared test conftest sets ``API_DEBUG=true`` so the
+    # production-only validator in ``SecuritySettings`` does not fire on the
+    # sentinel defaults. Drop it here so we are asserting the true
+    # out-of-the-box defaults rather than our test-runtime override.
+    monkeypatch.delenv("API_DEBUG", raising=False)
     s = APISettings()
     assert s.version == "1.0.0"
     assert s.prefix == "/api/v1"
@@ -51,6 +56,18 @@ def test_security_settings_rejects_defaults_in_production(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("API_DEBUG", "false")
+    with pytest.raises(ValidationError):
+        SecuritySettings()
+
+
+def test_security_settings_rejects_defaults_when_api_debug_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An unset ``API_DEBUG`` must be treated as "not debug", matching the
+    # production default. Earlier versions defaulted the unset case to
+    # ``"true"``, which silently bypassed the ``change-me-in-production``
+    # validator whenever operators forgot to set the variable explicitly.
+    monkeypatch.delenv("API_DEBUG", raising=False)
     with pytest.raises(ValidationError):
         SecuritySettings()
 

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -336,6 +336,88 @@ async def test_process_download_runs_when_only_likes_requested(
 
 
 @pytest.mark.asyncio
+async def test_process_download_breaks_when_page_count_exceeds_cap(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An unbounded cursor bump must not spin the outer loop forever.
+
+    Simulate an upstream that returns a non-empty page with a sticky
+    ``max_cursor`` and ``has_more=True`` on every call. Without the
+    ``max_pages`` guard the outer ``while`` loop relies on
+    ``downloaded_count >= total_posts`` to stop, which never fires when
+    uploads are slower than the fetch rate or when the upstream lies
+    about its total. The guard must terminate the loop deterministically
+    after ``max_items // 100 + 20`` iterations.
+    """
+    from dyvine.services import users as users_mod
+
+    mock_user_data = MagicMock()
+    mock_user_data.nickname = "sticky-cursor-user"
+    mock_user_data.aweme_count = 100
+
+    fetch_profile = AsyncMock(return_value=mock_user_data)
+
+    sticky_batch = MagicMock()
+    sticky_batch.has_aweme = True
+    sticky_batch.aweme_id = ["aw"]
+    sticky_batch.has_more = True
+    sticky_batch.max_cursor = 0
+    sticky_batch._to_list = MagicMock(return_value=[])
+
+    call_count = 0
+
+    async def fake_fetch_posts(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        yield sticky_batch
+
+    class FakeDownloader:
+        create_download_tasks = AsyncMock()
+
+    class FakeHandler:
+        def __init__(self, kwargs: dict) -> None:
+            pass
+
+        fetch_user_profile = fetch_profile
+        fetch_user_post_videos = staticmethod(fake_fetch_posts)
+        downloader = FakeDownloader()
+
+    monkeypatch.setattr(users_mod, "DouyinHandler", FakeHandler)
+    # The production loop sleeps five seconds between pages. Skip that so
+    # the test terminates in milliseconds.
+    monkeypatch.setattr(users_mod.asyncio, "sleep", AsyncMock())
+    monkeypatch.chdir(tmp_path)
+
+    service = UserService()
+    operation = await service.operation_store.create_operation(
+        operation_type="user_content_download",
+        subject_id="sticky-cursor-user",
+        status="pending",
+        message="scheduled",
+    )
+
+    await service._process_download(
+        operation.operation_id,
+        user_id="sticky-cursor-user",
+        include_posts=True,
+        include_likes=False,
+        max_items=50,  # max_pages = 50 // 100 + 20 = 20
+    )
+
+    # The fetcher must have been invoked, but not more than ``max_pages``
+    # times. The outer loop breaks once ``page_count > max_pages``.
+    assert (
+        1 <= call_count <= 21
+    ), f"Expected the outer loop to break near max_pages=20, got {call_count} calls"
+    refreshed = await service.get_download_status(operation.operation_id)
+    # The loop terminated after exhausting ``max_pages`` without reaching
+    # ``total_posts``, so the completion branch records ``partial`` with
+    # the 20 items that did download.
+    assert refreshed.status == "partial"
+    assert refreshed.completed_items == 20
+
+
+@pytest.mark.asyncio
 async def test_process_download_likes_reports_progress_as_indeterminate(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
Post-merge review of #40–#43 surfaced two security gaps and two correctness gaps that the new executor-and-NetworkPolicy work did not cover. This PR fixes them as two focused commits.

## Related
- Post-merge follow-up to #40, #41, #42, #43.

## Updates
| Path | Before | After | Why it matters |
| --- | --- | --- | --- |
| `src/dyvine/core/settings.py` | `os.getenv("API_DEBUG", "true")` — unset env silently bypassed the `change-me-in-production` validator | `os.getenv("API_DEBUG", "false")` — unset is treated as production | Deployments that forgot to set `API_DEBUG=false` kept the sentinel secrets without any error. |
| `k8s/base/core/configmap.yaml` | `R2_ENDPOINT: "https://<real-account-id>.r2.cloudflarestorage.com"` | `R2_ENDPOINT: "https://{account_id}.r2.cloudflarestorage.com"` | `R2StorageService.__init__` already calls `.format(account_id=settings.r2_account_id)`, so the template works; keeping the real id in a public repo served no functional purpose and narrowed the attack surface. |
| `src/dyvine/core/background.py` (new) + `src/dyvine/core/dependencies.py` + `src/dyvine/services/{users,livestreams}.py` | `asyncio.create_task(...)` with no tracking; lifespan shutdown reaped executor pools before in-flight downloads finished | `BackgroundTaskRegistry.spawn` + `drain(timeout=30s)` called in `ServiceContainer.shutdown` before executor teardown | Prevents `RuntimeError: cannot schedule new futures after shutdown` when a rolling restart happens mid-upload. |
| `src/dyvine/services/users.py::_process_download` | `max_cursor += 1 ; has_more = True` whenever cursor was stuck — unbounded outer loop | `max_pages = max_items//100 + 20` (or `total_posts//100 * 2 + 20`); the loop logs a warning and breaks once exceeded | Sticky upstream cursors and persistent upload failures can no longer pin a background task alive until process restart. |

## Details

### Security: `SecuritySettings.validate_not_default`
- **Design/Spec:** the validator exists to prevent shipping with placeholder secrets. Its scope is "production only" so tests with sentinels still pass.
- **Bug:** `os.getenv("API_DEBUG", "true")` defaulted unset to `"true"`, so the guard `os.getenv(...).lower() != "true"` evaluated False whenever `API_DEBUG` was absent and the validator never fired.
- **Fix:** default unset to `"false"`. Add `tests/core/test_settings.py::test_security_settings_rejects_defaults_when_api_debug_unset` to lock in the behavior.
- **Test side-effect:** the existing suite relied on the sentinel defaults passing silently. `tests/conftest.py` now sets `os.environ.setdefault("API_DEBUG", "true")` before any `dyvine.*` import, and `tests/core/test_settings.py::test_api_settings_defaults` uses `monkeypatch.delenv("API_DEBUG")` so it asserts the true out-of-the-box `debug=False`.

### Security: R2 account id in the public ConfigMap
- **Design/Spec:** `R2StorageService.__init__` at `src/dyvine/services/storage.py` already substitutes `{account_id}` using `settings.r2_account_id`, which is sourced from the `dyvine-secrets` Secret.
- **Fix:** replace the pre-interpolated account id in the ConfigMap with the literal `{account_id}` template. Add a short comment explaining the runtime interpolation so a future reviewer does not "fix" the template back to a real id.

### Runtime: background task registry
- **Design/Spec:**
  - New module `src/dyvine/core/background.py` provides `BackgroundTaskRegistry` (`spawn`, `drain`, `active_count`). `drain` awaits all tracked tasks under `asyncio.wait_for(drain_timeout=30s)` and cancels anything still outstanding.
  - `ServiceContainer.__init__` constructs a single registry and passes it into `UserService` and `LivestreamService` by kwarg.
  - `ServiceContainer.shutdown` calls `await self._background_tasks.drain()` **before** shutting down the R2 / sqlite / audit executors, so in-flight dispatches to `loop.run_in_executor(...)` resolve cleanly rather than hitting `"cannot schedule new futures after shutdown"`.
- **Implementation notes:**
  - Both services accept `task_registry: BackgroundTaskRegistry | None = None`. When `None`, they fall back to `asyncio.create_task(...)` so the existing unit tests (which construct the services directly) continue to work without touching them.
  - `LivestreamService` declares `_task_registry: BackgroundTaskRegistry | None = None` as a class-level default so tests using `object.__new__(LivestreamService)` still see the attribute.

### Runtime: `_process_download` iteration cap
- **Design/Spec:** the outer `while has_more and (max_items is None or downloaded_count < max_items)` loop depended on two stopping conditions: `has_more` flipping False, or `downloaded_count` meeting either `max_items` or `total_posts`. Neither fires when every page's uploads fail or when the upstream returns a sticky cursor. The PR #42 `iterated` sentinel only covered the empty-page shape.
- **Fix:** compute `max_pages` from `max_items` or `total_posts` before the loop (`500` ceiling when both are unknown). Break with a warning log once `page_count > max_pages`. The completion branch at the bottom of `_process_download` already records `status="partial"` when `downloaded_count < total_posts`, so the resulting state is a truthful "we fetched what we could."
- **Reviewer focus:** the loop still terminates naturally on well-behaved upstreams (`has_more=False` after a few pages). The cap only bites on pathological cases.

## Testing
- `uv run pytest --cov=src/dyvine --cov-fail-under=80 -W error -q` — **292 passed, coverage 87.87%** (up from 285 / 87.00%).
- `uv run black --check .` / `uv run ruff check .` / `uv run mypy src/` — all clean.
- `kubectl kustomize k8s/base` — renders the eight expected resources including the templated `R2_ENDPOINT`.
- Manual steps: Not run.

## Screenshots / Notes
- Not applicable.

## Breaking changes
- **Runtime env:** production deployments without `API_DEBUG=false` were implicitly "allowed" by the broken validator. They are now rejected at startup with `ValidationError: secret_key must be changed in production`. This is the intended behavior of the validator; any deployment relying on the previous silent bypass needs to set real secrets before applying this commit.
- **API:** `UserService.__init__` and `LivestreamService.__init__` grow an optional `task_registry` kwarg. Existing call sites (tests and `ServiceContainer`) are updated; downstream consumers that instantiate these services directly continue to work without changes because the kwarg defaults to `None`.

## Risks and rollout
- The drain timeout is 30 seconds. A livestream recording that legitimately needs longer to finalize will be cancelled. We record the cancellation as a failed operation via the existing `mark_incomplete_operations_failed` sweep on next startup, so the state stays consistent, but the recorded video up to that point is lost. If 30 seconds proves too short in production, bump `BackgroundTaskRegistry(drain_timeout=...)` in `ServiceContainer.__init__`.
- The `max_pages` cap can in principle under-count downloads if an upstream legitimately needs many more paginated calls than the heuristic expects. The default is `(total_posts // 100) * 2 + 20`, which gives 2× slack; for `max_items=N` it is `N // 100 + 20`, giving 20+ extra pages. If we see false-positive caps, we can tune the multiplier in one place.
- Rollback: revert `80f3733` (task registry + iteration cap) and `e25568e` (settings + configmap) — each stands on its own.

## Checklist
- [x] Tests added/updated if needed (five `BackgroundTaskRegistry` tests; one settings-validator test; one iteration-cap test)
- [x] Docs updated if needed (no behavior change on the wire; internal ConfigMap comment explains the template)
- [x] Backward compatibility considered (new kwargs optional; fall-through to `create_task` preserved)
- [x] Rollout/monitoring considerations noted (drain timeout; iteration-cap tuning knob)
