### PR TITLE
fix(runtime): post-review cleanup (concurrency, api, health, tests)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,11 @@ API_PROJECT_NAME="Dyvine API"
 API_VERSION=1.0.0
 API_PREFIX="/api/v1"
 API_RATE_LIMIT_PER_SECOND=10
-API_CORS_ORIGINS=["*"]
+# Production deployments MUST replace the wildcard with an explicit
+# allowlist of trusted browser origins. ``["*"]`` disables credentialed
+# CORS automatically (see ``main.py`` middleware), but it still exposes
+# the API to any origin and is suitable for local development only.
+API_CORS_ORIGINS=["http://localhost:3000"]
 API_OPERATION_DB_PATH=data/douyin/state/operations.db
 
 # ================================

--- a/src/dyvine/core/background.py
+++ b/src/dyvine/core/background.py
@@ -140,7 +140,18 @@ def spawn_or_fallback(
     unit tests (with no registry). Keeping the branch in one place stops
     each new long-lived service from hand-rolling the same ``if registry is
     not None`` pattern.
+
+    The fallback path is intended for unit tests that exercise services in
+    isolation. Production services constructed via ``ServiceContainer`` always
+    receive a real registry; a missing registry there means the spawned task
+    will not be drained on shutdown and may be cancelled mid-flight. Logging
+    a warning makes the misconfiguration observable instead of silent.
     """
     if registry is not None:
         return registry.spawn(coro, name=name)
+    logger.warning(
+        "spawn_or_fallback invoked without a BackgroundTaskRegistry; the "
+        "task will not be drained on shutdown",
+        extra={"task_name": name},
+    )
     return asyncio.create_task(coro, name=name)

--- a/src/dyvine/core/dependencies.py
+++ b/src/dyvine/core/dependencies.py
@@ -36,6 +36,7 @@ from typing import Any
 from f2.apps.douyin.handler import DouyinHandler  # type: ignore
 
 from ..services.livestreams import LivestreamService
+from ..services.posts import PostService
 from ..services.users import UserService
 from .background import BackgroundTaskRegistry
 from .operations import OperationStore
@@ -186,6 +187,15 @@ class ServiceContainer:
             task_registry=self._background_tasks,
         )
 
+        # Initialize post service. Bulk downloads are scheduled as
+        # long-running background tasks, so wire the service to the same
+        # operation store and registry the lifespan drains on shutdown.
+        self._services["post_service"] = PostService(
+            handler=self._services["douyin_handler"],
+            operation_store=operation_store,
+            task_registry=self._background_tasks,
+        )
+
         self._initialized = True
 
     async def shutdown(self) -> None:
@@ -329,6 +339,14 @@ class ServiceContainer:
             raise TypeError("livestream_service is not a LivestreamService instance")
         return service
 
+    @property
+    def post_service(self) -> PostService:
+        """Get the post management service."""
+        service = self.get_service("post_service")
+        if not isinstance(service, PostService):
+            raise TypeError("post_service is not a PostService instance")
+        return service
+
 
 @lru_cache
 def get_service_container() -> ServiceContainer:
@@ -398,3 +416,14 @@ def get_user_service() -> UserService:
 def get_livestream_service() -> LivestreamService:
     """FastAPI dependency provider for livestream service."""
     return get_service_container().livestream_service
+
+
+def get_post_service() -> PostService:
+    """FastAPI dependency provider for post service.
+
+    Returns the container-managed ``PostService`` so bulk downloads share
+    the same ``OperationStore`` and ``BackgroundTaskRegistry`` as the rest
+    of the application. Routers can depend on this provider directly via
+    ``Annotated[PostService, Depends(get_post_service)]``.
+    """
+    return get_service_container().post_service

--- a/src/dyvine/main.py
+++ b/src/dyvine/main.py
@@ -62,6 +62,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
 
+import psutil
 from fastapi import FastAPI, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -102,7 +103,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     Startup Sequence:
         1. Initialize structured logging system
         2. Create and configure logger instance
-        3. Record application start time for uptime tracking
+        3. Record monotonic startup baseline for uptime tracking
         4. Initialize service container with all dependencies
         5. Log successful startup with environment information
 
@@ -132,7 +133,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # === STARTUP PHASE ===
     setup_logging()
     app.state.logger = ContextLogger(__name__)
-    app.state.start_time = time.time()
+    # Use a monotonic baseline so uptime measurements stay correct across
+    # NTP step adjustments and any wall-clock skew. Wall-clock timestamps
+    # (for log records and the ``timestamp`` field in ``/health``) still go
+    # through ``time.time()`` where they are needed.
+    app.state.start_monotonic = time.monotonic()
 
     # Initialize service container with all dependencies
     container = get_service_container()
@@ -148,7 +153,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "version": settings.version,
             "debug_mode": settings.debug,
             "api_prefix": settings.prefix,
-            "startup_time": time.time() - app.state.start_time,
+            "startup_time": time.monotonic() - app.state.start_monotonic,
         },
     )
 
@@ -157,15 +162,19 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     yield
 
     # === SHUTDOWN PHASE ===
-    shutdown_start = time.time()
-    total_uptime = shutdown_start - app.state.start_time
+    # ``total_uptime`` is computed from the monotonic baseline so the value
+    # is stable even if the system clock jumped during the lifetime of the
+    # process. ``shutdown_initiated_at`` keeps a wall-clock stamp because
+    # operators correlate it with external log streams.
+    total_uptime = time.monotonic() - app.state.start_monotonic
+    shutdown_initiated_at = time.time()
 
     app.state.logger.info(
         "Dyvine application shutting down gracefully",
         extra={
             "total_uptime_seconds": round(total_uptime, 2),
             "total_uptime_hours": round(total_uptime / 3600, 2),
-            "shutdown_initiated_at": shutdown_start,
+            "shutdown_initiated_at": shutdown_initiated_at,
         },
     )
     app.state.startup_complete = False
@@ -315,8 +324,11 @@ async def request_middleware(request: Request, call_next: Any) -> Any:
     logger = app.state.logger
     logger.set_correlation_id(correlation_id)
 
-    # Record request start time for duration measurement
-    start_time = time.time()
+    # Record request start time for duration measurement. ``perf_counter``
+    # is monotonic and provides the highest available resolution, which is
+    # the right primitive for an elapsed-time pair where both endpoints are
+    # taken in the same process.
+    start_time = time.perf_counter()
 
     # Log request initiation with metadata
     logger.info(
@@ -335,8 +347,9 @@ async def request_middleware(request: Request, call_next: Any) -> Any:
     # Process request through application stack
     response = await call_next(request)
 
-    # Calculate total processing duration
-    duration = time.time() - start_time
+    # Calculate total processing duration on the same monotonic clock that
+    # captured ``start_time`` above.
+    duration = time.perf_counter() - start_time
 
     # Log request completion with performance metrics
     route = request.scope.get("route")
@@ -553,39 +566,54 @@ async def startup_probe(request: Request) -> JSONResponse:
 @app.get(
     "/health",
     summary="Application health summary",
-    description="Returns detailed health and performance metrics for monitoring",
-    response_description="Health status with system metrics and uptime information",
+    description="Returns aggregated runtime metrics for ops dashboards",
+    response_description="Aggregated metrics and informational dependency state",
     tags=["System"],
 )
 async def health_check(request: Request) -> JSONResponse:
-    """Comprehensive health check endpoint for monitoring and diagnostics.
+    """Aggregate runtime metrics for operational monitoring dashboards.
 
-    This endpoint provides detailed health information about the Dyvine API
-    including system metrics, resource usage, and operational status. It's
-    designed for use by monitoring systems, load balancers, and operational
-    dashboards.
+    ``/health`` is intentionally an informational endpoint: it exists so
+    operators, dashboards, and ad-hoc monitoring tools can scrape a single
+    URL for uptime, memory, and CPU figures. It always returns ``200 OK``
+    and never gates on dependency availability.
 
-    Health Metrics Included:
-        - Application status and version
-        - System uptime since last restart
-        - Memory usage (RSS) in megabytes
-        - CPU utilization percentage
-        - Service dependencies status
+    Probe responsibilities are split across dedicated endpoints so each
+    Kubernetes probe type maps to a single concern and can be tuned
+    independently:
+
+    - Liveness probe: ``GET /livez`` reflects only process health.
+    - Readiness probe: ``GET /readyz`` returns ``503`` when a required
+      dependency (Douyin cookie, service container, operation store, R2)
+      is unavailable so traffic is steered away from a Pod that cannot
+      serve real requests.
+    - Startup probe: ``GET /startupz`` reports whether the lifespan
+      startup sequence finished.
 
     Returns:
-        Dict[str, Any]: Comprehensive health information including:
-            - status: Overall health status ("healthy", "degraded", "unhealthy")
-            - version: Current application version
-            - uptime_seconds: Seconds since application startup
-            - uptime_human: Human-readable uptime string
-            - memory_mb: Current memory usage in MB
-            - cpu_percent: Current CPU usage percentage
-            - dependencies: Status of external dependencies
-            - correlation_id: Correlated request identifier for tracking
+        JSONResponse: The response body always carries ``status == "ok"``
+        plus the following fields:
+            - version: Current application version.
+            - environment: ``"development"`` or ``"production"``.
+            - uptime_seconds: Seconds since the lifespan startup hook ran,
+              measured on a monotonic clock so NTP adjustments cannot
+              produce negative or jumping values.
+            - uptime_human: Human-readable rendering of ``uptime_seconds``.
+            - memory_mb: Resident memory of the current process in MiB.
+            - cpu_percent: Instantaneous CPU usage percentage.
+            - timestamp: Wall-clock timestamp (``time.time()``) of the
+              snapshot, intended for log correlation.
+            - api_prefix: Configured API prefix.
+            - correlation_id: Request correlation ID, mirrored to the
+              ``X-Correlation-ID`` response header.
+            - dependencies: Informational dependency snapshot. Surfaced
+              for ops visibility only; values here never change the HTTP
+              status code.
+            - memory_pressure: ``"high"`` when RSS exceeds 1 GiB, else
+              ``"normal"``. Informational only.
 
     Status Codes:
-        - 200: Service is healthy and operational
-        - 503: Service is degraded or unhealthy
+        - 200: Always.
 
     Example:
         ```bash
@@ -595,76 +623,68 @@ async def health_check(request: Request) -> JSONResponse:
         Response:
         ```json
         {
-            "status": "healthy",
+            "status": "ok",
             "version": "1.0.0",
             "uptime_seconds": 3600,
-            "uptime_human": "1 hour, 0 minutes",
+            "uptime_human": "1 hours, 0 minutes",
             "memory_mb": 245.67,
             "cpu_percent": 12.5,
+            "memory_pressure": "normal",
             "dependencies": {
-                "douyin_api": "connected",
-                "r2_storage": "available"
+                "douyin_api": "configured",
+                "r2_storage": "configured",
+                "logging_system": "operational"
             },
+            "timestamp": 1714723200.123,
             "correlation_id": "550e8400-e29b-41d4-a716-446655440000"
         }
         ```
-
-    Note:
-        This endpoint is used by:
-        - Kubernetes liveness and readiness probes
-        - Load balancer health checks
-        - Monitoring systems (Prometheus, Grafana, etc.)
-        - Operational dashboards and alerting
     """
-    import psutil
-
     # Get current process information
     process = psutil.Process()
-    uptime_seconds = int(time.time() - app.state.start_time)
+    # ``start_monotonic`` is set at the top of the lifespan startup hook,
+    # which always runs before any HTTP request. The ``getattr`` fallback
+    # protects exotic call paths (e.g. tests instantiating ``app`` without
+    # the lifespan) by returning a zero uptime instead of raising.
+    start_monotonic = getattr(app.state, "start_monotonic", 0.0)
+    uptime_seconds = (
+        int(time.monotonic() - start_monotonic) if start_monotonic else 0
+    )
 
     # Calculate human-readable uptime
     hours = uptime_seconds // 3600
     minutes = (uptime_seconds % 3600) // 60
     uptime_human = f"{hours} hours, {minutes} minutes"
 
-    # Check dependency status (can be expanded for real health checks)
+    # Informational dependency snapshot. Values here document the current
+    # configuration but never affect the HTTP status code. Use ``/readyz``
+    # if you need the dependency-aware gate.
+    douyin_status = "configured" if settings.douyin.cookie else "missing_credentials"
+    r2_status = "configured" if settings.r2.is_configured else "missing_credentials"
     dependencies = {
-        "douyin_api": "configured" if settings.douyin.cookie else "missing_credentials",
-        "r2_storage": "available" if settings.r2.is_configured else "not_configured",
+        "douyin_api": douyin_status,
+        "r2_storage": r2_status,
         "logging_system": "operational",
     }
 
-    # Determine overall health status
-    health_status = "healthy"
-    if not settings.douyin.cookie:
-        health_status = "unhealthy"
-    elif not settings.r2.is_configured:
-        health_status = "degraded"
-
-    if process.memory_info().rss > 1024 * 1024 * 1024:  # > 1GB RAM
-        if health_status != "unhealthy":
-            health_status = "degraded"
+    rss_bytes = process.memory_info().rss
+    memory_pressure = "high" if rss_bytes > 1024 * 1024 * 1024 else "normal"
 
     correlation_id = getattr(request.state, "correlation_id", str(uuid.uuid4()))
 
     response_body = {
-        "status": health_status,
+        "status": "ok",
         "version": settings.version,
         "environment": "development" if settings.debug else "production",
         "uptime_seconds": uptime_seconds,
         "uptime_human": uptime_human,
-        "memory_mb": round(process.memory_info().rss / 1024 / 1024, 2),
+        "memory_mb": round(rss_bytes / 1024 / 1024, 2),
         "cpu_percent": round(process.cpu_percent(), 2),
+        "memory_pressure": memory_pressure,
         "dependencies": dependencies,
         "timestamp": time.time(),
         "api_prefix": settings.prefix,
         "correlation_id": correlation_id,
     }
 
-    status_code = (
-        status.HTTP_503_SERVICE_UNAVAILABLE
-        if health_status == "unhealthy"
-        else status.HTTP_200_OK
-    )
-
-    return JSONResponse(status_code=status_code, content=response_body)
+    return JSONResponse(status_code=status.HTTP_200_OK, content=response_body)

--- a/src/dyvine/main.py
+++ b/src/dyvine/main.py
@@ -647,9 +647,7 @@ async def health_check(request: Request) -> JSONResponse:
     # protects exotic call paths (e.g. tests instantiating ``app`` without
     # the lifespan) by returning a zero uptime instead of raising.
     start_monotonic = getattr(app.state, "start_monotonic", 0.0)
-    uptime_seconds = (
-        int(time.monotonic() - start_monotonic) if start_monotonic else 0
-    )
+    uptime_seconds = int(time.monotonic() - start_monotonic) if start_monotonic else 0
 
     # Calculate human-readable uptime
     hours = uptime_seconds // 3600

--- a/src/dyvine/routers/posts.py
+++ b/src/dyvine/routers/posts.py
@@ -33,11 +33,10 @@ Example Usage:
 
 from typing import Annotated
 
-from f2.apps.douyin.handler import DouyinHandler  # type: ignore
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 
 from ..core.decorators import handle_errors
-from ..core.dependencies import get_douyin_handler
+from ..core.dependencies import get_post_service
 from ..core.exceptions import DownloadError, UserNotFoundError
 from ..core.logging import ContextLogger
 from ..schemas.posts import BulkDownloadResponse, PostDetail
@@ -56,13 +55,6 @@ router = APIRouter(
         500: {"description": "Internal server error"},
     },
 )
-
-
-async def get_post_service(
-    douyin_handler: Annotated[DouyinHandler, Depends(get_douyin_handler)],
-) -> PostService:
-    """Create PostService instance with injected Douyin handler."""
-    return PostService(douyin_handler)
 
 
 @router.get(
@@ -266,16 +258,27 @@ async def list_user_posts(
 
 @router.post(
     "/users/{user_id}/posts:download",
+    status_code=status.HTTP_202_ACCEPTED,
     response_model=BulkDownloadResponse,
-    summary="Download user posts",
-    description="Downloads all available posts from a specific user",
+    summary="Schedule user posts bulk download",
+    description=(
+        "Schedules an asynchronous bulk download of every available post from "
+        "a specific user and returns an operation_id clients can poll for "
+        "progress"
+    ),
 )
 async def download_user_posts(
     service: Annotated[PostService, Depends(get_post_service)],
     user_id: str = Path(..., description="The unique identifier of the user"),
     max_cursor: int = Query(0, description="Starting pagination cursor"),
 ) -> BulkDownloadResponse:
-    """Downloads all available posts from a user.
+    """Schedule a bulk download of every available post from a user.
+
+    The endpoint validates that the user exists, persists a pending
+    operation record, and dispatches the long-running pagination plus
+    download loop onto the shared background task registry. The response
+    carries the ``operation_id`` clients can use to poll
+    ``/posts/operations/{operation_id}`` for progress.
 
     Args:
         user_id: The unique identifier of the user.
@@ -283,18 +286,19 @@ async def download_user_posts(
         service: An instance of PostService for handling the request.
 
     Returns:
-        BulkDownloadResponse: A response containing download operation results.
+        BulkDownloadResponse: Pending bulk download response with the
+        operation tracking identifier and initial status.
 
     Raises:
-        HTTPException: If the user is not found, the download fails, or an
-            unexpected error occurs.
+        HTTPException: If the user is not found, the bulk download cannot
+            be scheduled, or an unexpected error occurs.
     """
     try:
         logger.info(
             "Processing download_user_posts request",
             extra={"user_id": user_id, "max_cursor": max_cursor},
         )
-        return await service.download_all_user_posts(user_id, max_cursor)
+        return await service.start_bulk_download(user_id, max_cursor)
 
     except UserNotFoundError as e:
         logger.warning("User not found", extra={"user_id": user_id})
@@ -307,5 +311,57 @@ async def download_user_posts(
     except Exception as e:
         logger.exception(
             "Error processing download_user_posts request", extra={"user_id": user_id}
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.get(
+    "/operations/{operation_id}",
+    response_model=BulkDownloadResponse,
+    summary="Get bulk download operation status",
+    description=(
+        "Retrieves the current status of a bulk posts download operation, "
+        "including per-PostType counts and the destination download path "
+        "once available"
+    ),
+)
+async def get_bulk_download_operation(
+    service: Annotated[PostService, Depends(get_post_service)],
+    operation_id: str = Path(
+        ..., description="The unique identifier of the bulk download operation"
+    ),
+) -> BulkDownloadResponse:
+    """Retrieve the status of a bulk posts download operation.
+
+    Args:
+        operation_id: The unique identifier of the bulk download operation
+            returned by :func:`download_user_posts`.
+        service: An instance of PostService for handling the request.
+
+    Returns:
+        BulkDownloadResponse: Snapshot of the current bulk download state.
+
+    Raises:
+        HTTPException: If the operation is unknown (404) or an unexpected
+            error occurs (500).
+    """
+    try:
+        logger.info(
+            "Processing get_bulk_download_operation request",
+            extra={"operation_id": operation_id},
+        )
+        return await service.get_bulk_download_status(operation_id)
+
+    except DownloadError as e:
+        logger.warning(
+            "Bulk download operation not found",
+            extra={"operation_id": operation_id},
+        )
+        raise HTTPException(status_code=404, detail=str(e)) from e
+
+    except Exception as e:
+        logger.exception(
+            "Error processing get_bulk_download_operation request",
+            extra={"operation_id": operation_id},
         )
         raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/src/dyvine/schemas/posts.py
+++ b/src/dyvine/schemas/posts.py
@@ -40,11 +40,15 @@ class DownloadStatus(StrEnum):
     """Enumeration of possible download operation statuses.
 
     Attributes:
+        PENDING: Bulk download has been scheduled but not yet started
+        IN_PROGRESS: Bulk download is currently executing
         SUCCESS: All content downloaded successfully
         PARTIAL_SUCCESS: Some content downloaded successfully
         FAILED: No content downloaded successfully
     """
 
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
     SUCCESS = "success"
     PARTIAL_SUCCESS = "partial_success"
     FAILED = "failed"
@@ -120,6 +124,7 @@ class BulkDownloadResponse(BaseModel):
     """Response model for bulk download operations.
 
     Attributes:
+        operation_id: Identifier for tracking the asynchronous bulk download
         sec_user_id: Target user's identifier
         download_path: Local path where content was saved
         total_posts: Total number of posts available
@@ -130,9 +135,15 @@ class BulkDownloadResponse(BaseModel):
         error_details: Details of any errors encountered
     """
 
+    operation_id: str | None = Field(
+        default=None, description="Operation tracking identifier"
+    )
     sec_user_id: str = Field(..., description="Target user's identifier")
-    download_path: str = Field(..., description="Local path where content was saved")
-    total_posts: int = Field(..., description="Total number of posts available")
+    download_path: str | None = Field(
+        default=None,
+        description="Local path where content was saved",
+    )
+    total_posts: int = Field(default=0, description="Total number of posts available")
     downloaded_count: dict[PostType, int] = Field(
         default_factory=lambda: {
             PostType.VIDEO: 0,

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -282,9 +282,7 @@ class PostService:
                 "Failed to validate user profile",
                 extra={"sec_user_id": sec_user_id, "error": str(e)},
             )
-            raise PostServiceError(
-                f"Failed to validate user profile: {str(e)}"
-            ) from e
+            raise PostServiceError(f"Failed to validate user profile: {str(e)}") from e
 
         if not profile or not getattr(profile, "nickname", None):
             raise UserNotFoundError(f"User not found: {sec_user_id}")
@@ -298,8 +296,13 @@ class PostService:
             metadata={"max_cursor": max_cursor},
         )
 
+        # Forward the already-fetched profile to the background coroutine so
+        # the bulk loop does not have to repeat the upstream call. A second
+        # ``fetch_user_profile`` here would double the network cost and open
+        # a small failure window where the existence check passed but the
+        # bulk loop sees a transient error.
         coro = self._run_bulk_download(
-            operation.operation_id, sec_user_id, max_cursor
+            operation.operation_id, sec_user_id, max_cursor, profile=profile
         )
         # Route through the shared registry so the FastAPI lifespan can
         # drain the in-flight bulk download before the executor pools are
@@ -328,6 +331,8 @@ class PostService:
         operation_id: str,
         sec_user_id: str,
         max_cursor: int,
+        *,
+        profile: Any,
     ) -> None:
         """Execute the bulk download loop and persist progress to the store.
 
@@ -341,10 +346,15 @@ class PostService:
             operation_id: Identifier of the persisted operation record.
             sec_user_id: Unique identifier of the user.
             max_cursor: Starting pagination cursor for fetching posts.
+            profile: The user profile already validated by
+                :meth:`start_bulk_download`. Re-using the existing payload
+                avoids a second ``fetch_user_profile`` call.
         """
         download_stats: dict[PostType, int] = dict.fromkeys(PostType, 0)
         download_path: str | None = None
-        total_posts = 0
+
+        aweme_count = getattr(profile, "aweme_count", 0)
+        total_posts = aweme_count if isinstance(aweme_count, int) else 0
 
         try:
             await self.operation_store.update_operation(
@@ -356,25 +366,20 @@ class PostService:
                 error=None,
             )
 
-            logger.info(
-                "Fetching user profile",
-                extra={
-                    "sec_user_id": sec_user_id,
-                    "operation_id": operation_id,
-                },
-            )
-            profile = await self.handler.fetch_user_profile(sec_user_id)
+            # Defensive guard: ``start_bulk_download`` already validated the
+            # profile, but ad-hoc callers (or future refactors) may invoke
+            # ``_run_bulk_download`` with an invalid payload. Reject it so the
+            # operation moves to ``failed`` instead of silently iterating
+            # through an empty profile.
             if not profile or not getattr(profile, "nickname", None):
                 raise UserNotFoundError(f"User not found: {sec_user_id}")
 
-            aweme_count = profile.aweme_count
-            total_posts = aweme_count if isinstance(aweme_count, int) else 0
-
             logger.info(
-                "User profile fetched",
+                "Bulk download starting with cached profile",
                 extra={
                     "sec_user_id": sec_user_id,
-                    "nickname": profile.nickname,
+                    "operation_id": operation_id,
+                    "nickname": getattr(profile, "nickname", None),
                     "total_posts": total_posts,
                 },
             )
@@ -407,9 +412,7 @@ class PostService:
             # the server keeps replying with the same ``max_cursor`` the
             # only stop conditions become ``has_more=False`` or this cap.
             if total_posts > 0:
-                max_pages = (
-                    (total_posts // PAGE_SIZE) * PAGE_MULTIPLIER + PAGE_SLACK
-                )
+                max_pages = (total_posts // PAGE_SIZE) * PAGE_MULTIPLIER + PAGE_SLACK
             else:
                 max_pages = MAX_PAGES_FALLBACK
             page_count = 0
@@ -456,9 +459,7 @@ class PostService:
 
                     progress: float | None
                     if total_posts > 0:
-                        progress = min(
-                            (total_downloaded / total_posts) * 100, 100.0
-                        )
+                        progress = min((total_downloaded / total_posts) * 100, 100.0)
                     else:
                         progress = None
 
@@ -559,9 +560,7 @@ class PostService:
             )
         else:
             final_status = "failed"
-            terminal_message = (
-                "Bulk download failed: no posts were downloaded"
-            )
+            terminal_message = "Bulk download failed: no posts were downloaded"
 
         progress_value: float
         if total_posts > 0:
@@ -585,9 +584,7 @@ class PostService:
             },
         )
 
-    async def get_bulk_download_status(
-        self, operation_id: str
-    ) -> BulkDownloadResponse:
+    async def get_bulk_download_status(self, operation_id: str) -> BulkDownloadResponse:
         """Get the current status of a bulk download operation.
 
         Args:
@@ -604,9 +601,7 @@ class PostService:
         try:
             op = await self.operation_store.get_operation(operation_id)
         except DownloadError as e:
-            raise DownloadError(
-                f"Bulk download task {operation_id} not found"
-            ) from e
+            raise DownloadError(f"Bulk download task {operation_id} not found") from e
 
         if op.operation_type != "user_posts_bulk_download":
             raise DownloadError(f"Bulk download task {operation_id} not found")

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -25,6 +25,7 @@ from typing import Any
 from f2.apps.douyin.db import AsyncUserDB  # type: ignore
 from f2.apps.douyin.handler import DouyinHandler  # type: ignore
 
+from ..core.background import BackgroundTaskRegistry, spawn_or_fallback
 from ..core.exceptions import (
     DownloadError,
     PostNotFoundError,
@@ -32,6 +33,7 @@ from ..core.exceptions import (
     UserNotFoundError,
 )
 from ..core.logging import ContextLogger
+from ..core.operations import OperationStore
 from ..core.pagination import MAX_PAGES_FALLBACK, PAGE_MULTIPLIER, PAGE_SLACK
 from ..schemas.posts import (
     BulkDownloadResponse,
@@ -70,13 +72,34 @@ class PostService:
     - Type safety through type annotations
     """
 
-    def __init__(self, handler: DouyinHandler) -> None:
+    # Class-level default mirrors the pattern used by ``LivestreamService`` so
+    # tests that build the service via ``object.__new__`` (bypassing
+    # ``__init__``) still see a ``None`` registry and fall through to the bare
+    # ``asyncio.create_task`` branch in :func:`spawn_or_fallback`.
+    _task_registry: BackgroundTaskRegistry | None = None
+
+    def __init__(
+        self,
+        handler: DouyinHandler,
+        *,
+        operation_store: OperationStore | None = None,
+        task_registry: BackgroundTaskRegistry | None = None,
+    ) -> None:
         """Initialize the PostService instance.
 
         Args:
             handler: Configured DouyinHandler instance for Douyin operations.
+            operation_store: Persistent operation record store. A private
+                ``OperationStore`` is created when not provided, which is the
+                path unit tests take.
+            task_registry: Optional registry that owns long-lived bulk
+                download tasks. When omitted (e.g. in tests) the service
+                falls back to ``asyncio.create_task`` so the public API
+                remains testable without a full service container.
         """
         self.handler = handler
+        self.operation_store = operation_store or OperationStore()
+        self._task_registry = task_registry
         logger.info("PostService initialized", extra={"handler_config": handler.kwargs})
 
     async def get_post_detail(self, aweme_id: str) -> PostDetail:
@@ -219,42 +242,133 @@ class PostService:
             )
             raise PostServiceError(f"Failed to fetch user posts: {str(e)}") from e
 
-    async def download_all_user_posts(
+    async def start_bulk_download(
         self,
         sec_user_id: str,
         max_cursor: int = 0,
     ) -> BulkDownloadResponse:
-        """Download all available posts from a Douyin user.
+        """Schedule an asynchronous bulk download of every post from a user.
+
+        Validates the user profile up front so the caller receives a 404
+        immediately when the account does not exist, then persists a
+        ``pending`` operation record and dispatches the long-running
+        pagination + download loop onto the shared background task
+        registry. The HTTP layer can poll
+        :meth:`get_bulk_download_status` with the returned ``operation_id``
+        to observe progress.
 
         Args:
             sec_user_id: Unique identifier of the user.
             max_cursor: Starting pagination cursor for fetching posts.
 
         Returns:
-            BulkDownloadResponse: Object containing the results of the bulk download
-                operation.
+            BulkDownloadResponse: Pending response carrying the
+                ``operation_id`` clients can use to poll for progress.
 
         Raises:
             UserNotFoundError: If the requested user cannot be found.
-            DownloadError: If the download operation fails.
-            PostServiceError: If an error occurs during the operation.
+            PostServiceError: If the profile lookup itself fails.
         """
-        download_stats = dict.fromkeys(PostType, 0)
-        download_path = None
+        try:
+            logger.info(
+                "Validating user before scheduling bulk download",
+                extra={"sec_user_id": sec_user_id, "max_cursor": max_cursor},
+            )
+            profile = await self.handler.fetch_user_profile(sec_user_id)
+        except UserNotFoundError:
+            raise
+        except Exception as e:
+            logger.exception(
+                "Failed to validate user profile",
+                extra={"sec_user_id": sec_user_id, "error": str(e)},
+            )
+            raise PostServiceError(
+                f"Failed to validate user profile: {str(e)}"
+            ) from e
+
+        if not profile or not getattr(profile, "nickname", None):
+            raise UserNotFoundError(f"User not found: {sec_user_id}")
+
+        operation = await self.operation_store.create_operation(
+            operation_type="user_posts_bulk_download",
+            subject_id=sec_user_id,
+            status="pending",
+            message="Bulk download scheduled",
+            progress=0.0,
+            metadata={"max_cursor": max_cursor},
+        )
+
+        coro = self._run_bulk_download(
+            operation.operation_id, sec_user_id, max_cursor
+        )
+        # Route through the shared registry so the FastAPI lifespan can
+        # drain the in-flight bulk download before the executor pools are
+        # reaped. ``spawn_or_fallback`` falls back to ``asyncio.create_task``
+        # for unit tests that instantiate ``PostService`` directly.
+        spawn_or_fallback(
+            self._task_registry,
+            coro,
+            name=f"posts-bulk-{operation.operation_id}",
+        )
+
+        return BulkDownloadResponse(
+            operation_id=operation.operation_id,
+            sec_user_id=sec_user_id,
+            download_path=None,
+            total_posts=0,
+            downloaded_count=dict.fromkeys(PostType, 0),
+            total_downloaded=0,
+            status=DownloadStatus.PENDING,
+            message="Bulk download scheduled",
+            error_details=None,
+        )
+
+    async def _run_bulk_download(
+        self,
+        operation_id: str,
+        sec_user_id: str,
+        max_cursor: int,
+    ) -> None:
+        """Execute the bulk download loop and persist progress to the store.
+
+        Mirrors the orchestration shape used by
+        ``UserService._process_download``: the operation row is moved to
+        ``running`` on entry, refreshed after each successful batch with
+        the running tally, and finalized via ``completed`` / ``partial`` /
+        ``failed`` once the loop terminates.
+
+        Args:
+            operation_id: Identifier of the persisted operation record.
+            sec_user_id: Unique identifier of the user.
+            max_cursor: Starting pagination cursor for fetching posts.
+        """
+        download_stats: dict[PostType, int] = dict.fromkeys(PostType, 0)
+        download_path: str | None = None
         total_posts = 0
 
         try:
-            # Get user profile
-            logger.info("Fetching user profile", extra={"sec_user_id": sec_user_id})
+            await self.operation_store.update_operation(
+                operation_id,
+                status="running",
+                message="Bulk download in progress",
+                progress=0.0,
+                completed_items=0,
+                error=None,
+            )
+
+            logger.info(
+                "Fetching user profile",
+                extra={
+                    "sec_user_id": sec_user_id,
+                    "operation_id": operation_id,
+                },
+            )
             profile = await self.handler.fetch_user_profile(sec_user_id)
-            if not profile:
+            if not profile or not getattr(profile, "nickname", None):
                 raise UserNotFoundError(f"User not found: {sec_user_id}")
 
             aweme_count = profile.aweme_count
-            if isinstance(aweme_count, int):
-                total_posts = aweme_count
-            else:
-                total_posts = 0
+            total_posts = aweme_count if isinstance(aweme_count, int) else 0
 
             logger.info(
                 "User profile fetched",
@@ -265,6 +379,12 @@ class PostService:
                 },
             )
 
+            await self.operation_store.update_operation(
+                operation_id,
+                total_items=total_posts,
+                message="Bulk download in progress",
+            )
+
             # Set up user directory
             async with AsyncUserDB("douyin_users.db") as db:
                 user_path = await self.handler.get_or_add_user_data(
@@ -272,8 +392,13 @@ class PostService:
                 )
                 download_path = str(user_path)
                 logger.info(
-                    "Download directory created", extra={"download_path": download_path}
+                    "Download directory created",
+                    extra={"download_path": download_path},
                 )
+            await self.operation_store.update_operation(
+                operation_id,
+                download_path=download_path,
+            )
 
             current_cursor = max_cursor
             # Bound the outer loop so a sticky upstream cursor cannot pin a
@@ -282,7 +407,9 @@ class PostService:
             # the server keeps replying with the same ``max_cursor`` the
             # only stop conditions become ``has_more=False`` or this cap.
             if total_posts > 0:
-                max_pages = (total_posts // PAGE_SIZE) * PAGE_MULTIPLIER + PAGE_SLACK
+                max_pages = (
+                    (total_posts // PAGE_SIZE) * PAGE_MULTIPLIER + PAGE_SLACK
+                )
             else:
                 max_pages = MAX_PAGES_FALLBACK
             page_count = 0
@@ -294,6 +421,7 @@ class PostService:
                         "Bulk download loop exceeded max_pages; stopping",
                         extra={
                             "sec_user_id": sec_user_id,
+                            "operation_id": operation_id,
                             "cursor": current_cursor,
                             "max_pages": max_pages,
                             "total_downloaded": sum(download_stats.values()),
@@ -324,6 +452,26 @@ class PostService:
                         break
 
                     await self._process_posts_batch(posts, download_stats, user_path)
+                    total_downloaded = sum(download_stats.values())
+
+                    progress: float | None
+                    if total_posts > 0:
+                        progress = min(
+                            (total_downloaded / total_posts) * 100, 100.0
+                        )
+                    else:
+                        progress = None
+
+                    update_fields: dict[str, Any] = {
+                        "completed_items": total_downloaded,
+                        "total_items": total_posts,
+                        "message": "Bulk download in progress",
+                    }
+                    if progress is not None:
+                        update_fields["progress"] = progress
+                    await self.operation_store.update_operation(
+                        operation_id, **update_fields
+                    )
 
                     # Handle pagination
                     has_more = posts.get("has_more", False)
@@ -345,24 +493,147 @@ class PostService:
                     # the error instead of spinning indefinitely.
                     logger.error(
                         "Error processing batch; ending pagination",
-                        extra={"error": str(batch_error), "cursor": current_cursor},
+                        extra={
+                            "error": str(batch_error),
+                            "cursor": current_cursor,
+                            "operation_id": operation_id,
+                        },
                     )
                     break
 
-        except UserNotFoundError:
-            raise
+        except UserNotFoundError as e:
+            logger.warning(
+                "User not found during bulk download",
+                extra={"sec_user_id": sec_user_id, "operation_id": operation_id},
+            )
+            await self.operation_store.update_operation(
+                operation_id,
+                status="failed",
+                message="Bulk download failed",
+                error=str(e),
+                metadata={
+                    "max_cursor": max_cursor,
+                    "download_stats": _serialize_download_stats(download_stats),
+                    "download_path": download_path,
+                    "total_posts": total_posts,
+                },
+            )
+            return
         except Exception as e:
             logger.exception(
-                "Error in download process",
-                extra={"sec_user_id": sec_user_id, "error": str(e)},
+                "Error in bulk download process",
+                extra={
+                    "sec_user_id": sec_user_id,
+                    "operation_id": operation_id,
+                    "error": str(e),
+                },
             )
-            raise DownloadError(f"Download failed: {str(e)}") from e
+            await self.operation_store.update_operation(
+                operation_id,
+                status="failed",
+                message="Bulk download failed",
+                error=str(e),
+                metadata={
+                    "max_cursor": max_cursor,
+                    "download_stats": _serialize_download_stats(download_stats),
+                    "download_path": download_path,
+                    "total_posts": total_posts,
+                },
+            )
+            return
 
-        return self._create_download_response(
-            sec_user_id,
-            download_path,
-            total_posts,
-            download_stats,
+        # Success / partial-success classification matches
+        # :meth:`_create_download_response` so the polling response surfaces
+        # the same status the synchronous implementation used to return.
+        total_downloaded = sum(download_stats.values())
+        if total_downloaded == total_posts:
+            final_status = "completed"
+            terminal_message = (
+                f"Bulk download completed: {total_downloaded}/{total_posts} posts"
+            )
+        elif total_downloaded > 0:
+            final_status = "partial"
+            terminal_message = (
+                "Bulk download completed with missing items: "
+                f"{total_downloaded}/{total_posts} posts"
+            )
+        else:
+            final_status = "failed"
+            terminal_message = (
+                "Bulk download failed: no posts were downloaded"
+            )
+
+        progress_value: float
+        if total_posts > 0:
+            progress_value = min((total_downloaded / total_posts) * 100, 100.0)
+        else:
+            progress_value = 100.0 if final_status == "completed" else 0.0
+
+        await self.operation_store.update_operation(
+            operation_id,
+            status=final_status,
+            message=terminal_message,
+            progress=progress_value,
+            completed_items=total_downloaded,
+            total_items=total_posts,
+            download_path=download_path,
+            metadata={
+                "max_cursor": max_cursor,
+                "download_stats": _serialize_download_stats(download_stats),
+                "download_path": download_path,
+                "total_posts": total_posts,
+            },
+        )
+
+    async def get_bulk_download_status(
+        self, operation_id: str
+    ) -> BulkDownloadResponse:
+        """Get the current status of a bulk download operation.
+
+        Args:
+            operation_id: The unique identifier of the bulk download operation.
+
+        Returns:
+            BulkDownloadResponse: Snapshot of the operation including the
+                per-PostType counts persisted in the operation metadata.
+
+        Raises:
+            DownloadError: If no bulk download operation matches the
+                provided identifier.
+        """
+        try:
+            op = await self.operation_store.get_operation(operation_id)
+        except DownloadError as e:
+            raise DownloadError(
+                f"Bulk download task {operation_id} not found"
+            ) from e
+
+        if op.operation_type != "user_posts_bulk_download":
+            raise DownloadError(f"Bulk download task {operation_id} not found")
+
+        download_stats = _deserialize_download_stats(op.metadata)
+        total_posts = int(op.total_items or op.metadata.get("total_posts") or 0)
+        total_downloaded = sum(download_stats.values())
+        if op.completed_items is not None:
+            total_downloaded = max(total_downloaded, int(op.completed_items))
+
+        download_path = op.download_path or op.metadata.get("download_path")
+
+        status = _operation_status_to_download_status(op.status)
+        message = op.message or _build_bulk_message(
+            total_downloaded, total_posts, download_stats, download_path
+        )
+
+        return BulkDownloadResponse(
+            operation_id=op.operation_id,
+            sec_user_id=op.subject_id,
+            download_path=download_path,
+            total_posts=total_posts,
+            downloaded_count=download_stats,
+            total_downloaded=total_downloaded,
+            status=status,
+            message=message,
+            error_details=op.error,
         )
 
     async def _fetch_posts_batch(
@@ -635,3 +906,74 @@ class PostService:
             message=message,
             error_details=error_details,
         )
+
+
+# ----------------------------------------------------------------------
+# Module-level helpers shared between ``_run_bulk_download`` and
+# ``get_bulk_download_status``. Keeping them at module scope makes the
+# serialization shape easy to unit test and avoids leaking sqlite-aware
+# logic into the response model.
+# ----------------------------------------------------------------------
+
+
+def _serialize_download_stats(stats: dict[PostType, int]) -> dict[str, int]:
+    """Convert the per-PostType counter into JSON-friendly metadata."""
+    return {post_type.value: int(count) for post_type, count in stats.items()}
+
+
+def _deserialize_download_stats(
+    metadata: dict[str, Any],
+) -> dict[PostType, int]:
+    """Rebuild the per-PostType counter from operation metadata.
+
+    Missing or partial dictionaries default to zero counts so callers can
+    rely on every ``PostType`` member being present in the result.
+    """
+    raw = metadata.get("download_stats") or {}
+    counts: dict[PostType, int] = dict.fromkeys(PostType, 0)
+    if not isinstance(raw, dict):
+        return counts
+    for key, value in raw.items():
+        try:
+            post_type = PostType(key)
+        except ValueError:
+            # Unknown values are skipped silently so the response stays
+            # well-formed even after a future ``PostType`` change.
+            continue
+        try:
+            counts[post_type] = int(value)
+        except (TypeError, ValueError):
+            counts[post_type] = 0
+    return counts
+
+
+def _operation_status_to_download_status(status: str) -> DownloadStatus:
+    """Translate persisted operation status to public download status."""
+    mapping = {
+        "pending": DownloadStatus.PENDING,
+        "running": DownloadStatus.IN_PROGRESS,
+        "completed": DownloadStatus.SUCCESS,
+        "partial": DownloadStatus.PARTIAL_SUCCESS,
+        "failed": DownloadStatus.FAILED,
+    }
+    return mapping.get(status, DownloadStatus.FAILED)
+
+
+def _build_bulk_message(
+    total_downloaded: int,
+    total_posts: int,
+    download_stats: dict[PostType, int],
+    download_path: str | None,
+) -> str:
+    """Render a human-readable summary for the bulk download response."""
+    location = download_path or "(pending)"
+    return (
+        f"Downloaded {total_downloaded} out of {total_posts} posts. "
+        f"(Videos: {download_stats[PostType.VIDEO]}, "
+        f"Images: {download_stats[PostType.IMAGES]}, "
+        f"Mixed: {download_stats[PostType.MIXED]}, "
+        f"Lives: {download_stats[PostType.LIVE]}, "
+        f"Collections: {download_stats[PostType.COLLECTION]}, "
+        f"Stories: {download_stats[PostType.STORY]}) "
+        f"Files saved to {location}"
+    )

--- a/src/dyvine/services/storage.py
+++ b/src/dyvine/services/storage.py
@@ -353,8 +353,11 @@ class R2StorageService:
 
         file_size = file_path.stat().st_size
 
-        # Start upload metrics
-        start_time = time.time()
+        # Start upload metrics. ``perf_counter`` is monotonic and immune to
+        # NTP step adjustments or wall-clock drift, which is exactly what we
+        # want when measuring an elapsed duration paired with a single end
+        # call below.
+        start_time = time.perf_counter()
         try:
             logger.info(
                 "Starting R2 upload",
@@ -377,7 +380,7 @@ class R2StorageService:
                 metadata=metadata,
             )
 
-            duration = time.time() - start_time
+            duration = time.perf_counter() - start_time
 
             logger.info(
                 "Successfully uploaded file to R2",

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -471,14 +471,10 @@ class UserService:
 
         missing_error: str | None = None
         downloads_incomplete = (
-            not downloading_likes_only
-            and total_posts > 0
-            and downloaded < total_posts
+            not downloading_likes_only and total_posts > 0 and downloaded < total_posts
         )
         if downloads_incomplete:
-            missing_error = (
-                f"Only downloaded {downloaded} out of {total_posts} posts"
-            )
+            missing_error = f"Only downloaded {downloaded} out of {total_posts} posts"
 
         if missing_error and upload_error:
             combined_error: str | None = f"{missing_error}; {upload_error}"
@@ -506,7 +502,15 @@ class UserService:
                 downloaded,
             )
 
-        progress_value = 100.0 if status == "completed" else completion_percentage
+        # Clamp the partial percentage so the persisted ``progress`` field
+        # honors the implicit 0-100 contract. ``completion_percentage`` can
+        # exceed 100 when the run mixes posts and likes (``downloaded``
+        # accumulates likes while ``total_posts`` only reflects
+        # ``aweme_count``); without the clamp a single R2 upload failure
+        # could surface a 130%-style progress value to API clients.
+        progress_value = (
+            100.0 if status == "completed" else min(completion_percentage, 100.0)
+        )
         await self.operation_store.update_operation(
             task_id,
             status=status,

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -83,6 +83,20 @@ from .storage import ContentType, R2StorageService
 # to bound the number of pages we will walk before giving up.
 PAGE_SIZE = 100
 
+# Cool-down between successive page fetches inside ``_process_download``.
+# Douyin throttles aggressive callers, so the loop sleeps before pulling
+# the next cursor to keep the request cadence below their anti-scrape
+# threshold. Centralised here so the value can be tuned without touching
+# the loop body.
+PAGE_FETCH_DELAY_SECONDS = 5.0
+
+# Parent directory that holds per-task download workspaces. Each running
+# ``_process_download`` invocation gets its own ``TEMP_DOWNLOAD_ROOT /
+# <task_id>`` subdirectory so two concurrent tasks cannot stomp on each
+# other's files or have the cleanup branch in one task delete the other's
+# in-flight downloads.
+TEMP_DOWNLOAD_ROOT = Path("temp_downloads")
+
 
 def sanitize_filename(filename: str) -> str:
     """Sanitize filename for cross-platform filesystem compatibility.
@@ -294,6 +308,241 @@ class UserService:
             raise DownloadError(f"Download task {task_id} not found")
         return DownloadResponse(**operation.to_response())
 
+    def _build_handler_kwargs(
+        self,
+        user_id: str,
+        max_items: int | None,
+        mode_label: str,
+        downloading_likes_only: bool,
+        include_likes: bool,
+        temp_dir: Path,
+    ) -> dict[str, Any]:
+        """Assemble the keyword arguments forwarded to ``DouyinHandler``.
+
+        Centralising the payload keeps ``_process_download`` focused on the
+        state-machine flow and keeps the f2-specific knobs (mode, favorite
+        toggle, naming template) in a single auditable place.
+
+        Args:
+            user_id: Target Douyin user identifier.
+            max_items: Optional cap on the number of items to download.
+            mode_label: ``"post"`` or ``"like"``; selects the f2 fetch mode.
+            downloading_likes_only: ``True`` when the run targets the
+                liked-items feed exclusively.
+            include_likes: Original API flag from the caller; preserved so
+                the ``download_favorite`` rule below stays correct.
+            temp_dir: Per-task download workspace directory.
+
+        Returns:
+            Dict[str, Any]: Keyword payload suitable for ``DouyinHandler``.
+        """
+        return {
+            "url": f"https://www.douyin.com/user/{user_id}",
+            "cookie": settings.douyin_cookie,
+            "headers": {
+                "User-Agent": settings.douyin_user_agent,
+                "Referer": settings.douyin_referer,
+            },
+            "proxy": settings.douyin_proxy_http,
+            "download_path": str(temp_dir),
+            "max_counts": max_items,
+            # ``download_favorite`` only means "also fetch likes" when the
+            # loop is already walking the posts feed. In the dedicated
+            # likes path we point the fetcher at the likes endpoint
+            # directly, so keep the flag off to avoid f2's implicit
+            # dual-fetch behavior.
+            "download_favorite": (include_likes and not downloading_likes_only),
+            "timeout": 5,
+            "folderize": True,
+            "mode": mode_label,
+            "naming": "{create}_{desc}",
+            "download_image": True,
+            "filename_filter": sanitize_filename,
+        }
+
+    @staticmethod
+    def _resolve_total_posts(user_data: Any, downloading_likes_only: bool) -> int:
+        """Return the expected total post count for the run.
+
+        Likes-only runs leave the total at zero because the profile
+        endpoint does not expose a liked-items count, so progress has to
+        be tracked as an indeterminate counter. For the posts path the
+        value is the profile's ``aweme_count`` coerced to ``int``; any
+        non-int payload is treated as zero so the caller can short-circuit
+        the empty-profile case.
+
+        Args:
+            user_data: The profile payload returned by ``DouyinHandler``.
+            downloading_likes_only: ``True`` when the run targets the
+                liked-items feed exclusively.
+
+        Returns:
+            int: Resolved total post count, or ``0`` if unknown.
+        """
+        if downloading_likes_only:
+            return 0
+        aweme_count = user_data.aweme_count
+        return int(aweme_count) if isinstance(aweme_count, int) else 0
+
+    async def _upload_directory_to_r2(
+        self, user_dir: Path, user_id: str, user_data: Any
+    ) -> tuple[int, int]:
+        """Upload every file under ``user_dir`` to R2 storage.
+
+        Walks the directory recursively, derives a content type from each
+        file extension, generates the corresponding R2 path/metadata, and
+        uploads. Local files are deleted only after a successful upload so
+        a failed upload leaves the file on disk for the cleanup step to
+        sweep -- this keeps the download workspace empty between batches
+        without losing the file when the user retries.
+
+        Args:
+            user_dir: Local directory holding files just produced by f2.
+            user_id: Douyin user identifier used to derive R2 paths.
+            user_data: Profile payload supplying the author name for
+                metadata.
+
+        Returns:
+            Tuple of ``(uploaded_count, failed_count)`` so the caller can
+            promote partial-success states without re-walking the tree.
+        """
+        uploaded_count = 0
+        failed_count = 0
+        for file_path in user_dir.glob("**/*"):
+            if not file_path.is_file():
+                continue
+            try:
+                if file_path.suffix.lower() in [".jpg", ".jpeg", ".png", ".webp"]:
+                    content_type = "image/" + file_path.suffix.lower().lstrip(".")
+                else:
+                    content_type = "video/mp4"
+                r2_path = self.storage.generate_ugc_path(
+                    user_id, file_path.name, content_type
+                )
+                metadata = self.storage.generate_metadata(
+                    author=user_data.nickname,
+                    category=ContentType.POSTS,
+                    content_type=content_type,
+                    source="douyin",
+                )
+                await self.storage.upload_file(
+                    file_path, r2_path, metadata, content_type
+                )
+                file_path.unlink()
+                uploaded_count += 1
+            except Exception as e:
+                failed_count += 1
+                logger.error(f"Failed to upload {file_path} to R2: {str(e)}")
+        return uploaded_count, failed_count
+
+    async def _finalize_status(
+        self,
+        task_id: str,
+        downloaded: int,
+        total_posts: int,
+        failed_uploads: int,
+        downloading_likes_only: bool,
+    ) -> None:
+        """Persist the terminal state for a finished download loop.
+
+        Resolves the final status by combining download completeness with
+        R2 upload outcomes. The status is downgraded to ``partial`` when
+        any upload failed even if every post was fetched, so the operation
+        record stays observable instead of silently reporting success.
+
+        Args:
+            task_id: Operation identifier to update.
+            downloaded: Number of posts the loop successfully fetched.
+            total_posts: Expected total from the profile, or ``0`` when
+                unknown (likes-only runs).
+            failed_uploads: Count of files that failed to upload to R2.
+            downloading_likes_only: ``True`` when the run targets the
+                liked-items feed exclusively; suppresses the missing-items
+                error string because there is no authoritative total.
+        """
+        if total_posts > 0:
+            completion_percentage = (downloaded / total_posts) * 100.0
+        else:
+            completion_percentage = 100.0
+
+        upload_error: str | None = None
+        if failed_uploads > 0:
+            upload_error = f"R2 upload failed for {failed_uploads} file(s)"
+
+        missing_error: str | None = None
+        downloads_incomplete = (
+            not downloading_likes_only
+            and total_posts > 0
+            and downloaded < total_posts
+        )
+        if downloads_incomplete:
+            missing_error = (
+                f"Only downloaded {downloaded} out of {total_posts} posts"
+            )
+
+        if missing_error and upload_error:
+            combined_error: str | None = f"{missing_error}; {upload_error}"
+        else:
+            combined_error = missing_error or upload_error
+
+        if downloads_incomplete or failed_uploads > 0:
+            status = "partial"
+            message = "Download completed with missing items"
+            logger.warning(
+                "Finalising download with partial status",
+                extra={
+                    "task_id": task_id,
+                    "downloaded": downloaded,
+                    "total_posts": total_posts,
+                    "failed_uploads": failed_uploads,
+                    "completion_percentage": completion_percentage,
+                },
+            )
+        else:
+            status = "completed"
+            message = "Download completed"
+            logger.info(
+                "Successfully downloaded %s posts (100%% complete)",
+                downloaded,
+            )
+
+        progress_value = 100.0 if status == "completed" else completion_percentage
+        await self.operation_store.update_operation(
+            task_id,
+            status=status,
+            message=message,
+            error=combined_error,
+            progress=progress_value,
+            completed_items=downloaded,
+            total_items=total_posts,
+        )
+
+    @staticmethod
+    def _cleanup_temp_dir(temp_dir: Path | None) -> None:
+        """Remove a per-task download workspace and all of its contents.
+
+        Only the workspace itself is touched; the shared
+        ``TEMP_DOWNLOAD_ROOT`` parent is preserved so concurrent tasks
+        keep their own ``temp_downloads/<task_id>`` siblings intact.
+
+        Args:
+            temp_dir: Per-task workspace path. ``None`` and missing
+                directories are tolerated so the caller can invoke the
+                helper from a ``finally`` block without checking state.
+        """
+        if temp_dir is None or not temp_dir.exists():
+            return
+        try:
+            for file in sorted(temp_dir.glob("**/*"), reverse=True):
+                if file.is_file():
+                    file.unlink()
+            for sub_dir in sorted(temp_dir.glob("**/*"), reverse=True):
+                if sub_dir.is_dir():
+                    sub_dir.rmdir()
+            temp_dir.rmdir()
+        except Exception as e:
+            logger.error(f"Failed to clean up temp directory: {str(e)}")
+
     async def _process_download(
         self,
         task_id: str,
@@ -336,7 +585,13 @@ class UserService:
         downloading_likes_only = not include_posts and include_likes
         mode_label = "like" if downloading_likes_only else "post"
 
-        temp_dir = None
+        # Each task gets its own workspace under ``TEMP_DOWNLOAD_ROOT`` so
+        # concurrent downloads cannot share files, and the cleanup branch
+        # only ever touches one task's directory.
+        temp_dir: Path | None = None
+        downloaded_count = 0
+        total_posts = 0
+        failed_uploads = 0
         try:
             await self.operation_store.update_operation(
                 task_id,
@@ -347,34 +602,18 @@ class UserService:
                 error=None,
             )
 
-            temp_dir = Path("temp_downloads")
-            temp_dir.mkdir(exist_ok=True)
+            TEMP_DOWNLOAD_ROOT.mkdir(exist_ok=True)
+            temp_dir = TEMP_DOWNLOAD_ROOT / task_id
+            temp_dir.mkdir(parents=True, exist_ok=True)
 
-            # Initialize f2 handler with temporary directory
-            handler_kwargs = {
-                "url": f"https://www.douyin.com/user/{user_id}",
-                "cookie": settings.douyin_cookie,
-                "headers": {
-                    "User-Agent": settings.douyin_user_agent,
-                    "Referer": settings.douyin_referer,
-                },
-                "proxy": settings.douyin_proxy_http,
-                "download_path": str(temp_dir),
-                "max_counts": max_items,
-                # ``download_favorite`` only means "also fetch likes" when
-                # the loop is already walking the posts feed. In the
-                # dedicated likes path we point the fetcher at the likes
-                # endpoint directly, so keep the flag off to avoid f2's
-                # implicit dual-fetch behavior.
-                "download_favorite": (include_likes and not downloading_likes_only),
-                "timeout": 5,
-                "folderize": True,
-                "mode": mode_label,
-                "naming": "{create}_{desc}",
-                "download_image": True,
-                "filename_filter": sanitize_filename,  # Add filename sanitization
-            }
-
+            handler_kwargs = self._build_handler_kwargs(
+                user_id=user_id,
+                max_items=max_items,
+                mode_label=mode_label,
+                downloading_likes_only=downloading_likes_only,
+                include_likes=include_likes,
+                temp_dir=temp_dir,
+            )
             handler = DouyinHandler(handler_kwargs)
 
             # Get user profile to create user directory and verify post count
@@ -382,27 +621,18 @@ class UserService:
             if not user_data.nickname:
                 raise UserNotFoundError(f"User {user_id} not found")
 
-            if downloading_likes_only:
-                # The profile endpoint does not expose a total liked-items
-                # count. Leave ``total_posts`` unset and let the operation
-                # store track a running count; the completion branch at the
-                # bottom will record the final tally once the loop drains.
-                total_posts = 0
-            else:
-                # Get total posts count from profile
-                aweme_count = user_data.aweme_count
-                total_posts = int(aweme_count) if isinstance(aweme_count, int) else 0
-                if total_posts == 0:
-                    logger.info("User %s has no posts", user_id)
-                    await self.operation_store.update_operation(
-                        task_id,
-                        status="completed",
-                        message="Download completed",
-                        progress=100.0,
-                        total_items=0,
-                        completed_items=0,
-                    )
-                    return
+            total_posts = self._resolve_total_posts(user_data, downloading_likes_only)
+            if not downloading_likes_only and total_posts == 0:
+                logger.info("User %s has no posts", user_id)
+                await self.operation_store.update_operation(
+                    task_id,
+                    status="completed",
+                    message="Download completed",
+                    progress=100.0,
+                    total_items=0,
+                    completed_items=0,
+                )
+                return
 
             if downloading_likes_only:
                 logger.info("User %s requested likes-only download", user_data.nickname)
@@ -418,14 +648,13 @@ class UserService:
                     message="Download in progress",
                 )
 
-            # Create user directory in temp
+            # Create user directory inside the per-task workspace.
             user_dir = temp_dir / user_data.nickname
             user_dir.mkdir(exist_ok=True)
 
-            # Use the handler to download user posts
+            # Use the handler to download user posts.
             max_cursor = 0
             has_more = True
-            downloaded_count = 0
 
             # Guard against an unbounded outer loop. ``max_cursor += 1`` in
             # the "cursor stuck" branch below can spin indefinitely if the
@@ -518,54 +747,26 @@ class UserService:
                             progress,
                         )
 
-                    # Download files to temp directory
+                    # Download files to the per-task workspace.
                     await handler.downloader.create_download_tasks(
                         handler_kwargs, aweme_data._to_list(), user_dir
                     )
 
-                    # Upload downloaded files to R2 (search recursively)
-                    for file_path in user_dir.glob("**/*"):
-                        if file_path.is_file():
-                            try:
-                                # Generate R2 storage path
-                                if file_path.suffix.lower() in [
-                                    ".jpg",
-                                    ".jpeg",
-                                    ".png",
-                                    ".webp",
-                                ]:
-                                    content_type = (
-                                        "image/" + file_path.suffix.lower().lstrip(".")
-                                    )
-                                    r2_path = self.storage.generate_ugc_path(
-                                        user_id, file_path.name, content_type
-                                    )
-                                else:
-                                    content_type = "video/mp4"
-                                    r2_path = self.storage.generate_ugc_path(
-                                        user_id, file_path.name, content_type
-                                    )
-
-                                # Generate metadata
-                                metadata = self.storage.generate_metadata(
-                                    author=user_data.nickname,
-                                    category=ContentType.POSTS,
-                                    content_type=content_type,
-                                    source="douyin",
-                                )
-
-                                # Upload to R2
-                                await self.storage.upload_file(
-                                    file_path, r2_path, metadata, content_type
-                                )
-
-                                # Delete local file after upload
-                                file_path.unlink()
-
-                            except Exception as e:
-                                logger.error(
-                                    f"Failed to upload {file_path} to R2: {str(e)}"
-                                )
+                    # Push the freshly downloaded files to R2 and track
+                    # any failures so the final status can be downgraded.
+                    batch_uploaded, batch_failed = await self._upload_directory_to_r2(
+                        user_dir, user_id, user_data
+                    )
+                    failed_uploads += batch_failed
+                    logger.debug(
+                        "R2 upload batch finished",
+                        extra={
+                            "task_id": task_id,
+                            "user_id": user_id,
+                            "uploaded": batch_uploaded,
+                            "failed": batch_failed,
+                        },
+                    )
 
                     # Update cursor for next page
                     if (
@@ -590,7 +791,7 @@ class UserService:
                         break
 
                     # Add delay between pages
-                    await asyncio.sleep(5.0)
+                    await asyncio.sleep(PAGE_FETCH_DELAY_SECONDS)
 
                 if not iterated:
                     # The fetcher produced no items (either because the
@@ -599,49 +800,14 @@ class UserService:
                     # bail-out ``has_more`` stays True and the outer while
                     # loop spins.
                     has_more = False
-            # Verify download completion
-            if total_posts > 0:
-                completion_percentage = (downloaded_count / total_posts) * 100
-            else:
-                completion_percentage = 100.0
 
-            if completion_percentage >= 100:
-                # Consider anything >= 100% as complete success
-                logger.info(
-                    "Successfully downloaded %s posts (100%% complete)",
-                    downloaded_count,
-                )
-                await self.operation_store.update_operation(
-                    task_id,
-                    status="completed",
-                    message="Download completed",
-                    progress=100.0,
-                    completed_items=downloaded_count,
-                    total_items=total_posts,
-                )
-            else:
-                # Less than 100% means we missed some posts
-                logger.warning(
-                    (
-                        "Only downloaded %s/%s posts (%.1f%%). "
-                        "Some posts may have been missed."
-                    ),
-                    downloaded_count,
-                    total_posts,
-                    completion_percentage,
-                )
-                await self.operation_store.update_operation(
-                    task_id,
-                    status="partial",
-                    message="Download completed with missing items",
-                    error=(
-                        f"Only downloaded {downloaded_count} "
-                        f"out of {total_posts} posts"
-                    ),
-                    progress=completion_percentage,
-                    completed_items=downloaded_count,
-                    total_items=total_posts,
-                )
+            await self._finalize_status(
+                task_id=task_id,
+                downloaded=downloaded_count,
+                total_posts=total_posts,
+                failed_uploads=failed_uploads,
+                downloading_likes_only=downloading_likes_only,
+            )
 
         except Exception as e:
             logger.exception(
@@ -656,14 +822,4 @@ class UserService:
             )
 
         finally:
-            try:
-                if temp_dir and temp_dir.exists():
-                    for file in sorted(temp_dir.glob("**/*"), reverse=True):
-                        if file.is_file():
-                            file.unlink()
-                    for dir in sorted(temp_dir.glob("**/*"), reverse=True):
-                        if dir.is_dir():
-                            dir.rmdir()
-                    temp_dir.rmdir()
-            except Exception as e:
-                logger.error(f"Failed to clean up temp directory: {str(e)}")
+            self._cleanup_temp_dir(temp_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,10 +32,20 @@ if str(SRC_DIR) not in sys.path:
 
 @pytest.fixture(autouse=True)
 def reset_singletons(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Reset cached state and isolate operation storage between tests."""
+    """Reset cached state and isolate operation storage between tests.
+
+    The autouse fixture also strips ``SECURITY_SECRET_KEY`` and
+    ``SECURITY_API_KEY`` from the process environment before each test runs.
+    ``get_settings`` calls ``load_dotenv`` on import, which leaks any real
+    credentials from the developer's ``.env`` into ``os.environ`` and would
+    otherwise make ``SecuritySettings`` tests assert against a live secret
+    instead of the documented ``change-me-in-production`` sentinel.
+    """
     from dyvine.core.dependencies import get_service_container
     from dyvine.core.settings import settings
 
+    monkeypatch.delenv("SECURITY_SECRET_KEY", raising=False)
+    monkeypatch.delenv("SECURITY_API_KEY", raising=False)
     monkeypatch.setattr(
         settings.api,
         "operation_db_path",

--- a/tests/routers/test_posts_router.py
+++ b/tests/routers/test_posts_router.py
@@ -22,7 +22,8 @@ def mock_post_service() -> MagicMock:
     svc = MagicMock()
     svc.get_post_detail = AsyncMock()
     svc.get_user_posts = AsyncMock()
-    svc.download_all_user_posts = AsyncMock()
+    svc.start_bulk_download = AsyncMock()
+    svc.get_bulk_download_status = AsyncMock()
     return svc
 
 
@@ -101,23 +102,64 @@ async def test_list_user_posts_unexpected_error(
 
 
 @pytest.mark.asyncio
-async def test_download_user_posts_success(
+async def test_download_user_posts_returns_pending_response(
     mock_post_service: MagicMock,
 ) -> None:
     from dyvine.routers.posts import download_user_posts
 
     resp = BulkDownloadResponse(
+        operation_id="op-123",
         sec_user_id="u1",
-        download_path="/dl",
-        total_posts=5,
-        status=DownloadStatus.SUCCESS,
+        download_path=None,
+        total_posts=0,
+        status=DownloadStatus.PENDING,
+        message="Bulk download scheduled",
     )
-    mock_post_service.download_all_user_posts.return_value = resp
+    mock_post_service.start_bulk_download.return_value = resp
 
     result = await download_user_posts(
         service=mock_post_service, user_id="u1", max_cursor=0
     )
-    assert result.status == DownloadStatus.SUCCESS
+    assert result.status == DownloadStatus.PENDING
+    assert result.operation_id == "op-123"
+    mock_post_service.start_bulk_download.assert_awaited_once_with("u1", 0)
+
+
+def test_download_user_posts_route_returns_202() -> None:
+    """The bulk download endpoint must advertise HTTP 202 Accepted.
+
+    A test client check guards against future regressions where the
+    decorator drops the ``status_code`` argument and silently reverts to
+    the default 200.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from dyvine.core.dependencies import get_post_service
+    from dyvine.routers.posts import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+
+    pending = BulkDownloadResponse(
+        operation_id="op-202",
+        sec_user_id="u1",
+        download_path=None,
+        total_posts=0,
+        status=DownloadStatus.PENDING,
+        message="Bulk download scheduled",
+    )
+    fake_service = MagicMock()
+    fake_service.start_bulk_download = AsyncMock(return_value=pending)
+    app.dependency_overrides[get_post_service] = lambda: fake_service
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/posts/users/u1/posts:download")
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["operation_id"] == "op-202"
+    assert payload["status"] == DownloadStatus.PENDING.value
 
 
 @pytest.mark.asyncio
@@ -126,7 +168,7 @@ async def test_download_user_posts_user_not_found(
 ) -> None:
     from dyvine.routers.posts import download_user_posts
 
-    mock_post_service.download_all_user_posts.side_effect = UserNotFoundError("nf")
+    mock_post_service.start_bulk_download.side_effect = UserNotFoundError("nf")
 
     with pytest.raises(HTTPException) as exc_info:
         await download_user_posts(
@@ -141,8 +183,78 @@ async def test_download_user_posts_download_error(
 ) -> None:
     from dyvine.routers.posts import download_user_posts
 
-    mock_post_service.download_all_user_posts.side_effect = DownloadError("fail")
+    mock_post_service.start_bulk_download.side_effect = DownloadError("fail")
 
     with pytest.raises(HTTPException) as exc_info:
         await download_user_posts(service=mock_post_service, user_id="u1", max_cursor=0)
+    assert exc_info.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_download_user_posts_unexpected_error(
+    mock_post_service: MagicMock,
+) -> None:
+    from dyvine.routers.posts import download_user_posts
+
+    mock_post_service.start_bulk_download.side_effect = RuntimeError("boom")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await download_user_posts(service=mock_post_service, user_id="u1", max_cursor=0)
+    assert exc_info.value.status_code == 500
+
+
+# ── get_bulk_download_operation ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_bulk_download_operation_success(
+    mock_post_service: MagicMock,
+) -> None:
+    from dyvine.routers.posts import get_bulk_download_operation
+
+    resp = BulkDownloadResponse(
+        operation_id="op-1",
+        sec_user_id="u1",
+        download_path="/dl",
+        total_posts=5,
+        total_downloaded=5,
+        status=DownloadStatus.SUCCESS,
+        message="done",
+    )
+    mock_post_service.get_bulk_download_status.return_value = resp
+
+    result = await get_bulk_download_operation(
+        service=mock_post_service, operation_id="op-1"
+    )
+    assert result.operation_id == "op-1"
+    assert result.status == DownloadStatus.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_get_bulk_download_operation_not_found(
+    mock_post_service: MagicMock,
+) -> None:
+    from dyvine.routers.posts import get_bulk_download_operation
+
+    mock_post_service.get_bulk_download_status.side_effect = DownloadError("nf")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_bulk_download_operation(
+            service=mock_post_service, operation_id="missing"
+        )
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_bulk_download_operation_unexpected_error(
+    mock_post_service: MagicMock,
+) -> None:
+    from dyvine.routers.posts import get_bulk_download_operation
+
+    mock_post_service.get_bulk_download_status.side_effect = RuntimeError("boom")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_bulk_download_operation(
+            service=mock_post_service, operation_id="op-1"
+        )
     assert exc_info.value.status_code == 500

--- a/tests/services/test_post_service.py
+++ b/tests/services/test_post_service.py
@@ -422,9 +422,7 @@ async def test_start_bulk_download_returns_pending_response_immediately(
         scheduled.append(future)
         return future
 
-    monkeypatch.setattr(
-        "dyvine.core.background.asyncio.create_task", fake_create_task
-    )
+    monkeypatch.setattr("dyvine.core.background.asyncio.create_task", fake_create_task)
 
     response = await svc.start_bulk_download("pending-user", max_cursor=42)
 
@@ -478,7 +476,9 @@ async def test_run_bulk_download_marks_completed_for_zero_post_user(
         mock_db.return_value = mock_ctx
 
         with patch.object(svc, "_fetch_posts_batch", new=AsyncMock(return_value={})):
-            await svc._run_bulk_download(operation.operation_id, "u1", 0)
+            await svc._run_bulk_download(
+                operation.operation_id, "u1", 0, profile=profile
+            )
 
     refreshed = await store.get_operation(operation.operation_id)
     assert refreshed.status == "completed"
@@ -506,7 +506,12 @@ async def test_run_bulk_download_records_failure_when_user_disappears(
     )
 
     svc = _build_service(handler, operation_store=store)
-    await svc._run_bulk_download(operation.operation_id, "ghost-user", 0)
+    # Pass ``profile=None`` to exercise the defensive guard inside
+    # ``_run_bulk_download``: when the caller supplies an invalid profile
+    # (e.g. the user disappeared between scheduling and execution) the
+    # operation must be marked failed instead of letting the
+    # ``UserNotFoundError`` propagate uncaught.
+    await svc._run_bulk_download(operation.operation_id, "ghost-user", 0, profile=None)
 
     refreshed = await store.get_operation(operation.operation_id)
     assert refreshed.status == "failed"
@@ -590,7 +595,9 @@ async def test_run_bulk_download_breaks_on_empty_aweme_list(tmp_path) -> None:
             }
 
         with patch.object(svc, "_fetch_posts_batch", side_effect=fake_fetch):
-            await svc._run_bulk_download(operation.operation_id, "loop-user", 0)
+            await svc._run_bulk_download(
+                operation.operation_id, "loop-user", 0, profile=profile
+            )
 
         # The first empty batch must short-circuit the loop.
         assert call_count == 1
@@ -661,7 +668,7 @@ async def test_run_bulk_download_caps_pagination_under_sticky_cursor(
         with patch.object(svc, "_fetch_posts_batch", side_effect=sticky_fetch):
             with patch.object(svc, "_process_posts_batch", new=process_batch):
                 await svc._run_bulk_download(
-                    operation.operation_id, "sticky-user", 0
+                    operation.operation_id, "sticky-user", 0, profile=profile
                 )
 
         # max_pages = (100 // 20) * 2 + 20 = 30. The loop breaks when
@@ -728,7 +735,9 @@ async def test_run_bulk_download_stops_on_batch_error(tmp_path) -> None:
             raise RuntimeError("upstream flaky")
 
         with patch.object(svc, "_fetch_posts_batch", side_effect=failing_fetch):
-            await svc._run_bulk_download(operation.operation_id, "error-user", 0)
+            await svc._run_bulk_download(
+                operation.operation_id, "error-user", 0, profile=profile
+            )
 
         assert call_count == 1
 

--- a/tests/services/test_post_service.py
+++ b/tests/services/test_post_service.py
@@ -1,19 +1,33 @@
 from __future__ import annotations
 
+import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from dyvine.core.exceptions import PostNotFoundError, ServiceError
+from dyvine.core.exceptions import DownloadError, PostNotFoundError, ServiceError
+from dyvine.core.operations import OperationStore
 from dyvine.schemas.posts import DownloadStatus, PostType
 from dyvine.services.posts import PostService
 
 
-def _build_service(handler: MagicMock | None = None) -> PostService:
-    """Create PostService without calling __init__ (avoids DouyinHandler)."""
+def _build_service(
+    handler: MagicMock | None = None,
+    *,
+    operation_store: OperationStore | None = None,
+) -> PostService:
+    """Create PostService without calling __init__ (avoids DouyinHandler).
+
+    Tests that exercise the bulk download paths must pass an
+    ``operation_store`` so the service can persist progress; the simple
+    helper-coverage tests only touch private helpers and can omit it.
+    """
     svc = object.__new__(PostService)  # type: ignore[return-value]
     if handler is not None:
         svc.handler = handler  # type: ignore[attr-defined]
+    if operation_store is not None:
+        svc.operation_store = operation_store  # type: ignore[attr-defined]
     return svc
 
 
@@ -365,49 +379,138 @@ async def test_download_post_content_success() -> None:
     handler.downloader.create_download_tasks.assert_awaited_once()
 
 
-# ── download_all_user_posts (async, mocked) ─────────────────────────────
+# ── start_bulk_download (async, mocked) ─────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_download_all_user_posts_user_not_found() -> None:
+async def test_start_bulk_download_user_not_found(tmp_path) -> None:
     from dyvine.core.exceptions import UserNotFoundError
 
     handler = MagicMock()
     handler.fetch_user_profile = AsyncMock(return_value=None)
 
-    svc = _build_service(handler)
+    store = OperationStore(str(tmp_path / "operations.db"))
+    svc = _build_service(handler, operation_store=store)
+
     with pytest.raises(UserNotFoundError):
-        await svc.download_all_user_posts("missing-user")
+        await svc.start_bulk_download("missing-user")
 
 
 @pytest.mark.asyncio
-async def test_download_all_user_posts_no_posts() -> None:
+async def test_start_bulk_download_returns_pending_response_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """``start_bulk_download`` must persist the operation and return without
+    awaiting the long-running download loop."""
+    handler = MagicMock()
+    profile = MagicMock()
+    profile.aweme_count = 0
+    profile.nickname = "PendingUser"
+    handler.fetch_user_profile = AsyncMock(return_value=profile)
+
+    store = OperationStore(str(tmp_path / "operations.db"))
+    svc = _build_service(handler, operation_store=store)
+
+    scheduled: list[asyncio.Future[None]] = []
+
+    def fake_create_task(coro: Any, **_kwargs: Any) -> asyncio.Future[None]:
+        if hasattr(coro, "close"):
+            coro.close()
+        future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        future.set_result(None)
+        scheduled.append(future)
+        return future
+
+    monkeypatch.setattr(
+        "dyvine.core.background.asyncio.create_task", fake_create_task
+    )
+
+    response = await svc.start_bulk_download("pending-user", max_cursor=42)
+
+    assert response.status == DownloadStatus.PENDING
+    assert response.operation_id
+    assert response.sec_user_id == "pending-user"
+    assert response.total_posts == 0
+    assert response.total_downloaded == 0
+    assert response.message == "Bulk download scheduled"
+    assert scheduled, "Expected the bulk download loop to be scheduled"
+
+    persisted = await store.get_operation(response.operation_id)
+    assert persisted.operation_type == "user_posts_bulk_download"
+    assert persisted.status == "pending"
+    assert persisted.metadata == {"max_cursor": 42}
+
+
+# ── _run_bulk_download (async, awaited inline) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_bulk_download_marks_completed_for_zero_post_user(
+    tmp_path,
+) -> None:
+    """A user with no posts walks through ``_run_bulk_download`` cleanly."""
     handler = MagicMock()
     profile = MagicMock()
     profile.aweme_count = 0
     profile.nickname = "EmptyUser"
     handler.fetch_user_profile = AsyncMock(return_value=profile)
 
-    # Mock the db context manager
     from pathlib import Path
     from unittest.mock import patch
+
+    handler.get_or_add_user_data = AsyncMock(return_value=Path("/tmp/user"))
+    store = OperationStore(str(tmp_path / "operations.db"))
+    operation = await store.create_operation(
+        operation_type="user_posts_bulk_download",
+        subject_id="u1",
+        status="pending",
+        message="scheduled",
+        metadata={"max_cursor": 0},
+    )
+
+    svc = _build_service(handler, operation_store=store)
 
     with patch("dyvine.services.posts.AsyncUserDB") as mock_db:
         mock_ctx = MagicMock()
         mock_ctx.__aenter__ = AsyncMock(return_value=MagicMock())
         mock_ctx.__aexit__ = AsyncMock(return_value=False)
         mock_db.return_value = mock_ctx
-        handler.get_or_add_user_data = AsyncMock(return_value=Path("/tmp/user"))
 
-        # No posts to fetch
-        svc = _build_service(handler)
-        mock_fetch = AsyncMock(return_value={})
-        with patch.object(svc, "_fetch_posts_batch", new=mock_fetch):
-            svc.handler = handler
-            result = await svc.download_all_user_posts("u1")
-            assert result.total_downloaded == 0
-            # total_downloaded == total_posts (both 0) → SUCCESS
-            assert result.status == DownloadStatus.SUCCESS
+        with patch.object(svc, "_fetch_posts_batch", new=AsyncMock(return_value={})):
+            await svc._run_bulk_download(operation.operation_id, "u1", 0)
+
+    refreshed = await store.get_operation(operation.operation_id)
+    assert refreshed.status == "completed"
+    # ``total_downloaded == total_posts == 0`` is treated as a clean run.
+    assert refreshed.completed_items == 0
+    assert refreshed.total_items == 0
+
+
+@pytest.mark.asyncio
+async def test_run_bulk_download_records_failure_when_user_disappears(
+    tmp_path,
+) -> None:
+    """If the user disappears between scheduling and execution, the operation
+    is marked failed rather than letting ``UserNotFoundError`` propagate."""
+    handler = MagicMock()
+    handler.fetch_user_profile = AsyncMock(return_value=None)
+
+    store = OperationStore(str(tmp_path / "operations.db"))
+    operation = await store.create_operation(
+        operation_type="user_posts_bulk_download",
+        subject_id="ghost-user",
+        status="pending",
+        message="scheduled",
+        metadata={"max_cursor": 0},
+    )
+
+    svc = _build_service(handler, operation_store=store)
+    await svc._run_bulk_download(operation.operation_id, "ghost-user", 0)
+
+    refreshed = await store.get_operation(operation.operation_id)
+    assert refreshed.status == "failed"
+    assert refreshed.error and "ghost-user" in refreshed.error
 
 
 @pytest.mark.asyncio
@@ -427,11 +530,11 @@ async def test_download_post_content_error() -> None:
         )
 
 
-# ── download_all_user_posts pagination guards ───────────────────────────
+# ── _run_bulk_download pagination guards ────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_download_all_user_posts_breaks_on_empty_aweme_list() -> None:
+async def test_run_bulk_download_breaks_on_empty_aweme_list(tmp_path) -> None:
     """An empty ``aweme_list`` with ``has_more=True`` must not spin the loop.
 
     Before the fix, a page with ``aweme_list=[]`` but ``has_more=True``
@@ -450,14 +553,22 @@ async def test_download_all_user_posts_breaks_on_empty_aweme_list() -> None:
     handler.fetch_user_profile = AsyncMock(return_value=profile)
     handler.get_or_add_user_data = AsyncMock(return_value=Path("/tmp/loop-user"))
 
+    store = OperationStore(str(tmp_path / "operations.db"))
+    operation = await store.create_operation(
+        operation_type="user_posts_bulk_download",
+        subject_id="loop-user",
+        status="pending",
+        message="scheduled",
+        metadata={"max_cursor": 0},
+    )
+
     with patch("dyvine.services.posts.AsyncUserDB") as mock_db:
         mock_ctx = MagicMock()
         mock_ctx.__aenter__ = AsyncMock(return_value=MagicMock())
         mock_ctx.__aexit__ = AsyncMock(return_value=False)
         mock_db.return_value = mock_ctx
 
-        svc = _build_service(handler)
-        svc.handler = handler
+        svc = _build_service(handler, operation_store=store)
 
         # Each invocation returns ``has_more=True`` and a fresh cursor, so
         # without the empty-batch guard the outer ``while True`` would
@@ -479,15 +590,19 @@ async def test_download_all_user_posts_breaks_on_empty_aweme_list() -> None:
             }
 
         with patch.object(svc, "_fetch_posts_batch", side_effect=fake_fetch):
-            result = await svc.download_all_user_posts("loop-user")
+            await svc._run_bulk_download(operation.operation_id, "loop-user", 0)
 
         # The first empty batch must short-circuit the loop.
         assert call_count == 1
-        assert result.total_downloaded == 0
+
+    refreshed = await svc.get_bulk_download_status(operation.operation_id)
+    assert refreshed.total_downloaded == 0
 
 
 @pytest.mark.asyncio
-async def test_download_all_user_posts_caps_pagination_under_sticky_cursor() -> None:
+async def test_run_bulk_download_caps_pagination_under_sticky_cursor(
+    tmp_path,
+) -> None:
     """A non-empty batch with a sticky cursor must terminate via ``max_pages``.
 
     Without the cap, the ``+1`` cursor advance keeps the loop running
@@ -505,14 +620,22 @@ async def test_download_all_user_posts_caps_pagination_under_sticky_cursor() -> 
     handler.fetch_user_profile = AsyncMock(return_value=profile)
     handler.get_or_add_user_data = AsyncMock(return_value=Path("/tmp/sticky-user"))
 
+    store = OperationStore(str(tmp_path / "operations.db"))
+    operation = await store.create_operation(
+        operation_type="user_posts_bulk_download",
+        subject_id="sticky-user",
+        status="pending",
+        message="scheduled",
+        metadata={"max_cursor": 0},
+    )
+
     with patch("dyvine.services.posts.AsyncUserDB") as mock_db:
         mock_ctx = MagicMock()
         mock_ctx.__aenter__ = AsyncMock(return_value=MagicMock())
         mock_ctx.__aexit__ = AsyncMock(return_value=False)
         mock_db.return_value = mock_ctx
 
-        svc = _build_service(handler)
-        svc.handler = handler
+        svc = _build_service(handler, operation_store=store)
 
         call_count = 0
 
@@ -537,7 +660,9 @@ async def test_download_all_user_posts_caps_pagination_under_sticky_cursor() -> 
         process_batch = AsyncMock()
         with patch.object(svc, "_fetch_posts_batch", side_effect=sticky_fetch):
             with patch.object(svc, "_process_posts_batch", new=process_batch):
-                result = await svc.download_all_user_posts("sticky-user")
+                await svc._run_bulk_download(
+                    operation.operation_id, "sticky-user", 0
+                )
 
         # max_pages = (100 // 20) * 2 + 20 = 30. The loop breaks when
         # ``page_count > max_pages``, so call_count should be at most 31.
@@ -546,15 +671,17 @@ async def test_download_all_user_posts_caps_pagination_under_sticky_cursor() -> 
         ), f"max_pages cap failed; loop ran {call_count} iterations"
         # Forward progress was made before the cap kicked in.
         assert process_batch.await_count == call_count
-        # ``total_downloaded`` is computed from ``download_stats`` which
-        # the patched ``_process_posts_batch`` never increments, so the
-        # response status must be FAILED. The important contract for
-        # this test is termination, not the stats.
-        assert result.total_downloaded == 0
+
+    refreshed = await svc.get_bulk_download_status(operation.operation_id)
+    # ``total_downloaded`` is computed from ``download_stats`` which the
+    # patched ``_process_posts_batch`` never increments, so the response
+    # status must be FAILED. The important contract for this test is
+    # termination, not the stats.
+    assert refreshed.total_downloaded == 0
 
 
 @pytest.mark.asyncio
-async def test_download_all_user_posts_stops_on_batch_error() -> None:
+async def test_run_bulk_download_stops_on_batch_error(tmp_path) -> None:
     """A persistent batch-level exception must not busy-loop.
 
     The previous ``except Exception: continue`` path swallowed the error
@@ -572,14 +699,22 @@ async def test_download_all_user_posts_stops_on_batch_error() -> None:
     handler.fetch_user_profile = AsyncMock(return_value=profile)
     handler.get_or_add_user_data = AsyncMock(return_value=Path("/tmp/error-user"))
 
+    store = OperationStore(str(tmp_path / "operations.db"))
+    operation = await store.create_operation(
+        operation_type="user_posts_bulk_download",
+        subject_id="error-user",
+        status="pending",
+        message="scheduled",
+        metadata={"max_cursor": 0},
+    )
+
     with patch("dyvine.services.posts.AsyncUserDB") as mock_db:
         mock_ctx = MagicMock()
         mock_ctx.__aenter__ = AsyncMock(return_value=MagicMock())
         mock_ctx.__aexit__ = AsyncMock(return_value=False)
         mock_db.return_value = mock_ctx
 
-        svc = _build_service(handler)
-        svc.handler = handler
+        svc = _build_service(handler, operation_store=store)
 
         call_count = 0
 
@@ -593,8 +728,78 @@ async def test_download_all_user_posts_stops_on_batch_error() -> None:
             raise RuntimeError("upstream flaky")
 
         with patch.object(svc, "_fetch_posts_batch", side_effect=failing_fetch):
-            result = await svc.download_all_user_posts("error-user")
+            await svc._run_bulk_download(operation.operation_id, "error-user", 0)
 
         assert call_count == 1
-        assert result.total_downloaded == 0
-        assert result.status == DownloadStatus.FAILED
+
+    refreshed = await svc.get_bulk_download_status(operation.operation_id)
+    assert refreshed.total_downloaded == 0
+    # The loop terminated with no successful downloads but did not raise,
+    # so the operation lands in ``failed`` status (mapped to FAILED).
+    assert refreshed.status == DownloadStatus.FAILED
+
+
+# ── get_bulk_download_status (async) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_bulk_download_status_returns_persisted_state(tmp_path) -> None:
+    store = OperationStore(str(tmp_path / "operations.db"))
+    operation = await store.create_operation(
+        operation_type="user_posts_bulk_download",
+        subject_id="poll-user",
+        status="running",
+        message="Bulk download in progress",
+        progress=42.5,
+        total_items=100,
+        completed_items=42,
+        download_path="/tmp/poll-user",
+        metadata={
+            "download_stats": {
+                "video": 30,
+                "images": 10,
+                "mixed": 2,
+            },
+            "download_path": "/tmp/poll-user",
+        },
+    )
+
+    svc = _build_service(operation_store=store)
+
+    response = await svc.get_bulk_download_status(operation.operation_id)
+    assert response.operation_id == operation.operation_id
+    assert response.status == DownloadStatus.IN_PROGRESS
+    assert response.sec_user_id == "poll-user"
+    assert response.download_path == "/tmp/poll-user"
+    assert response.total_posts == 100
+    assert response.downloaded_count[PostType.VIDEO] == 30
+    assert response.downloaded_count[PostType.IMAGES] == 10
+    assert response.downloaded_count[PostType.MIXED] == 2
+    # ``completed_items`` always wins when it exceeds the per-PostType sum.
+    assert response.total_downloaded == 42
+
+
+@pytest.mark.asyncio
+async def test_get_bulk_download_status_raises_for_unknown_id(tmp_path) -> None:
+    store = OperationStore(str(tmp_path / "operations.db"))
+    svc = _build_service(operation_store=store)
+
+    with pytest.raises(DownloadError):
+        await svc.get_bulk_download_status("missing-id")
+
+
+@pytest.mark.asyncio
+async def test_get_bulk_download_status_rejects_non_post_operation(
+    tmp_path,
+) -> None:
+    store = OperationStore(str(tmp_path / "operations.db"))
+    operation = await store.create_operation(
+        operation_type="livestream_download",
+        subject_id="room-1",
+        status="pending",
+        message="scheduled",
+    )
+
+    svc = _build_service(operation_store=store)
+    with pytest.raises(DownloadError):
+        await svc.get_bulk_download_status(operation.operation_id)

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -505,3 +505,211 @@ async def test_process_download_likes_reports_progress_as_indeterminate(
     refreshed = await service.get_download_status(operation.operation_id)
     assert refreshed.status == "completed"
     assert refreshed.completed_items == 1
+
+
+@pytest.mark.asyncio
+async def test_upload_directory_to_r2_counts_partial_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Three files, one upload error: helper must report (2 uploaded, 1 failed).
+
+    The new ``_upload_directory_to_r2`` helper centralises R2 upload
+    accounting so ``_finalize_status`` can downgrade to ``partial`` when
+    the loop completes with any failed uploads. Verifies the return tuple
+    matches the success/failure split and that failed local files stay on
+    disk while successful ones are unlinked.
+    """
+    from dyvine.services import users as users_mod
+
+    user_dir = tmp_path / "nick"
+    user_dir.mkdir()
+    file_ok_one = user_dir / "video1.mp4"
+    file_ok_one.write_bytes(b"a")
+    file_failing = user_dir / "video2.mp4"
+    file_failing.write_bytes(b"b")
+    file_ok_two = user_dir / "image1.jpg"
+    file_ok_two.write_bytes(b"c")
+
+    # Force the storage layer to raise on the second file only.
+    failing_target = file_failing.resolve()
+
+    async def fake_upload_file(
+        local_path: Path,
+        _r2_path: str,
+        _metadata: dict[str, str],
+        _content_type: str,
+    ) -> None:
+        if Path(local_path).resolve() == failing_target:
+            raise users_mod.ServiceError("simulated upload outage")
+
+    service = UserService()
+    service.storage.generate_ugc_path = MagicMock(return_value="r2/path")
+    service.storage.generate_metadata = MagicMock(return_value={"category": "posts"})
+    monkeypatch.setattr(service.storage, "upload_file", fake_upload_file)
+
+    user_data = MagicMock()
+    user_data.nickname = "nick"
+
+    uploaded, failed = await service._upload_directory_to_r2(
+        user_dir, user_id="user-123", user_data=user_data
+    )
+
+    assert (uploaded, failed) == (2, 1)
+    # Successfully uploaded files are unlinked; the failed one remains so
+    # the cleanup step can pick it up.
+    assert not file_ok_one.exists()
+    assert not file_ok_two.exists()
+    assert file_failing.exists()
+
+
+def test_cleanup_temp_dir_only_removes_target_subdirectory(tmp_path: Path) -> None:
+    """Cleanup must isolate per-task workspaces from sibling tasks.
+
+    The helper is invoked from a ``finally`` block so it has to be safe
+    against concurrent tasks owning their own siblings under the shared
+    ``temp_downloads`` parent. Verifies that wiping one task's directory
+    leaves the parent and the other task's workspace untouched.
+    """
+    from dyvine.services import users as users_mod
+
+    parent = tmp_path / "temp_downloads"
+    parent.mkdir()
+    target = parent / "task-target"
+    target.mkdir()
+    (target / "nested").mkdir()
+    (target / "nested" / "file.bin").write_bytes(b"x")
+
+    sibling = parent / "task-sibling"
+    sibling.mkdir()
+    sibling_file = sibling / "keep.bin"
+    sibling_file.write_bytes(b"y")
+
+    users_mod.UserService._cleanup_temp_dir(target)
+
+    assert not target.exists()
+    assert parent.exists(), "shared parent must survive cleanup"
+    assert sibling.exists(), "sibling task workspace must not be touched"
+    assert sibling_file.read_bytes() == b"y"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_downloads_use_isolated_temp_directories(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Two concurrent ``_process_download`` runs must not share files.
+
+    Schedules two downloads through ``asyncio.gather`` with distinct
+    ``user_id`` values and a stub fetcher that records which directory
+    f2 was asked to write into. Both invocations must see workspaces
+    rooted at ``temp_downloads/<task_id>`` and the cleanup branch must
+    leave neither task's files behind.
+    """
+    from dyvine.services import users as users_mod
+
+    monkeypatch.chdir(tmp_path)
+
+    seen_dirs: list[Path] = []
+
+    aweme_batch = MagicMock()
+    aweme_batch.has_aweme = True
+    aweme_batch.aweme_id = ["aw1"]
+    aweme_batch.has_more = False
+    aweme_batch.max_cursor = 0
+    aweme_batch._to_list = MagicMock(return_value=[])
+
+    async def fake_fetch_posts(*_args: Any, **_kwargs: Any) -> Any:
+        yield aweme_batch
+
+    class FakeDownloader:
+        async def create_download_tasks(
+            self,
+            _kwargs: dict[str, Any],
+            _items: list[Any],
+            user_dir: Path,
+        ) -> None:
+            # Record which workspace we were handed and drop a sentinel
+            # file so the test can later assert per-task isolation.
+            seen_dirs.append(Path(user_dir).parent)
+            (Path(user_dir) / f"file-{Path(user_dir).parent.name}.txt").write_text("x")
+
+    def make_handler(user_data: MagicMock) -> type:
+        class FakeHandler:
+            def __init__(self, _kwargs: dict) -> None:
+                self.downloader = FakeDownloader()
+
+            fetch_user_profile = AsyncMock(return_value=user_data)
+            fetch_user_post_videos = staticmethod(fake_fetch_posts)
+
+        return FakeHandler
+
+    user_data_a = MagicMock()
+    user_data_a.nickname = "alpha"
+    user_data_a.aweme_count = 1
+
+    user_data_b = MagicMock()
+    user_data_b.nickname = "bravo"
+    user_data_b.aweme_count = 1
+
+    handlers = iter([make_handler(user_data_a), make_handler(user_data_b)])
+
+    def handler_factory(kwargs: dict) -> Any:
+        return next(handlers)(kwargs)
+
+    monkeypatch.setattr(users_mod, "DouyinHandler", handler_factory)
+    monkeypatch.setattr(users_mod.asyncio, "sleep", AsyncMock())
+
+    service = UserService()
+    # Avoid contacting R2 in the concurrency test; the helper is unit
+    # tested directly above.
+    monkeypatch.setattr(
+        service,
+        "_upload_directory_to_r2",
+        AsyncMock(return_value=(0, 0)),
+    )
+
+    op_a = await service.operation_store.create_operation(
+        operation_type="user_content_download",
+        subject_id="alpha",
+        status="pending",
+        message="scheduled",
+    )
+    op_b = await service.operation_store.create_operation(
+        operation_type="user_content_download",
+        subject_id="bravo",
+        status="pending",
+        message="scheduled",
+    )
+
+    await asyncio.gather(
+        service._process_download(
+            op_a.operation_id,
+            user_id="alpha",
+            include_posts=True,
+            include_likes=False,
+            max_items=1,
+        ),
+        service._process_download(
+            op_b.operation_id,
+            user_id="bravo",
+            include_posts=True,
+            include_likes=False,
+            max_items=1,
+        ),
+    )
+
+    # The downloader was handed two distinct per-task workspaces, each
+    # rooted at ``temp_downloads/<task_id>``. ``TEMP_DOWNLOAD_ROOT`` is a
+    # relative path, so resolve both sides against the cwd before
+    # comparing.
+    assert len(seen_dirs) == 2
+    assert seen_dirs[0] != seen_dirs[1]
+    workspace_root = (tmp_path / users_mod.TEMP_DOWNLOAD_ROOT).resolve()
+    for directory in seen_dirs:
+        assert directory.resolve().parent == workspace_root
+        assert directory.name in {op_a.operation_id, op_b.operation_id}
+
+    # Cleanup ran for both tasks: each per-task workspace is gone, but
+    # the shared parent is preserved.
+    assert workspace_root.exists()
+    assert not (workspace_root / op_a.operation_id).exists()
+    assert not (workspace_root / op_b.operation_id).exists()

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -96,3 +96,28 @@ def test_service_container_requires_initialization(
     container = dependencies.ServiceContainer()
     with pytest.raises(RuntimeError, match="ServiceContainer has not been initialized"):
         _ = container.douyin_handler
+
+
+@pytest.mark.asyncio
+async def test_service_container_exposes_post_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The container must expose the bulk-download-aware ``PostService``.
+
+    The post service shares the operation store and background task
+    registry with the user and livestream services so the lifespan can
+    drain in-flight bulk downloads alongside the other long-running
+    workflows.
+    """
+    monkeypatch.setattr(
+        dependencies, "DouyinHandler", lambda kwargs: DummyHandler(kwargs)
+    )
+
+    container = dependencies.ServiceContainer()
+    await container.initialize()
+
+    post_service = container.post_service
+    assert isinstance(post_service, dependencies.PostService)
+    assert post_service.operation_store is container.operation_store
+    assert post_service._task_registry is container._background_tasks
+    assert dependencies.get_post_service.__name__ == "get_post_service"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -185,9 +185,16 @@ def test_invalid_request_id_is_regenerated(monkeypatch: pytest.MonkeyPatch) -> N
         uuid.UUID(response.headers["X-Correlation-ID"])
 
 
-def test_health_check_degraded_when_r2_missing(
+def test_health_check_returns_200_when_r2_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """``/health`` must stay informational and never gate on dependencies.
+
+    The dependency-aware gate lives on ``/readyz``; ``/health`` is a
+    metrics aggregator for ops dashboards and is required to return
+    ``200 OK`` with ``status == "ok"`` even when optional dependency
+    credentials (Douyin cookie, R2 settings) are not configured.
+    """
     with TestClient(app) as client:
         monkeypatch.setattr(settings.douyin, "cookie", "cookie")
         _configure_r2(
@@ -203,10 +210,35 @@ def test_health_check_degraded_when_r2_missing(
 
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "degraded"
+        assert data["status"] == "ok"
+        # Dependency snapshot is informational only.
+        assert data["dependencies"]["r2_storage"] == "missing_credentials"
         correlation_id = data["correlation_id"]
         assert correlation_id == response.headers["X-Correlation-ID"]
         uuid.UUID(correlation_id)
+
+
+def test_health_check_returns_200_when_douyin_cookie_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``/health`` must remain a metrics aggregator that returns 200.
+
+    Even with no Douyin cookie configured (which previously flipped the
+    legacy status to ``"unhealthy"`` and forced a 503), the endpoint now
+    surfaces the missing credential through the informational
+    ``dependencies`` map while keeping the HTTP contract at ``200 OK``.
+    """
+    with TestClient(app) as client:
+        monkeypatch.setattr(settings.douyin, "cookie", "")
+        _configure_r2(monkeypatch)
+
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["dependencies"]["douyin_api"] == "missing_credentials"
+        assert data["memory_pressure"] in {"normal", "high"}
 
 
 def test_metrics_endpoint_exposed() -> None:


### PR DESCRIPTION
## Summary
Address P0/P1 issues raised in the post-#47 main-branch review across concurrency safety, API consistency, health-probe semantics, time measurement, and test isolation. The follow-up commit `bcca11f` clears the `quality` CI lane and absorbs the bot review feedback (progress clamp, profile-fetch dedupe).

## Related
- Post-#47 main-branch review (no upstream issue)

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| `services/users.py` `_process_download` | 373-line god method, shared `temp_downloads/` | five helpers, per-task subdirectory, R2 failures surfaced, partial progress clamped to <=100 | P0-1 / P1-2 / P1-3 / P2-3 + review fix |
| `routers/posts.py` `download_user_posts` | sync-blocks until done | `202` + `operation_id`, async `_run_bulk_download`, new `GET /posts/operations/{id}` | P1-1 |
| `services/posts.py` `start_bulk_download` | profile fetched twice (validation + bulk loop) | profile fetched once and forwarded to the background coroutine | review fix |
| `main.py` `/health` | dependency-driven, returns 503 on missing creds | always 200, monitoring summary only | P1-5 |
| `main.py` + `services/storage.py` time measurement | `time.time()` for elapsed | `perf_counter()` / `monotonic()` | P1-4 |
| `main.py` `psutil` import | hot-path import | module-level | P2-5 |
| `core/background.py` `spawn_or_fallback` | silent fallback | warns when registry missing | P2-4 |
| `tests/conftest.py` SecuritySettings env | leaked developer `.env` | autouse fixture strips `SECURITY_*` | P0-2 |
| `.env.example` CORS default | `["*"]` | `["http://localhost:3000"]` + production note | P2-6 |

## Details
### `_process_download` refactor
- Design/Spec: per-task temp directory prevents concurrent downloads from deleting one another's files; R2 upload failure count is now persisted to the operation `error` field with `status="partial"` even when page count completes.
- Implementation notes: helpers `_build_handler_kwargs`, `_resolve_total_posts`, `_upload_directory_to_r2`, `_finalize_status`, `_cleanup_temp_dir`. `_process_download` signature unchanged; logging extras preserved. The `_finalize_status` partial branch clamps `progress` to <=100 so a posts+likes run cannot persist a 130%-style value when an upload also fails.
- Reviewer focus: `try`/`finally` cleanup symmetry; failure-count merge logic in `_finalize_status`; concurrent-download isolation test.

### Bulk posts download async model
- Design/Spec: aligns with `start_download` / `LivestreamService.download_stream` pattern using `OperationStore` + `BackgroundTaskRegistry`. The validated profile is forwarded to `_run_bulk_download` so the bulk loop does not duplicate the upstream call.
- Implementation notes: `PostService.start_bulk_download` returns immediately with a pending operation; `_run_bulk_download(profile=...)` performs the work and keeps a defensive guard against invalid payloads; `get_bulk_download_status` reads back state. `BulkDownloadResponse` gains optional `operation_id`. `DownloadStatus` adds `PENDING` / `IN_PROGRESS`. `PostService` now wired through `ServiceContainer`.
- Reviewer focus: `download_stats` JSON round-trip in operation metadata; HTTP status code change from 200 to 202 on `download_user_posts`; new `_run_bulk_download(profile=...)` keyword-only argument.

### `/health` demotion
- Design/Spec: `/livez`, `/readyz`, `/startupz` already cover liveness / readiness / startup; `/health` now returns ops-monitoring fields without a 503 path.
- Implementation notes: dependency status retained as informational `dependencies` map plus `memory_pressure` indicator; uptime uses `monotonic` clock, immune to NTP jumps.
- Reviewer focus: `k8s/base/core/deployment.yaml` already targets `/livez`,`/readyz`,`/startupz` (verified) so no ops change required; alerting dashboards reading `/health` for liveness should switch to `/readyz`.

### Time measurement
- Design/Spec: monotonic clocks for elapsed durations; wall-clock retained only for `timestamp` payloads.
- Implementation notes: `app.state.start_time` renamed to `app.state.start_monotonic`; `getattr` fallback in `health_check` for unit tests bypassing the lifespan.
- Reviewer focus: no external callers of `app.state.start_time` were found in the repository.

### `spawn_or_fallback` warning
- Design/Spec: production must always supply a `BackgroundTaskRegistry`; a missing registry causes shutdown drain to skip the task.
- Implementation notes: `logger.warning` with `task_name` extra; fallback behavior unchanged so tests that pass `None` still work.

### Test isolation
- Design/Spec: `SecuritySettings` defaults are sentinel `change-me-in-production`; tests must assert against the sentinel, not the developer's real secret.
- Implementation notes: autouse fixture deletes `SECURITY_SECRET_KEY` and `SECURITY_API_KEY` before each test runs.

### CORS default
- Design/Spec: production deployments must replace the allowlist; localhost default is dev-friendly.
- Implementation notes: comment block above the variable explains the production requirement.

## Testing
- `uv run black --check src/dyvine tests` -- 46 files would be left unchanged
- `uv run ruff check src/dyvine tests` -- All checks passed!
- `uv run mypy src/dyvine` -- Success: no issues found in 23 source files
- `uv run pytest -q` -- 318 passed in 10.88s (15 new tests covering concurrency isolation, partial R2 failure, bulk download operation lifecycle, async router contract, dependency wiring, and the relaxed `/health` contract; the disappearing-user test now exercises the defensive guard via `profile=None`)
- Manual steps: not run (changes verified via the expanded unit suite)

## Screenshots / Notes
- Not applicable

## Breaking changes
- `POST /api/v1/posts/users/{user_id}/posts:download` now returns `202` with a pending `BulkDownloadResponse` (including `operation_id`) instead of synchronously waiting for the bulk download to complete. Callers that relied on synchronous response semantics must poll `GET /api/v1/posts/operations/{operation_id}`.
- The same endpoint also changes intent persistence: previously, a client disconnect implicitly cancelled the download because the work happened inline; now the bulk download runs in the background registry and continues to completion regardless of the original client connection. Operators expecting client-disconnect cancellation must drive cancellation via the operation API.
- `/health` no longer returns 503 on missing Douyin/R2 credentials; orchestrators relying on `/health` for liveness/readiness should switch to `/livez` / `/readyz` (k8s base manifests already do).
- `app.state.start_time` renamed to `app.state.start_monotonic` (internal; no external callers found in the repository).

## Risks and rollout
- Bulk posts download contract change -- coordinate with API consumers; documented in the OpenAPI schema via the new fields.
- Per-task temp directories increase fanout into `temp_downloads/` -- cleanup path covers self-only; orphan dirs from crashed processes should be cleared by deployment housekeeping.
- `/health` demotion may surprise dashboards that interpret 503 as "down" -- update alerts to use `/readyz` if they read `/health` for availability.
- Background task lifetime change for bulk downloads -- update SDKs/clients to poll `GET /posts/operations/{id}` instead of relying on connection lifetime.

## Followup (deferred to next PR)
- `_run_bulk_download` is still ~145 lines; the same helper-extraction treatment applied to `_process_download` should follow.
- `_upload_directory_to_r2` uploads serially; switching to bounded `asyncio.gather` would exercise the existing 16-worker R2 executor.
- Move `temp_downloads/` under `data/douyin/temp_downloads` to align with `operations.db`.
- Add coverage for the 17 lines flagged by Codecov (mostly `_run_bulk_download` except branches and `get_bulk_download_status` metadata fallbacks).

## Checklist
- [x] Tests added/updated if needed
- [ ] Docs updated if needed
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted