### PR TITLE
fix(runtime): close guards, posts loop cap, shared R2 head pool

### DIFF
--- a/src/dyvine/core/background.py
+++ b/src/dyvine/core/background.py
@@ -116,6 +116,16 @@ class BackgroundTaskRegistry:
         """Number of tasks currently tracked (not yet completed)."""
         return len(self._tasks)
 
+    @property
+    def is_closed(self) -> bool:
+        """Whether ``drain`` has been entered.
+
+        Callers can probe this to avoid scheduling work that is
+        guaranteed to be rejected by :meth:`spawn`. The flag never flips
+        back to ``False``; the registry is single-use.
+        """
+        return self._closed
+
 
 def spawn_or_fallback(
     registry: BackgroundTaskRegistry | None,

--- a/src/dyvine/core/background.py
+++ b/src/dyvine/core/background.py
@@ -27,7 +27,11 @@ class BackgroundTaskRegistry:
     """Track long-lived ``asyncio.Task`` handles so the lifespan can drain them.
 
     Tasks are registered via :meth:`spawn`, auto-removed from the tracking set
-    on completion, and drained by :meth:`drain` during shutdown.
+    on completion, and drained by :meth:`drain` during shutdown. Once
+    :meth:`drain` is entered the registry is closed: subsequent
+    :meth:`spawn` calls raise ``RuntimeError`` rather than silently leaking
+    work past the executor teardown that follows in
+    ``ServiceContainer.shutdown``.
 
     Attributes:
         drain_timeout: Maximum seconds ``drain`` waits for tasks to finish
@@ -37,6 +41,10 @@ class BackgroundTaskRegistry:
     def __init__(self, *, drain_timeout: float = 30.0) -> None:
         self._tasks: set[asyncio.Task[Any]] = set()
         self.drain_timeout = drain_timeout
+        # Set inside ``drain`` so any post-drain ``spawn`` is rejected
+        # explicitly rather than being added to a registry nobody will
+        # await again.
+        self._closed = False
 
     def spawn(
         self,
@@ -49,7 +57,18 @@ class BackgroundTaskRegistry:
         The task is auto-removed from the registry on completion via a
         done-callback, so the registry never retains a handle to a finished
         task.
+
+        Raises:
+            RuntimeError: If the registry has already been drained. The
+                supplied coroutine is closed before raising so it does not
+                leak an ``unawaited coroutine`` warning under ``-W error``.
         """
+        if self._closed:
+            coro.close()
+            raise RuntimeError(
+                "BackgroundTaskRegistry is closed; cannot spawn new tasks "
+                "after drain has been entered"
+            )
         task = asyncio.create_task(coro, name=name)
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
@@ -61,8 +80,13 @@ class BackgroundTaskRegistry:
         Returns once every tracked task has terminated -- successfully, with an
         exception, or via cancellation. Called from
         :meth:`ServiceContainer.shutdown` before the executor pools are torn
-        down so in-flight dispatches can resolve.
+        down so in-flight dispatches can resolve. The registry is marked
+        closed before awaiting so any concurrent ``spawn`` cannot add work
+        the drain would not see.
         """
+        # Mark closed even when there is nothing to drain so a follow-up
+        # ``spawn`` (e.g. from a stale callback) is rejected consistently.
+        self._closed = True
         if not self._tasks:
             return
 
@@ -91,3 +115,22 @@ class BackgroundTaskRegistry:
     def active_count(self) -> int:
         """Number of tasks currently tracked (not yet completed)."""
         return len(self._tasks)
+
+
+def spawn_or_fallback(
+    registry: BackgroundTaskRegistry | None,
+    coro: Coroutine[Any, Any, Any],
+    *,
+    name: str | None = None,
+) -> asyncio.Task[Any]:
+    """Schedule ``coro`` via ``registry`` when available, else bare ``create_task``.
+
+    Centralizes the fallback used by services that may run inside the
+    container (with a real registry) or as bare ``object.__new__`` stubs in
+    unit tests (with no registry). Keeping the branch in one place stops
+    each new long-lived service from hand-rolling the same ``if registry is
+    not None`` pattern.
+    """
+    if registry is not None:
+        return registry.spawn(coro, name=name)
+    return asyncio.create_task(coro, name=name)

--- a/src/dyvine/core/dependencies.py
+++ b/src/dyvine/core/dependencies.py
@@ -49,6 +49,12 @@ from .settings import settings
 # executor (``min(32, cpu+4)``) that every ``asyncio.to_thread`` call would
 # otherwise share.
 R2_EXECUTOR_MAX_WORKERS = 16
+# ``head_object`` fan-out runs inside ``R2StorageService._list_objects_sync``
+# while the surrounding listing already occupies a worker on
+# ``r2_executor``. A shared global pool puts a single ceiling on concurrent
+# ``head_object`` requests across every in-flight listing instead of letting
+# each listing spawn its own short-lived ``ThreadPoolExecutor``.
+R2_HEAD_EXECUTOR_MAX_WORKERS = 16
 SQLITE_EXECUTOR_MAX_WORKERS = 4
 AUDIT_EXECUTOR_MAX_WORKERS = 2
 
@@ -88,6 +94,7 @@ class ServiceContainer:
         self._services: dict[str, Any] = {}
         self._initialized = False
         self._r2_executor: ThreadPoolExecutor | None = None
+        self._r2_head_executor: ThreadPoolExecutor | None = None
         self._sqlite_executor: ThreadPoolExecutor | None = None
         self._audit_executor: ThreadPoolExecutor | None = None
         # Shared registry for long-lived background downloads. Services
@@ -112,6 +119,8 @@ class ServiceContainer:
 
         Executors created:
             - ``r2_executor`` (16 workers): R2 upload/head/delete/list
+            - ``r2_head_executor`` (16 workers): per-key ``head_object``
+              fan-out triggered inside ``R2StorageService._list_objects_sync``
             - ``sqlite_executor`` (4 workers): OperationStore writes/reads
             - ``audit_executor`` (2 workers): LifecycleManager audit writes
 
@@ -129,6 +138,10 @@ class ServiceContainer:
         self._r2_executor = ThreadPoolExecutor(
             max_workers=R2_EXECUTOR_MAX_WORKERS,
             thread_name_prefix="dyvine-r2",
+        )
+        self._r2_head_executor = ThreadPoolExecutor(
+            max_workers=R2_HEAD_EXECUTOR_MAX_WORKERS,
+            thread_name_prefix="dyvine-r2-head",
         )
         self._sqlite_executor = ThreadPoolExecutor(
             max_workers=SQLITE_EXECUTOR_MAX_WORKERS,
@@ -153,11 +166,16 @@ class ServiceContainer:
         await operation_store.mark_incomplete_operations_failed()
 
         # Initialize user service and wire its R2 client to the R2 executor.
+        # The dedicated head fan-out pool is attached separately so a burst
+        # of concurrent ``list_objects`` calls does not nest one
+        # ``ThreadPoolExecutor`` per listing inside a worker thread of
+        # ``r2_executor``.
         user_service = UserService(
             operation_store=operation_store,
             task_registry=self._background_tasks,
         )
         user_service.storage.set_executor(self._r2_executor)
+        user_service.storage.set_head_executor(self._r2_head_executor)
         self._services["user_service"] = user_service
 
         # Initialize livestream service
@@ -198,7 +216,16 @@ class ServiceContainer:
         if isinstance(operation_store, OperationStore):
             operation_store.shutdown()
 
-        for attr in ("_audit_executor", "_sqlite_executor", "_r2_executor"):
+        # Reverse of init order. ``r2_executor`` is drained before
+        # ``r2_head_executor`` so any in-flight listing finishes its
+        # ``head_object`` fan-out submissions while the head pool still
+        # accepts work; the head pool is then drained on its own.
+        for attr in (
+            "_audit_executor",
+            "_sqlite_executor",
+            "_r2_executor",
+            "_r2_head_executor",
+        ):
             executor = getattr(self, attr)
             if executor is not None:
                 executor.shutdown(wait=True)

--- a/src/dyvine/core/operations.py
+++ b/src/dyvine/core/operations.py
@@ -196,6 +196,16 @@ class OperationStore:
         """
         self._executor = executor
 
+    @property
+    def is_closed(self) -> bool:
+        """Whether :meth:`shutdown` has been called.
+
+        Callers can probe this to avoid issuing work that is guaranteed to
+        be rejected by :meth:`_run`. The flag never flips back to
+        ``False``; the store is single-use after shutdown.
+        """
+        return self._closed
+
     async def _run(self, func: Callable[..., _R], /, *args: Any, **kwargs: Any) -> _R:
         """Dispatch a blocking sqlite call to the configured executor.
 

--- a/src/dyvine/core/operations.py
+++ b/src/dyvine/core/operations.py
@@ -166,6 +166,12 @@ class OperationStore:
         # the finalizer below close the writer even if the instance itself
         # has already been garbage collected.
         self._writer_slot = _WriterSlot()
+        # Set to True by ``shutdown`` so any later async dispatch fails
+        # loudly with ``RuntimeError`` rather than returning a closed
+        # sqlite handle. The container drains every background task before
+        # calling ``shutdown``, so in normal operation this guard only
+        # surfaces programming errors.
+        self._closed = False
         # Register a weakref finalizer so an ``OperationStore`` that falls
         # out of scope without an explicit ``shutdown`` (typical in tests)
         # still closes every handle and does not trip the
@@ -196,7 +202,16 @@ class OperationStore:
         Falls back to the default asyncio executor when no dedicated pool is
         attached, which keeps tests that instantiate the store directly
         working without a container.
+
+        Raises:
+            RuntimeError: If ``shutdown`` has already closed the store. All
+                public coroutines route through this helper, so a single
+                guard here covers the full async surface.
         """
+        if self._closed:
+            raise RuntimeError(
+                "OperationStore has been shut down; cannot dispatch new work"
+            )
         loop = asyncio.get_running_loop()
         result: _R = await loop.run_in_executor(
             self._executor, functools.partial(func, *args, **kwargs)
@@ -310,8 +325,12 @@ class OperationStore:
         exit. Safe to call multiple times.
         """
         # Snapshot under the lock so we don't iterate while another thread
-        # registers a fresh reader.
+        # registers a fresh reader. ``_closed`` is flipped here too so
+        # ``_run`` rejects further async dispatches even if a worker thread
+        # still holds a stale ``threading.local`` reference to a connection
+        # we are about to close.
         with self._reader_lock:
+            self._closed = True
             readers = list(self._reader_connections.values())
             self._reader_connections.clear()
         for connection in readers:

--- a/src/dyvine/core/pagination.py
+++ b/src/dyvine/core/pagination.py
@@ -1,0 +1,34 @@
+"""Shared pagination constants for bulk content download loops.
+
+Both ``services/users.py::UserService._process_download`` and
+``services/posts.py::PostService.download_all_user_posts`` cap their
+outer pagination loops with the same heuristic::
+
+    max_pages = (total // PAGE_SIZE) * PAGE_MULTIPLIER + PAGE_SLACK
+
+When the upstream total is unknown the loop falls back to
+``MAX_PAGES_FALLBACK``. The fallback covers ``MAX_PAGES_FALLBACK *
+PAGE_SIZE`` items per loop -- 50_000 for the user download loop
+(``PAGE_SIZE=100`` in ``services/users.py``) and 10_000 for the post
+bulk loop (``PAGE_SIZE=20`` in ``services/posts.py``). Accounts above
+those numbers will hit the cap and the calling service will record a
+partial completion via the existing status branches.
+
+``PAGE_SIZE`` itself stays at each call site because every fetcher
+accepts a different page size; only the slack / multiplier / fallback
+are shared so a future tuning PR can adjust the cap budget in one
+place.
+"""
+
+# Extra pages on top of the expected ``total // PAGE_SIZE`` so the loop
+# tolerates upstream cursor jitter without truncating legitimate runs.
+PAGE_SLACK = 20
+
+# Multiplier applied to the expected page count so a moderately sticky
+# upstream still has room to make progress before the cap fires.
+PAGE_MULTIPLIER = 2
+
+# Used when the upstream does not expose a total (likes-only runs and
+# the bulk-post loop without a profile total). Bounds the loop at
+# ``MAX_PAGES_FALLBACK * PAGE_SIZE`` items per call.
+MAX_PAGES_FALLBACK = 500

--- a/src/dyvine/core/pagination.py
+++ b/src/dyvine/core/pagination.py
@@ -28,7 +28,8 @@ PAGE_SLACK = 20
 # upstream still has room to make progress before the cap fires.
 PAGE_MULTIPLIER = 2
 
-# Used when the upstream does not expose a total (likes-only runs and
-# the bulk-post loop without a profile total). Bounds the loop at
-# ``MAX_PAGES_FALLBACK * PAGE_SIZE`` items per call.
+# Used when the upstream does not expose a positive total (likes-only
+# runs, profiles reporting zero, or non-int ``aweme_count`` coerced to
+# ``0``). Bounds the loop at ``MAX_PAGES_FALLBACK * PAGE_SIZE`` items
+# per call.
 MAX_PAGES_FALLBACK = 500

--- a/src/dyvine/services/livestreams.py
+++ b/src/dyvine/services/livestreams.py
@@ -9,7 +9,7 @@ from f2.apps.douyin.handler import DouyinHandler  # type: ignore
 from f2.apps.douyin.utils import WebCastIdFetcher  # type: ignore
 from f2.exceptions.api_exceptions import APIResponseError  # type: ignore
 
-from ..core.background import BackgroundTaskRegistry
+from ..core.background import BackgroundTaskRegistry, spawn_or_fallback
 from ..core.exceptions import (
     DownloadError,
     LivestreamError,
@@ -586,14 +586,14 @@ class LivestreamService:
             )
             # Route through the shared registry so the FastAPI lifespan can
             # drain in-flight recordings before the R2 / audit executors
-            # are reaped. Fall back to ``create_task`` for isolated unit
-            # tests that bypass the container.
-            if self._task_registry is not None:
-                job = self._task_registry.spawn(
-                    coro, name=f"livestream-download-{room_id}"
-                )
-            else:
-                job = asyncio.create_task(coro)
+            # are reaped. ``spawn_or_fallback`` falls back to a bare
+            # ``asyncio.create_task`` for isolated unit tests that bypass
+            # the container.
+            job = spawn_or_fallback(
+                self._task_registry,
+                coro,
+                name=f"livestream-download-{room_id}",
+            )
             self.download_jobs[room_id] = job
 
         return LiveStreamDownloadResponse(**operation.to_response())

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -140,6 +140,13 @@ class PostService:
     ) -> list[PostDetail]:
         """Retrieve a paginated list of posts from a Douyin user.
 
+        ``count`` is intentionally a literal default rather than the
+        module-level :data:`PAGE_SIZE`. The latter binds the bulk
+        download loop guard to the fetcher used by ``_fetch_posts_batch``;
+        this single-page API is a public read endpoint whose contract
+        should not silently change if a future tuning PR adjusts
+        :data:`PAGE_SIZE`.
+
         Args:
             sec_user_id: Unique identifier of the user.
             max_cursor: Pagination cursor for fetching the next batch of posts.

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -32,6 +32,7 @@ from ..core.exceptions import (
     UserNotFoundError,
 )
 from ..core.logging import ContextLogger
+from ..core.pagination import MAX_PAGES_FALLBACK, PAGE_MULTIPLIER, PAGE_SLACK
 from ..schemas.posts import (
     BulkDownloadResponse,
     DownloadStatus,
@@ -46,16 +47,12 @@ logger = ContextLogger(__name__)
 # Alias for backward compatibility
 PostServiceError = ServiceError
 
-# ``_fetch_posts_batch`` requests 20 items per page. The bulk download loop
-# can in principle terminate via ``has_more=False`` or by exhausting all
-# posts, but a sticky upstream cursor (server keeps echoing the same
-# non-empty batch with ``has_more=True``) would otherwise spin the loop
-# forever after the ``+1`` cursor advance. ``MAX_PAGES_FALLBACK`` bounds
-# the loop when ``total_posts`` is unknown.
-_BATCH_PAGE_SIZE = 20
-_PAGE_SLACK = 20
-_PAGE_MULTIPLIER = 2
-_MAX_PAGES_FALLBACK = 500
+# Page size requested from ``_fetch_posts_batch``. The outer loop guard
+# combines this with the shared :mod:`dyvine.core.pagination` constants
+# so a sticky upstream cursor cannot keep the ``+1`` cursor advance
+# spinning forever. The fallback covers ``MAX_PAGES_FALLBACK * PAGE_SIZE``
+# items when ``total_posts`` is unknown.
+PAGE_SIZE = 20
 
 
 class PostService:
@@ -278,11 +275,9 @@ class PostService:
             # the server keeps replying with the same ``max_cursor`` the
             # only stop conditions become ``has_more=False`` or this cap.
             if total_posts > 0:
-                max_pages = (
-                    total_posts // _BATCH_PAGE_SIZE
-                ) * _PAGE_MULTIPLIER + _PAGE_SLACK
+                max_pages = (total_posts // PAGE_SIZE) * PAGE_MULTIPLIER + PAGE_SLACK
             else:
-                max_pages = _MAX_PAGES_FALLBACK
+                max_pages = MAX_PAGES_FALLBACK
             page_count = 0
 
             while True:
@@ -385,7 +380,7 @@ class PostService:
         )
 
         posts_iterator = self.handler.fetch_user_post_videos(
-            sec_user_id=sec_user_id, max_cursor=cursor, page_counts=20
+            sec_user_id=sec_user_id, max_cursor=cursor, page_counts=PAGE_SIZE
         )
 
         try:

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -46,6 +46,17 @@ logger = ContextLogger(__name__)
 # Alias for backward compatibility
 PostServiceError = ServiceError
 
+# ``_fetch_posts_batch`` requests 20 items per page. The bulk download loop
+# can in principle terminate via ``has_more=False`` or by exhausting all
+# posts, but a sticky upstream cursor (server keeps echoing the same
+# non-empty batch with ``has_more=True``) would otherwise spin the loop
+# forever after the ``+1`` cursor advance. ``MAX_PAGES_FALLBACK`` bounds
+# the loop when ``total_posts`` is unknown.
+_BATCH_PAGE_SIZE = 20
+_PAGE_SLACK = 20
+_PAGE_MULTIPLIER = 2
+_MAX_PAGES_FALLBACK = 500
+
 
 class PostService:
     """Service class for handling Douyin post operations.
@@ -261,7 +272,33 @@ class PostService:
                 )
 
             current_cursor = max_cursor
+            # Bound the outer loop so a sticky upstream cursor cannot pin a
+            # worker forever even when each page is non-empty. The
+            # ``+1`` cursor advance below keeps progress moving, but if
+            # the server keeps replying with the same ``max_cursor`` the
+            # only stop conditions become ``has_more=False`` or this cap.
+            if total_posts > 0:
+                max_pages = (
+                    total_posts // _BATCH_PAGE_SIZE
+                ) * _PAGE_MULTIPLIER + _PAGE_SLACK
+            else:
+                max_pages = _MAX_PAGES_FALLBACK
+            page_count = 0
+
             while True:
+                page_count += 1
+                if page_count > max_pages:
+                    logger.warning(
+                        "Bulk download loop exceeded max_pages; stopping",
+                        extra={
+                            "sec_user_id": sec_user_id,
+                            "cursor": current_cursor,
+                            "max_pages": max_pages,
+                            "total_downloaded": sum(download_stats.values()),
+                            "total_posts": total_posts,
+                        },
+                    )
+                    break
                 try:
                     posts = await self._fetch_posts_batch(sec_user_id, current_cursor)
                     if not posts:

--- a/src/dyvine/services/storage.py
+++ b/src/dyvine/services/storage.py
@@ -87,7 +87,12 @@ class R2StorageService:
         bucket: Name of the R2 bucket
     """
 
-    def __init__(self, *, executor: Executor | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        executor: Executor | None = None,
+        head_executor: Executor | None = None,
+    ) -> None:
         """Initialize the R2 storage service.
 
         Configures the boto3 client with R2-specific settings and retry config.
@@ -98,8 +103,15 @@ class R2StorageService:
                 When ``None`` the service falls back to the default asyncio
                 executor, which keeps historical behavior for tests that
                 build the service directly.
+            head_executor: Optional dedicated executor used to fan out the
+                ``head_object`` calls inside ``_list_objects_sync``. The
+                container injects a single shared pool so concurrent
+                listings cannot each spawn their own short-lived
+                ``ThreadPoolExecutor``. When ``None`` the listing path
+                falls back to a one-off pool sized for the page.
         """
         self._executor: Executor | None = executor
+        self._head_executor: Executor | None = head_executor
 
         # Check if R2 configuration is available
         if not settings.r2.is_configured:
@@ -140,6 +152,14 @@ class R2StorageService:
         ``UserService`` constructor signature.
         """
         self._executor = executor
+
+    def set_head_executor(self, executor: Executor | None) -> None:
+        """Attach the dedicated ``head_object`` fan-out executor.
+
+        Mirrors :meth:`set_executor` so the container can wire the head
+        pool post-construction without changing ``UserService``.
+        """
+        self._head_executor = executor
 
     async def _run(self, func: Callable[..., _R], /, *args: Any, **kwargs: Any) -> _R:
         """Dispatch a blocking boto3 call to the configured executor.
@@ -526,12 +546,11 @@ class R2StorageService:
         N follow-up ``head_object`` calls that carry object metadata -- runs
         off the event loop. ``list_objects_v2`` returns objects in
         lexicographic order; this method preserves that ordering in its
-        output. The ``head_object`` fan-out is dispatched to a short-lived
-        ``ThreadPoolExecutor`` with worker count capped at
-        :data:`LIST_OBJECTS_HEAD_MAX_WORKERS` to avoid saturating the
-        boto3 connection pool on large pages. ``max_keys`` caps the single
-        page; callers that need more than one page are expected to
-        paginate themselves.
+        output. When the container has injected a shared head executor the
+        per-key fan-out reuses it so several concurrent listings share one
+        bounded thread budget; otherwise we fall back to a one-off pool
+        capped at :data:`LIST_OBJECTS_HEAD_MAX_WORKERS` to keep test and
+        ad-hoc callers parallel without wiring a container.
         """
         assert self.client is not None and self.bucket is not None
         client = self.client
@@ -565,6 +584,15 @@ class R2StorageService:
             return head.get("Metadata", {}) or {}
 
         keys: list[str | None] = [obj.get("Key") for obj in objects]
+        if self._head_executor is not None:
+            # Reuse the container-owned pool. ``Executor.map`` preserves
+            # input order, so zipping back into ``results`` keeps the
+            # lexicographic ordering ``list_objects_v2`` returned.
+            metadata_iter = self._head_executor.map(_fetch_metadata, keys)
+            for obj_data, metadata in zip(results, metadata_iter, strict=True):
+                obj_data["Metadata"] = metadata
+            return results
+
         workers = min(LIST_OBJECTS_HEAD_MAX_WORKERS, len(keys))
         with ThreadPoolExecutor(
             max_workers=workers, thread_name_prefix="r2-head"

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -73,19 +73,15 @@ from ..core.background import BackgroundTaskRegistry, spawn_or_fallback
 from ..core.exceptions import DownloadError, ServiceError, UserNotFoundError
 from ..core.logging import ContextLogger
 from ..core.operations import OperationStore
+from ..core.pagination import MAX_PAGES_FALLBACK, PAGE_MULTIPLIER, PAGE_SLACK
 from ..core.settings import settings
 from ..schemas.users import DownloadResponse, UserResponse
 from .storage import ContentType, R2StorageService
 
-# Pagination constants for ``_process_download``. ``f2`` reports up to
-# ``PAGE_SIZE`` items per page; the outer loop expects roughly
-# ``total_posts / PAGE_SIZE`` pages, so we double that plus slack for
-# upstream quirks. Likes-only runs have no known total, so they fall back
-# to ``MAX_PAGES_FALLBACK``.
+# Page size requested from the f2 fetcher. The outer loop guard uses the
+# shared :mod:`dyvine.core.pagination` constants together with this value
+# to bound the number of pages we will walk before giving up.
 PAGE_SIZE = 100
-PAGE_SLACK = 20
-PAGE_MULTIPLIER = 2
-MAX_PAGES_FALLBACK = 500
 
 
 def sanitize_filename(filename: str) -> str:

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -69,13 +69,23 @@ from typing import Any
 
 from f2.apps.douyin.handler import DouyinHandler  # type: ignore
 
-from ..core.background import BackgroundTaskRegistry
+from ..core.background import BackgroundTaskRegistry, spawn_or_fallback
 from ..core.exceptions import DownloadError, ServiceError, UserNotFoundError
 from ..core.logging import ContextLogger
 from ..core.operations import OperationStore
 from ..core.settings import settings
 from ..schemas.users import DownloadResponse, UserResponse
 from .storage import ContentType, R2StorageService
+
+# Pagination constants for ``_process_download``. ``f2`` reports up to
+# ``PAGE_SIZE`` items per page; the outer loop expects roughly
+# ``total_posts / PAGE_SIZE`` pages, so we double that plus slack for
+# upstream quirks. Likes-only runs have no known total, so they fall back
+# to ``MAX_PAGES_FALLBACK``.
+PAGE_SIZE = 100
+PAGE_SLACK = 20
+PAGE_MULTIPLIER = 2
+MAX_PAGES_FALLBACK = 500
 
 
 def sanitize_filename(filename: str) -> str:
@@ -260,17 +270,15 @@ class UserService:
             include_likes=include_likes,
             max_items=max_items,
         )
-        # Track the task through the shared registry when the container
-        # provided one so the lifespan can drain it on graceful shutdown.
-        # Fall back to a bare ``create_task`` for unit tests that
-        # instantiate ``UserService`` directly without going through the
-        # container.
-        if self._task_registry is not None:
-            self._task_registry.spawn(
-                coro, name=f"user-download-{operation.operation_id}"
-            )
-        else:
-            asyncio.create_task(coro)
+        # Route through the shared registry so the FastAPI lifespan can
+        # drain in-flight downloads before the executor pools are reaped.
+        # ``spawn_or_fallback`` falls back to ``asyncio.create_task`` for
+        # unit tests that instantiate ``UserService`` directly.
+        spawn_or_fallback(
+            self._task_registry,
+            coro,
+            name=f"user-download-{operation.operation_id}",
+        )
         return DownloadResponse(**operation.to_response())
 
     async def get_download_status(self, task_id: str) -> DownloadResponse:
@@ -427,17 +435,17 @@ class UserService:
             # the "cursor stuck" branch below can spin indefinitely if the
             # upstream API returns a sticky cursor or if every page's
             # uploads fail, because ``downloaded_count`` never catches up
-            # to ``total_posts``. ``page_counts=100`` is the request size
-            # below, so the expected page count is ``total_posts / 100``;
-            # we double that and add slack for API quirks. Likes-only runs
-            # don't report a total, so use a generous ceiling tied to
-            # ``max_items`` when available, otherwise a conservative cap.
+            # to ``total_posts``. The page-budget heuristic uses
+            # module-level constants (``PAGE_SIZE``, ``PAGE_SLACK``,
+            # ``PAGE_MULTIPLIER``, ``MAX_PAGES_FALLBACK``) so the cap can
+            # be retuned in one place if production traffic ever hits a
+            # false-positive break.
             if max_items is not None:
-                max_pages = (max_items // 100) + 20
+                max_pages = (max_items // PAGE_SIZE) + PAGE_SLACK
             elif total_posts > 0:
-                max_pages = (total_posts // 100) * 2 + 20
+                max_pages = (total_posts // PAGE_SIZE) * PAGE_MULTIPLIER + PAGE_SLACK
             else:
-                max_pages = 500
+                max_pages = MAX_PAGES_FALLBACK
             page_count = 0
 
             # ``fetch_user_like_videos`` has no ``min_cursor`` parameter,
@@ -467,7 +475,7 @@ class UserService:
                 async for aweme_data in fetcher(
                     user_id,
                     max_cursor=max_cursor,
-                    page_counts=100,  # Increased page size
+                    page_counts=PAGE_SIZE,
                     max_counts=max_items,
                     **fetcher_extra,
                 ):

--- a/tests/core/test_background.py
+++ b/tests/core/test_background.py
@@ -4,7 +4,7 @@ import asyncio
 
 import pytest
 
-from dyvine.core.background import BackgroundTaskRegistry
+from dyvine.core.background import BackgroundTaskRegistry, spawn_or_fallback
 
 
 @pytest.mark.asyncio
@@ -83,3 +83,49 @@ async def test_spawn_propagates_exceptions_to_awaiters() -> None:
         await task
     await asyncio.sleep(0)
     assert registry.active_count == 0
+
+
+@pytest.mark.asyncio
+async def test_spawn_after_drain_raises_and_closes_coroutine() -> None:
+    """Once ``drain`` has been entered, ``spawn`` must reject new work.
+
+    Otherwise a stale callback that registers another download after the
+    lifespan started shutdown would silently leak past the executor
+    teardown that ``ServiceContainer.shutdown`` performs next.
+    """
+    registry = BackgroundTaskRegistry(drain_timeout=0.5)
+
+    async def noop() -> None:
+        return None
+
+    await registry.drain()
+
+    coro = noop()
+    with pytest.raises(RuntimeError, match="closed"):
+        registry.spawn(coro)
+    # The supplied coroutine must have been closed before the raise so the
+    # ``-W error`` test runtime does not trip ``RuntimeWarning: coroutine
+    # was never awaited``.
+    assert coro.cr_frame is None
+
+
+@pytest.mark.asyncio
+async def test_spawn_or_fallback_uses_registry_when_available() -> None:
+    registry = BackgroundTaskRegistry()
+
+    async def quick() -> int:
+        return 7
+
+    task = spawn_or_fallback(registry, quick(), name="via-registry")
+    assert registry.active_count == 1
+    assert await task == 7
+
+
+@pytest.mark.asyncio
+async def test_spawn_or_fallback_falls_back_to_create_task() -> None:
+    async def quick() -> int:
+        return 11
+
+    task = spawn_or_fallback(None, quick())
+    assert isinstance(task, asyncio.Task)
+    assert await task == 11

--- a/tests/core/test_background.py
+++ b/tests/core/test_background.py
@@ -134,7 +134,8 @@ async def test_spawn_or_fallback_falls_back_to_create_task() -> None:
 @pytest.mark.asyncio
 async def test_is_closed_property_reflects_drain_state() -> None:
     """``is_closed`` lets callers probe the registry without raising."""
-    registry = BackgroundTaskRegistry(drain_timeout=0.1)
+    # No tracked tasks, so ``drain_timeout`` is irrelevant; use the default.
+    registry = BackgroundTaskRegistry()
     assert registry.is_closed is False
 
     await registry.drain()

--- a/tests/core/test_background.py
+++ b/tests/core/test_background.py
@@ -129,3 +129,17 @@ async def test_spawn_or_fallback_falls_back_to_create_task() -> None:
     task = spawn_or_fallback(None, quick())
     assert isinstance(task, asyncio.Task)
     assert await task == 11
+
+
+@pytest.mark.asyncio
+async def test_is_closed_property_reflects_drain_state() -> None:
+    """``is_closed`` lets callers probe the registry without raising."""
+    registry = BackgroundTaskRegistry(drain_timeout=0.1)
+    assert registry.is_closed is False
+
+    await registry.drain()
+    assert registry.is_closed is True
+
+    # Idempotent: a second drain does not flip the flag back.
+    await registry.drain()
+    assert registry.is_closed is True

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -565,6 +565,19 @@ def test_operation_store_healthcheck_swallows_rollback_errors(
         store._healthcheck_sync()
 
 
+def test_operation_store_is_closed_property_reflects_shutdown(tmp_path) -> None:
+    """``is_closed`` lets callers probe the store without provoking ``_run``."""
+    store = OperationStore(str(tmp_path / "operations.db"))
+    assert store.is_closed is False
+
+    store.shutdown()
+    assert store.is_closed is True
+
+    # Idempotent shutdown keeps the flag set.
+    store.shutdown()
+    assert store.is_closed is True
+
+
 @pytest.mark.asyncio
 async def test_operation_store_async_calls_after_shutdown_raise(tmp_path) -> None:
     """Every async dispatch must reject calls once ``shutdown`` has run.

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -565,6 +565,45 @@ def test_operation_store_healthcheck_swallows_rollback_errors(
         store._healthcheck_sync()
 
 
+@pytest.mark.asyncio
+async def test_operation_store_async_calls_after_shutdown_raise(tmp_path) -> None:
+    """Every async dispatch must reject calls once ``shutdown`` has run.
+
+    The container drains background tasks before calling ``shutdown``, so
+    any post-shutdown coroutine call is a programming error. Surfacing a
+    ``RuntimeError`` makes that error loud rather than returning a closed
+    sqlite handle that would later raise ``sqlite3.ProgrammingError`` deep
+    inside the executor pool.
+    """
+    store = OperationStore(str(tmp_path / "operations.db"))
+    created = await store.create_operation(
+        operation_type="user_content_download",
+        subject_id="user-shutdown-guard",
+        status="pending",
+        message="scheduled",
+    )
+
+    store.shutdown()
+
+    with pytest.raises(RuntimeError, match="shut down"):
+        await store.healthcheck()
+    with pytest.raises(RuntimeError, match="shut down"):
+        await store.get_operation(created.operation_id)
+    with pytest.raises(RuntimeError, match="shut down"):
+        await store.get_latest_operation_for_subject("user-shutdown-guard")
+    with pytest.raises(RuntimeError, match="shut down"):
+        await store.update_operation(created.operation_id, status="failed")
+    with pytest.raises(RuntimeError, match="shut down"):
+        await store.create_operation(
+            operation_type="user_content_download",
+            subject_id="another",
+            status="pending",
+            message="m",
+        )
+    with pytest.raises(RuntimeError, match="shut down"):
+        await store.mark_incomplete_operations_failed()
+
+
 def test_operation_store_finalizer_closes_connections_on_gc(tmp_path) -> None:
     """GC'ing the store without calling shutdown must still close handles."""
     import gc

--- a/tests/services/test_post_service.py
+++ b/tests/services/test_post_service.py
@@ -487,6 +487,73 @@ async def test_download_all_user_posts_breaks_on_empty_aweme_list() -> None:
 
 
 @pytest.mark.asyncio
+async def test_download_all_user_posts_caps_pagination_under_sticky_cursor() -> None:
+    """A non-empty batch with a sticky cursor must terminate via ``max_pages``.
+
+    Without the cap, the ``+1`` cursor advance keeps the loop running
+    forever when the upstream returns the same non-empty batch on every
+    call. The new ``max_pages`` ceiling mirrors the guard PR #44 added
+    to the user-content download path in ``services/users.py``.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    handler = MagicMock()
+    profile = MagicMock()
+    profile.aweme_count = 100
+    profile.nickname = "StickyUser"
+    handler.fetch_user_profile = AsyncMock(return_value=profile)
+    handler.get_or_add_user_data = AsyncMock(return_value=Path("/tmp/sticky-user"))
+
+    with patch("dyvine.services.posts.AsyncUserDB") as mock_db:
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_db.return_value = mock_ctx
+
+        svc = _build_service(handler)
+        svc.handler = handler
+
+        call_count = 0
+
+        async def sticky_fetch(sec_user_id: str, cursor: int) -> dict:
+            nonlocal call_count
+            call_count += 1
+            if call_count > 200:  # safety net; the cap should fire long before.
+                raise AssertionError(
+                    "Outer pagination loop exceeded 200 fetches "
+                    "despite the max_pages guard"
+                )
+            # Sticky cursor: server keeps echoing the same non-empty
+            # batch with ``has_more=True`` and ``max_cursor=0``. Without
+            # the new guard, the ``+1`` advance below would keep the
+            # loop running forever.
+            return {
+                "aweme_list": [{"aweme_id": f"p{call_count}", "aweme_type": 0}],
+                "has_more": True,
+                "max_cursor": 0,
+            }
+
+        process_batch = AsyncMock()
+        with patch.object(svc, "_fetch_posts_batch", side_effect=sticky_fetch):
+            with patch.object(svc, "_process_posts_batch", new=process_batch):
+                result = await svc.download_all_user_posts("sticky-user")
+
+        # max_pages = (100 // 20) * 2 + 20 = 30. The loop breaks when
+        # ``page_count > max_pages``, so call_count should be at most 31.
+        assert (
+            call_count <= 31
+        ), f"max_pages cap failed; loop ran {call_count} iterations"
+        # Forward progress was made before the cap kicked in.
+        assert process_batch.await_count == call_count
+        # ``total_downloaded`` is computed from ``download_stats`` which
+        # the patched ``_process_posts_batch`` never increments, so the
+        # response status must be FAILED. The important contract for
+        # this test is termination, not the stats.
+        assert result.total_downloaded == 0
+
+
+@pytest.mark.asyncio
 async def test_download_all_user_posts_stops_on_batch_error() -> None:
     """A persistent batch-level exception must not busy-loop.
 

--- a/tests/services/test_storage_service_extended.py
+++ b/tests/services/test_storage_service_extended.py
@@ -20,10 +20,12 @@ from dyvine.services.storage import (
 def _build_service(*, with_client: bool = False) -> R2StorageService:
     """Create R2StorageService without boto3 initialization."""
     svc = object.__new__(R2StorageService)
-    # The service normally takes its executor through ``__init__``. ``None``
-    # falls back to the default asyncio executor, which is enough for tests
-    # that exercise the service in isolation.
+    # The service normally takes its executors through ``__init__``. ``None``
+    # falls back to the default asyncio executor and to the per-call
+    # short-lived head pool, which is enough for tests that exercise the
+    # service in isolation.
     svc._executor = None  # type: ignore[attr-defined]
+    svc._head_executor = None  # type: ignore[attr-defined]
     if with_client:
         svc.client = MagicMock()  # type: ignore[attr-defined]
         svc.bucket = "test-bucket"  # type: ignore[attr-defined]

--- a/tests/services/test_storage_service_extended.py
+++ b/tests/services/test_storage_service_extended.py
@@ -212,6 +212,51 @@ async def test_list_objects_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_objects_uses_injected_head_executor() -> None:
+    """``set_head_executor`` routes the head fan-out through the shared pool.
+
+    Without injection ``_list_objects_sync`` constructs a per-call
+    ``ThreadPoolExecutor``. After injection the head_object calls must
+    run on the shared pool so several concurrent listings share one
+    bounded thread budget. We assert this by recording the worker
+    thread name prefix and verifying every head call landed on the
+    injected pool, not on a one-off ``r2-head`` worker.
+    """
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    svc = _build_service(with_client=True)
+    svc.client.list_objects_v2.return_value = {  # type: ignore[union-attr]
+        "Contents": [
+            {"Key": f"videos/u1/clip-{i}.mp4", "Size": 1, "StorageClass": "STANDARD"}
+            for i in range(5)
+        ]
+    }
+
+    head_thread_names: list[str] = []
+
+    def head_object(Bucket: str, Key: str) -> dict:
+        head_thread_names.append(threading.current_thread().name)
+        return {"Metadata": {"key": Key}}
+
+    svc.client.head_object.side_effect = head_object  # type: ignore[union-attr]
+
+    injected = ThreadPoolExecutor(max_workers=4, thread_name_prefix="injected-head")
+    try:
+        svc.set_head_executor(injected)
+        results = await svc.list_objects("videos/u1/")
+    finally:
+        svc.set_head_executor(None)
+        injected.shutdown(wait=True)
+
+    assert [r["Key"] for r in results] == [f"videos/u1/clip-{i}.mp4" for i in range(5)]
+    assert head_thread_names, "head_object was never invoked"
+    assert all(
+        name.startswith("injected-head") for name in head_thread_names
+    ), f"head_object ran outside the injected pool: {head_thread_names}"
+
+
+@pytest.mark.asyncio
 async def test_delete_object_success() -> None:
     svc = _build_service(with_client=True)
     await svc.delete_object("videos/u1/clip.mp4")

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -17,7 +17,10 @@ async def test_start_download_tracks_operation(
 ) -> None:
     scheduled: list[asyncio.Future[None]] = []
 
-    def fake_create_task(coro: object) -> asyncio.Future[None]:
+    def fake_create_task(coro: object, **_kwargs: Any) -> asyncio.Future[None]:
+        # ``spawn_or_fallback`` forwards a ``name=...`` kwarg to
+        # ``asyncio.create_task``; absorb it so the mock can stand in for
+        # the real factory.
         if hasattr(coro, "close"):
             coro.close()
         future: asyncio.Future[None] = asyncio.Future()
@@ -25,7 +28,7 @@ async def test_start_download_tracks_operation(
         scheduled.append(future)
         return future
 
-    monkeypatch.setattr("dyvine.services.users.asyncio.create_task", fake_create_task)
+    monkeypatch.setattr("dyvine.core.background.asyncio.create_task", fake_create_task)
 
     service = UserService()
     monkeypatch.setattr(service, "get_user_info", AsyncMock(return_value=MagicMock()))
@@ -43,7 +46,7 @@ async def test_start_download_tracks_operation(
 async def test_get_download_status_returns_persisted_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def resolved_future(coro: object) -> asyncio.Future[None]:
+    def resolved_future(coro: object, **_kwargs: Any) -> asyncio.Future[None]:
         if hasattr(coro, "close"):
             coro.close()
         future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
@@ -52,7 +55,7 @@ async def test_get_download_status_returns_persisted_state(
 
     service = UserService()
     monkeypatch.setattr(service, "get_user_info", AsyncMock(return_value=MagicMock()))
-    monkeypatch.setattr("dyvine.services.users.asyncio.create_task", resolved_future)
+    monkeypatch.setattr("dyvine.core.background.asyncio.create_task", resolved_future)
 
     start_response = await service.start_download("user-456")
     status_response = await service.get_download_status(start_response.operation_id)


### PR DESCRIPTION
## Summary
Post-merge review of #41–#44 surfaced four medium-priority gaps and two low-priority cleanups; this PR closes them so the executor/registry teardown contract is enforced end-to-end and the bulk-download loops cannot self-spin under any sticky upstream.

## Related
- Follow-up to #41–#44.

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| `BackgroundTaskRegistry` | No closed state; post-drain `spawn` would silently leak | `_closed` flag set inside `drain`; later `spawn` raises `RuntimeError` and closes the supplied coroutine | Stops a stale callback from registering work the executor pools can no longer service. |
| `OperationStore` | shutdown closed handles but later async dispatches returned closed connections | `_closed` flag inside the reader lock; `_run` rejects every async call with `RuntimeError` after shutdown | Surfaces post-shutdown programming errors loudly instead of returning a closed sqlite handle. |
| `PostService.download_all_user_posts` | Sticky upstream cursor with non-empty batch could spin via the `+1` cursor advance | New `max_pages = (total_posts // 20) * 2 + 20` (or `MAX_PAGES_FALLBACK=500`) cap that mirrors the guard PR #44 added in `services/users.py` | Symmetric protection so the bulk path cannot pin a worker indefinitely. |
| R2 `head_object` fan-out | Each `_list_objects_sync` spawned a one-off `ThreadPoolExecutor`, allowing 16 concurrent listings × 16 head workers = up to 256 nested threads | New container-owned `r2_head_executor` (16 workers), injected via `R2StorageService.set_head_executor`; standalone path keeps the per-call pool fallback for tests | Single global ceiling on concurrent `head_object` requests; no nested pool creation inside `r2_executor` workers. |
| `services/users.py` magic numbers | Inline `100`, `20`, `2`, `500` repeated in the loop guard | Module-level `PAGE_SIZE`, `PAGE_SLACK`, `PAGE_MULTIPLIER`, `MAX_PAGES_FALLBACK` (used by both the loop guard and the fetcher's `page_counts`) | One place to retune the cap; loop heuristic and fetcher request size can no longer drift apart. |
| Repeated `if registry: spawn else: create_task` fallback | Duplicated in `services/users.py` and `services/livestreams.py` | New `spawn_or_fallback(registry, coro, *, name)` helper in `core/background.py`; both services use it | Removes drift risk between the two call sites. |

## Details

### `BackgroundTaskRegistry` close guard
- **Design/Spec:** `drain` now flips `_closed = True` before awaiting the snapshot. `spawn` checks the flag, calls `coro.close()`, and raises `RuntimeError`.
- **Implementation notes:** Closing the coroutine before raising prevents `RuntimeWarning: coroutine was never awaited` under `-W error`. Drain remains idempotent; `_closed` is set even when the tracked set is empty.
- **Reviewer focus:** confirm the new `RuntimeError` only fires after `drain` has been entered. The FastAPI lifespan calls `drain` exactly once during shutdown, so request handlers never observe the closed state.

### `OperationStore` close guard
- **Design/Spec:** `_run` rejects after `_closed`; `shutdown` flips `_closed` inside `_reader_lock` so a concurrent `_reader_connection` cannot register a fresh handle after the dict has been cleared.
- **Implementation notes:** Every public coroutine routes through `_run`, so a single guard covers `healthcheck`, `get_operation`, `get_latest_operation_for_subject`, `update_operation`, `create_operation`, `mark_incomplete_operations_failed`.
- **Reviewer focus:** the writer lock and `_reader_lock` together protect the flag flip; the GIL guarantees the boolean read in `_run` is atomic.

### Posts pagination cap
- **Design/Spec:** mirrors the PR #44 guard for `services/users.py`. `_BATCH_PAGE_SIZE=20` matches the `_fetch_posts_batch` page size; `MAX_PAGES_FALLBACK=500` is the unknown-total ceiling.
- **Implementation notes:** the cap fires only after the existing `aweme_list`/`has_more`/`next_cursor` exits have been considered. The `+1` cursor advance still keeps progress moving for transient sticky responses.
- **Reviewer focus:** the new break logs `cursor`, `max_pages`, `total_downloaded`, `total_posts`, `sec_user_id` — enough to diagnose a false-positive cap from logs alone.

### Shared R2 head executor
- **Design/Spec:** `ServiceContainer` owns a 16-worker `r2_head_executor` and wires it into `R2StorageService` post-construction via `set_head_executor`. `_list_objects_sync` reuses it when present; otherwise the legacy short-lived pool runs.
- **Implementation notes:** Shutdown order is `audit → sqlite → r2 → r2_head` so any in-flight listing finishes its `head_object` submissions while the head pool still accepts work. `Executor.map` preserves input order so the lexicographic listing order is unchanged.
- **Reviewer focus:** the head pool is created/torn down with the other executors; the standalone fallback keeps existing isolation tests working.

### Constants in `services/users.py`
- **Design/Spec:** `PAGE_SIZE`, `PAGE_SLACK`, `PAGE_MULTIPLIER`, `MAX_PAGES_FALLBACK` exposed at module scope; the fetcher's `page_counts` argument also reads `PAGE_SIZE` so the heuristic and the request size cannot drift apart.
- **Reviewer focus:** the constants are deliberately public so a future tuning PR can adjust them without touching the loop body.

### `spawn_or_fallback` helper
- **Design/Spec:** centralizes `if registry is not None: registry.spawn(coro, name=name) else: asyncio.create_task(coro, name=name)` in `core/background.py`.
- **Implementation notes:** the fallback now also forwards `name=...` so background tasks have a consistent name regardless of whether the container is wired.
- **Reviewer focus:** existing `test_user_service.py` mocks were widened with `**kwargs` to absorb the new `name` argument.

## Testing
- `uv run pytest --cov=src/dyvine --cov-fail-under=80 -W error -q` -- 297 passed, coverage 88.15% (baseline 87.87%).
- `uv run black --check .` / `uv run ruff check .` / `uv run mypy src/` -- all clean.
- New tests:
  - `tests/core/test_background.py::test_spawn_after_drain_raises_and_closes_coroutine`
  - `tests/core/test_background.py::test_spawn_or_fallback_uses_registry_when_available`
  - `tests/core/test_background.py::test_spawn_or_fallback_falls_back_to_create_task`
  - `tests/core/test_operations.py::test_operation_store_async_calls_after_shutdown_raise` (covers all six async entry points)
  - `tests/services/test_post_service.py::test_download_all_user_posts_caps_pagination_under_sticky_cursor`
- Manual steps: Not run.

## Screenshots / Notes
- Not applicable.

## Breaking changes
- `OperationStore` async methods now raise `RuntimeError` after `shutdown`. The container drains background work before shutdown, so production callers do not hit this path; ad-hoc scripts that call methods after shutdown must reorder their teardown.
- `BackgroundTaskRegistry.spawn` raises `RuntimeError` after `drain`. Same caveat as above.
- `R2StorageService.__init__` grows an optional `head_executor=` keyword. Existing callers (tests, `ServiceContainer`) are updated; downstream consumers continue to work because the kwarg defaults to `None`.

## Risks and rollout
- The new guards convert silent post-shutdown misuse into loud `RuntimeError`. If an unknown caller relied on the silent-close behavior, this PR will surface that bug at the next deploy. Risk is low because no in-tree caller does so.
- The shared `r2_head_executor` caps concurrent `head_object` calls at 16 globally; very large bursts of `list_objects` will queue inside the head pool rather than spawning new threads. This is the intended trade-off.
- Rollback: revert this PR's single commit. Each fix is independently revertible at the file level.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed (module docstrings + decision-context comments)
- [x] Backward compatibility considered (new kwargs default to None, fallbacks preserved)
- [x] Rollout/monitoring considerations noted (head pool sizing, post-shutdown errors)