### PR TITLE
fix(services): mirror live_status onto livestream filter dict

### DIFF
--- a/src/dyvine/services/livestreams.py
+++ b/src/dyvine/services/livestreams.py
@@ -129,18 +129,28 @@ class LivestreamService:
 
     @staticmethod
     def _live_filter_to_dict(live_filter: Any) -> dict[str, Any]:
-        """Safely convert an f2 live filter to a dict.
+        """Safely convert an f2 live filter to a normalized dict.
 
         Falls back to an empty dict if the private ``_to_dict`` method is
-        unavailable or raises.
+        unavailable or raises. When the underlying object exposes a
+        ``live_status`` attribute, its value is mirrored to ``status`` so
+        callers can reliably gate on ``status == 2`` (live) without
+        having to reach back into the original object — ``_to_dict()``
+        does not surface ``live_status`` itself.
         """
         try:
-            return dict(live_filter._to_dict())
+            result: dict[str, Any] = dict(live_filter._to_dict())
         except Exception:
             logger.warning(
                 "live_filter._to_dict() unavailable; falling back to empty dict"
             )
-            return {}
+            result = {}
+
+        live_status = getattr(live_filter, "live_status", None)
+        if live_status is not None:
+            result["status"] = live_status
+
+        return result
 
     @staticmethod
     def _extract_stream_map(live_filter: Any) -> dict[str, str]:

--- a/tests/services/test_livestream_service.py
+++ b/tests/services/test_livestream_service.py
@@ -255,6 +255,34 @@ class TestLiveFilterToDict:
         result = LivestreamService._live_filter_to_dict(BrokenFilter())
         assert result == {}
 
+    def test_mirrors_live_status_to_status(self) -> None:
+        class FakeLiveFilter:
+            live_status = 2
+
+            def _to_dict(self) -> dict[str, str]:
+                return {"room_id": "123"}
+
+        result = LivestreamService._live_filter_to_dict(FakeLiveFilter())
+        assert result == {"room_id": "123", "status": 2}
+
+    def test_mirrors_offline_live_status(self) -> None:
+        class FakeLiveFilter:
+            live_status = 0
+
+            def _to_dict(self) -> dict[str, str]:
+                return {"room_id": "123"}
+
+        result = LivestreamService._live_filter_to_dict(FakeLiveFilter())
+        assert result["status"] == 0
+
+    def test_skips_when_live_status_absent(self) -> None:
+        class FakeLiveFilter:
+            def _to_dict(self) -> dict[str, str]:
+                return {"room_id": "123"}
+
+        result = LivestreamService._live_filter_to_dict(FakeLiveFilter())
+        assert "status" not in result
+
 
 # ---------------------------------------------------------------------------
 # _parse_url


### PR DESCRIPTION
## Summary
`download_stream` always returned 404 "User is not currently streaming" because `_live_filter_to_dict` did not expose `live_status`. Mirror it onto `status` in the helper so callers get a normalized dict.

## Related
- Not applicable

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| `LivestreamService._live_filter_to_dict` | returned raw `_to_dict()` | injects `live_status -> status` | unblocks `POST /livestreams/stream:download` for live rooms |
| livestream service tests | 37 cases | 40 cases | adds live/offline/missing-attribute coverage |

## Details
### Updates `_live_filter_to_dict` to mirror `live_status`
- Design/Spec: align helper output with the contract `download_stream` (services/livestreams.py:507) and `get_room_info` (services/livestreams.py:293-296) already assume — `status == 2` means live.
- Implementation notes: `getattr(live_filter, "live_status", None)` + `is not None` so an explicit `0` (offline) round-trips intact; `_to_dict()` failures still degrade to `{}` as before.
- Reviewer focus: confirm the helper's new contract does not double-write inconsistent values in `get_room_info` (it now sets the same key twice; values match, so behavior is unchanged).

## Testing
- `uv run pytest tests/services/test_livestream_service.py -q` -- 40 passed
- Manual: built `dyvine:latest`, ran container, `POST /api/v1/livestreams/stream:download` against a live room returned HTTP 202 and the background task wrote a growing `.flv` to the bind-mounted `data/` directory.

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable. The helper now adds a `status` key when `live_status` is present; callers that already set `status` themselves overwrite the same value.

## Risks and rollout
- Risk: an upstream f2 release could rename `live_status` -- mitigation: `getattr` with `None` default keeps the helper safe and the existing `get_room_info` fallback (`status = 0`) is preserved.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed (no doc changes required)
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted