### PR TITLE
fix(posts): persist runtime bulk download stats

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,6 +1,6 @@
 # Architecture Diagrams Overview
 
-_Last Updated: 2026-04-17_
+_Last Updated: 2026-05-06_
 
 ## Summary
 
@@ -18,6 +18,9 @@ These diagrams describe the current production architecture and must be updated 
 
 - Layered architecture with explicit operation tracking for asynchronous downloads
 - Async/await request handling with persistent operation state
+- Background post bulk downloads persist per-PostType counters in operation metadata
+  during progress updates so polling clients receive consistent totals while work
+  is still running.
 - Dedicated liveness, readiness, and startup probes
 - Prometheus metrics exposed through an ASGI application
 - Structured error handling and request-scoped correlation tracking

--- a/docs/architecture/sequence.md
+++ b/docs/architecture/sequence.md
@@ -1,10 +1,10 @@
 # Sequence Diagram
 
-_Last Updated: 2026-04-17_
+_Last Updated: 2026-05-06_
 
 ## Description
 
-Sequence of interactions for livestream download and standard API requests, showing component communications.
+Sequence of interactions for livestream download, post bulk download, and standard API requests, showing component communications.
 
 <!--@auto:diagram:seq:start-->
 
@@ -13,6 +13,7 @@ sequenceDiagram
     participant C as Client
     participant R as FastAPI Router
     participant LS as LivestreamService
+    participant PS as PostService
     participant US as UserService
     participant OP as OperationStore
     participant F2 as f2 / Douyin API
@@ -45,6 +46,26 @@ sequenceDiagram
     DL->>F2: create_stream_tasks()
     F2-->>DL: stream segments
     DL->>OP: update status / progress / result
+
+    C->>R: POST /posts/users/{user_id}/posts:download
+    R->>PS: start_bulk_download(user_id)
+    PS->>F2: fetch user profile
+    F2-->>PS: profile data
+    PS->>OP: create operation
+    PS-->>R: BulkDownloadResponse
+    R-->>C: 202 {operation_id: "...", status: "pending"}
+
+    Note over PS: Background post pagination and downloads run asynchronously
+    PS->>F2: fetch posts page
+    F2-->>PS: aweme_list + pagination cursor
+    PS->>DL: create_download_tasks()
+    PS->>OP: update status / progress / per-PostType download_stats
+    C->>R: GET /posts/operations/{operation_id}
+    R->>PS: get_bulk_download_status(operation_id)
+    PS->>OP: get operation
+    OP-->>PS: operation metadata with download_stats
+    PS-->>R: BulkDownloadResponse
+    R-->>C: current totals and per-PostType counts
 ```
 
 <!--@auto:diagram:seq:end-->

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -467,6 +467,12 @@ class PostService:
                         "completed_items": total_downloaded,
                         "total_items": total_posts,
                         "message": "Bulk download in progress",
+                        "metadata": {
+                            "max_cursor": max_cursor,
+                            "download_stats": _serialize_download_stats(download_stats),
+                            "download_path": download_path,
+                            "total_posts": total_posts,
+                        },
                     }
                     if progress is not None:
                         update_fields["progress"] = progress

--- a/tests/services/test_post_service.py
+++ b/tests/services/test_post_service.py
@@ -748,6 +748,93 @@ async def test_run_bulk_download_stops_on_batch_error(tmp_path) -> None:
     assert refreshed.status == DownloadStatus.FAILED
 
 
+# ── runtime polling consistency ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_bulk_download_persists_runtime_download_stats(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Runtime progress updates include the per-type counters clients poll."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    handler = MagicMock()
+    profile = MagicMock()
+    profile.aweme_count = 2
+    profile.nickname = "RuntimeUser"
+    user_path = tmp_path / "runtime-user"
+    handler.fetch_user_profile = AsyncMock(return_value=profile)
+    handler.get_or_add_user_data = AsyncMock(return_value=user_path)
+
+    store = OperationStore(str(tmp_path / "operations.db"))
+    operation = await store.create_operation(
+        operation_type="user_posts_bulk_download",
+        subject_id="runtime-user",
+        status="pending",
+        message="scheduled",
+        metadata={"max_cursor": 0},
+    )
+
+    runtime_metadata_samples: list[dict[str, Any] | None] = []
+    original_update = store.update_operation
+
+    async def capture_update(operation_id: str, **fields: Any) -> Any:
+        if (
+            fields.get("message") == "Bulk download in progress"
+            and fields.get("completed_items", 0) > 0
+        ):
+            runtime_metadata_samples.append(fields.get("metadata"))
+        return await original_update(operation_id, **fields)
+
+    async def process_batch(
+        posts: dict[str, Any],
+        download_stats: dict[PostType, int],
+        path: Path,
+    ) -> None:
+        assert path == user_path
+        download_stats[PostType.VIDEO] += 1
+        download_stats[PostType.IMAGES] += 1
+
+    monkeypatch.setattr(store, "update_operation", capture_update)
+
+    with patch("dyvine.services.posts.AsyncUserDB") as mock_db:
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_db.return_value = mock_ctx
+
+        svc = _build_service(handler, operation_store=store)
+        batch = {
+            "aweme_list": [
+                {"aweme_id": "video-1", "aweme_type": 0},
+                {"aweme_id": "image-1", "aweme_type": 0},
+            ],
+            "has_more": False,
+            "max_cursor": 0,
+        }
+        with patch.object(svc, "_fetch_posts_batch", new=AsyncMock(return_value=batch)):
+            with patch.object(svc, "_process_posts_batch", side_effect=process_batch):
+                await svc._run_bulk_download(
+                    operation.operation_id, "runtime-user", 0, profile=profile
+                )
+
+    assert runtime_metadata_samples
+    runtime_metadata = runtime_metadata_samples[-1]
+    assert runtime_metadata is not None
+    assert runtime_metadata["max_cursor"] == 0
+    assert runtime_metadata["download_path"] == str(user_path)
+    assert runtime_metadata["total_posts"] == 2
+    assert runtime_metadata["download_stats"]["video"] == 1
+    assert runtime_metadata["download_stats"]["images"] == 1
+
+    refreshed = await svc.get_bulk_download_status(operation.operation_id)
+    assert refreshed.total_downloaded == 2
+    assert refreshed.downloaded_count[PostType.VIDEO] == 1
+    assert refreshed.downloaded_count[PostType.IMAGES] == 1
+
+
 # ── get_bulk_download_status (async) ────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Persist per-PostType bulk download counters during runtime progress updates so polling clients receive consistent aggregate and typed totals while a job is still running.

## Related
- Not applicable

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| Bulk download progress metadata | Runtime updates only persisted aggregate progress fields | Runtime updates also persist `download_stats`, `download_path`, `total_posts`, and `max_cursor` | Keeps `total_downloaded` and `downloaded_count` consistent during polling |
| Service tests | No runtime metadata regression coverage | Added a focused regression test for runtime per-type stats persistence | Covers the review-reported inconsistency |
| Architecture docs | Generic async operation tracking | Documents post bulk download per-PostType metadata persistence | Keeps docs aligned with implementation |

## Details
### Updates bulk download progress metadata from aggregate-only to per-type counters
- Design/Spec: Runtime operation metadata should expose the same counter shape as terminal metadata so polling responses remain internally consistent.
- Implementation notes: `_run_bulk_download` now writes the current serialized `download_stats` snapshot during each successful in-progress update.
- Reviewer focus: Confirm metadata writes preserve terminal behavior and do not change public response fields.

### Updates regression coverage from status-only polling to runtime counter consistency
- Design/Spec: A running operation with completed items should also expose the matching per-type counters.
- Implementation notes: The new service test captures runtime `update_operation` metadata and verifies the polled response totals.
- Reviewer focus: Check that the test exercises the pre-terminal update path, not only the final update.

### Updates architecture docs from generic tracking to post bulk metadata tracking
- Design/Spec: Architecture documentation should describe production behavior for async operation progress.
- Implementation notes: The sequence diagram now includes post bulk download polling and per-PostType metadata updates.
- Reviewer focus: Confirm the docs stay high-level and match the service behavior.

## Testing
- `uv run pytest -q tests/services/test_post_service.py -q` — 42 passed
- `uv run pytest -q` — 319 passed
- `uv run ruff check src/dyvine/services/posts.py tests/services/test_post_service.py` — passed
- `uv run black --check src/dyvine/services/posts.py tests/services/test_post_service.py` — passed
- `git diff --check` — passed
- Manual steps: Not run

## Screenshots / Notes
Not applicable

## Breaking changes
Not applicable

## Risks and rollout
- Runtime progress updates write a slightly larger metadata payload — the payload is limited to fixed-size counters and existing bulk download metadata fields.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted
