### PR TITLE
fix(runtime): batch-error terminal state and review followups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,12 @@ API_PROJECT_NAME="Dyvine API"
 API_VERSION=1.0.0
 API_PREFIX="/api/v1"
 API_RATE_LIMIT_PER_SECOND=10
-# Production deployments MUST replace the wildcard with an explicit
-# allowlist of trusted browser origins. ``["*"]`` disables credentialed
-# CORS automatically (see ``main.py`` middleware), but it still exposes
-# the API to any origin and is suitable for local development only.
+# Production deployments MUST replace this localhost default with an
+# explicit allowlist of trusted browser origins. ``["*"]`` is accepted
+# but automatically disables credentialed CORS (see ``main.py``
+# middleware) and still exposes the API to any origin, so it is suitable
+# for local development only. Omitting this variable falls back to the
+# Pydantic default ``["http://localhost:3000"]``.
 API_CORS_ORIGINS=["http://localhost:3000"]
 API_OPERATION_DB_PATH=data/douyin/state/operations.db
 

--- a/src/dyvine/core/logging.py
+++ b/src/dyvine/core/logging.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any
 
+import psutil
+
 from .settings import settings
 
 # Module-level ContextVars shared by every ``ContextLogger`` instance.
@@ -134,8 +136,6 @@ class ContextLogger:
 
     @asynccontextmanager
     async def track_memory(self, operation: str) -> AsyncGenerator[None, None]:
-        import psutil
-
         process = psutil.Process()
         start_mem = process.memory_info().rss
         try:

--- a/src/dyvine/core/settings.py
+++ b/src/dyvine/core/settings.py
@@ -63,7 +63,14 @@ class APISettings(BaseSettings):
         default=10, ge=1, description="API rate limiting threshold per second"
     )
     cors_origins: list[str] = Field(
-        default=["*"], description="List of allowed CORS origins"
+        default_factory=lambda: ["http://localhost:3000"],
+        description=(
+            "Allowed browser origins. Defaults to localhost development; "
+            "production deployments must replace this with an explicit "
+            'allowlist via the ``API_CORS_ORIGINS`` env var. ``["*"]`` is '
+            "accepted but disables credentialed CORS automatically (see "
+            "``main.py`` middleware)."
+        ),
     )
     operation_db_path: str = Field(
         default="data/douyin/state/operations.db",

--- a/src/dyvine/routers/posts.py
+++ b/src/dyvine/routers/posts.py
@@ -304,17 +304,17 @@ async def download_user_posts(
         logger.warning("User not found", extra={"user_id": user_id})
         raise HTTPException(status_code=404, detail=str(e)) from e
 
-    except DownloadError as e:
-        logger.error("Download failed", extra={"user_id": user_id, "error": str(e)})
-        raise HTTPException(status_code=500, detail=str(e)) from e
-
     except ServiceError as e:
-        # ``PostServiceError`` (a ``ServiceError`` that is not a
-        # ``DownloadError``) is raised when the upstream profile fetch fails
-        # before the operation record can be created. Surface the service-
-        # level message so clients can distinguish "upstream unavailable"
-        # from a generic crash, instead of the opaque ``Internal server error``
-        # the bare ``Exception`` branch would emit.
+        # ``start_bulk_download`` raises ``PostServiceError`` (an alias for
+        # ``ServiceError``) when the upstream profile fetch fails before
+        # the operation record can be created. 502 surfaces the upstream
+        # nature of the failure to clients instead of the opaque
+        # ``Internal server error`` the bare ``Exception`` branch would
+        # emit, while still letting the response body carry the original
+        # message for debugging. ``DownloadError`` is also a
+        # ``ServiceError``, so any future download-layer failure routed
+        # through this handler is mapped to the same status — keep it
+        # there until a finer mapping is justified.
         logger.error(
             "Bulk download scheduling failed",
             extra={"user_id": user_id, "error": str(e)},

--- a/src/dyvine/routers/posts.py
+++ b/src/dyvine/routers/posts.py
@@ -37,7 +37,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 
 from ..core.decorators import handle_errors
 from ..core.dependencies import get_post_service
-from ..core.exceptions import DownloadError, UserNotFoundError
+from ..core.exceptions import DownloadError, ServiceError, UserNotFoundError
 from ..core.logging import ContextLogger
 from ..schemas.posts import BulkDownloadResponse, PostDetail
 from ..services.posts import PostService
@@ -307,6 +307,19 @@ async def download_user_posts(
     except DownloadError as e:
         logger.error("Download failed", extra={"user_id": user_id, "error": str(e)})
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+    except ServiceError as e:
+        # ``PostServiceError`` (a ``ServiceError`` that is not a
+        # ``DownloadError``) is raised when the upstream profile fetch fails
+        # before the operation record can be created. Surface the service-
+        # level message so clients can distinguish "upstream unavailable"
+        # from a generic crash, instead of the opaque ``Internal server error``
+        # the bare ``Exception`` branch would emit.
+        logger.error(
+            "Bulk download scheduling failed",
+            extra={"user_id": user_id, "error": str(e)},
+        )
+        raise HTTPException(status_code=502, detail=str(e)) from e
 
     except Exception as e:
         logger.exception(

--- a/src/dyvine/schemas/posts.py
+++ b/src/dyvine/schemas/posts.py
@@ -135,9 +135,7 @@ class BulkDownloadResponse(BaseModel):
         error_details: Details of any errors encountered
     """
 
-    operation_id: str | None = Field(
-        default=None, description="Operation tracking identifier"
-    )
+    operation_id: str = Field(..., description="Operation tracking identifier")
     sec_user_id: str = Field(..., description="Target user's identifier")
     download_path: str | None = Field(
         default=None,

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -352,6 +352,8 @@ class PostService:
         """
         download_stats: dict[PostType, int] = dict.fromkeys(PostType, 0)
         download_path: str | None = None
+        batch_errored = False
+        batch_error_message: str | None = None
 
         aweme_count = getattr(profile, "aweme_count", 0)
         total_posts = aweme_count if isinstance(aweme_count, int) else 0
@@ -506,6 +508,8 @@ class PostService:
                             "operation_id": operation_id,
                         },
                     )
+                    batch_errored = True
+                    batch_error_message = str(batch_error)
                     break
 
         except UserNotFoundError as e:
@@ -549,11 +553,28 @@ class PostService:
             )
             return
 
-        # Success / partial-success classification matches
-        # :meth:`_create_download_response` so the polling response surfaces
-        # the same status the synchronous implementation used to return.
+        # Terminal classification. The batch-error branch must take precedence
+        # over the count-based classifier: otherwise an upstream failure on
+        # the very first batch of a zero-post user would fall through as
+        # ``completed`` (because ``0 == 0``), and a partial run interrupted by
+        # an error would surface as ``partial`` with an empty ``error`` field
+        # — both of which lose the failure signal clients rely on.
         total_downloaded = sum(download_stats.values())
-        if total_downloaded == total_posts:
+        terminal_error: str | None = None
+        if batch_errored:
+            terminal_error = batch_error_message
+            if total_downloaded > 0:
+                final_status = "partial"
+                terminal_message = (
+                    "Bulk download interrupted by upstream error: "
+                    f"{total_downloaded}/{total_posts} posts"
+                )
+            else:
+                final_status = "failed"
+                terminal_message = (
+                    "Bulk download failed before any posts were downloaded"
+                )
+        elif total_downloaded == total_posts:
             final_status = "completed"
             terminal_message = (
                 f"Bulk download completed: {total_downloaded}/{total_posts} posts"
@@ -582,6 +603,7 @@ class PostService:
             completed_items=total_downloaded,
             total_items=total_posts,
             download_path=download_path,
+            error=terminal_error,
             metadata={
                 "max_cursor": max_cursor,
                 "download_stats": _serialize_download_stats(download_stats),
@@ -604,10 +626,10 @@ class PostService:
             DownloadError: If no bulk download operation matches the
                 provided identifier.
         """
-        try:
-            op = await self.operation_store.get_operation(operation_id)
-        except DownloadError as e:
-            raise DownloadError(f"Bulk download task {operation_id} not found") from e
+        # ``OperationStore.get_operation`` already raises ``DownloadError``
+        # with a descriptive message when the row is missing; re-wrapping
+        # here would just discard the original ``error_code`` and ``details``.
+        op = await self.operation_store.get_operation(operation_id)
 
         if op.operation_type != "user_posts_bulk_download":
             raise DownloadError(f"Bulk download task {operation_id} not found")
@@ -851,62 +873,6 @@ class PostService:
                     )
                 )
         return image_info if image_info else None
-
-    def _create_download_response(
-        self,
-        sec_user_id: str,
-        download_path: str,
-        total_posts: int,
-        download_stats: dict[PostType, int],
-        error_details: str | None = None,
-    ) -> BulkDownloadResponse:
-        """Create the response object for a bulk download operation.
-
-        Args:
-            sec_user_id (str): Unique identifier of the user.
-            download_path (str): Path to the directory where the content was
-                downloaded.
-            total_posts (int): Total number of posts for the user.
-            download_stats (Dict[PostType, int]): Dictionary containing the
-                download statistics for each post type.
-
-        Returns:
-            BulkDownloadResponse: Object containing the results of the bulk
-                download operation.
-        """
-        total_downloaded = sum(download_stats.values())
-
-        status = (
-            DownloadStatus.SUCCESS
-            if total_downloaded == total_posts
-            else (
-                DownloadStatus.PARTIAL_SUCCESS
-                if total_downloaded > 0
-                else DownloadStatus.FAILED
-            )
-        )
-
-        message = (
-            f"Downloaded {total_downloaded} out of {total_posts} posts. "
-            f"(Videos: {download_stats[PostType.VIDEO]}, "
-            f"Images: {download_stats[PostType.IMAGES]}, "
-            f"Mixed: {download_stats[PostType.MIXED]}, "
-            f"Lives: {download_stats[PostType.LIVE]}, "
-            f"Collections: {download_stats[PostType.COLLECTION]}, "
-            f"Stories: {download_stats[PostType.STORY]}) "
-            f"Files saved to {download_path}"
-        )
-
-        return BulkDownloadResponse(
-            sec_user_id=sec_user_id,
-            download_path=download_path,
-            total_posts=total_posts,
-            downloaded_count=download_stats,
-            total_downloaded=total_downloaded,
-            status=status,
-            message=message,
-            error_details=error_details,
-        )
 
 
 # ----------------------------------------------------------------------

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -64,6 +64,7 @@ Performance Considerations:
 
 import asyncio
 import re
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -536,16 +537,13 @@ class UserService:
         """
         if temp_dir is None or not temp_dir.exists():
             return
-        try:
-            for file in sorted(temp_dir.glob("**/*"), reverse=True):
-                if file.is_file():
-                    file.unlink()
-            for sub_dir in sorted(temp_dir.glob("**/*"), reverse=True):
-                if sub_dir.is_dir():
-                    sub_dir.rmdir()
-            temp_dir.rmdir()
-        except Exception as e:
-            logger.error(f"Failed to clean up temp directory: {str(e)}")
+        # ``shutil.rmtree`` walks the tree atomically (single OS call per
+        # entry) so a file created mid-cleanup cannot strand a non-empty
+        # subdirectory the way a hand-rolled two-pass glob walker would.
+        # ``ignore_errors=True`` keeps the helper safe to call from a
+        # ``finally`` block when partial state may already have been torn
+        # down by another task.
+        shutil.rmtree(temp_dir, ignore_errors=True)
 
     async def _process_download(
         self,

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -537,13 +537,26 @@ class UserService:
         """
         if temp_dir is None or not temp_dir.exists():
             return
-        # ``shutil.rmtree`` walks the tree atomically (single OS call per
-        # entry) so a file created mid-cleanup cannot strand a non-empty
-        # subdirectory the way a hand-rolled two-pass glob walker would.
-        # ``ignore_errors=True`` keeps the helper safe to call from a
-        # ``finally`` block when partial state may already have been torn
-        # down by another task.
-        shutil.rmtree(temp_dir, ignore_errors=True)
+
+        # ``shutil.rmtree`` handles nested files in a single walk so a file
+        # created mid-cleanup cannot strand a non-empty subdirectory the
+        # way a hand-rolled two-pass glob walker would. The ``onexc``
+        # callback (Python 3.12+) keeps the helper safe to call from a
+        # ``finally`` block — a cleanup failure must never mask the
+        # original error — but records each failed entry so a permission
+        # issue on a production volume is still observable in logs
+        # instead of silently leaving orphaned files behind.
+        def _on_rmtree_error(func: Any, path: str, exc: BaseException) -> None:
+            logger.warning(
+                "Failed to remove temp file during workspace cleanup",
+                extra={
+                    "path": path,
+                    "operation": getattr(func, "__name__", str(func)),
+                    "error": str(exc),
+                },
+            )
+
+        shutil.rmtree(temp_dir, onexc=_on_rmtree_error)
 
     async def _process_download(
         self,

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -545,16 +545,13 @@ class UserService:
         # ``finally`` block — a cleanup failure must never mask the
         # original error — but records each failed entry so a permission
         # issue on a production volume is still observable in logs
-        # instead of silently leaving orphaned files behind.
-        def _on_rmtree_error(func: Any, path: str | bytes, exc: BaseException) -> None:
-            # ``shutil`` documents ``path`` as ``str`` for path-argument
-            # syscalls (``os.unlink``/``os.rmdir``) but it can arrive as
-            # ``bytes`` when ``os.scandir``/``os.lstat`` surfaces a path
-            # the filesystem returned in a non-UTF-8 encoding. Decode
-            # defensively so structured logs stay text and downstream
-            # log shippers do not have to special-case ``bytes``.
-            if isinstance(path, bytes):
-                path = path.decode("utf-8", errors="replace")
+        # instead of silently leaving orphaned files behind. ``path`` is
+        # typed ``str``: on Linux + Python 3.12 ``shutil.rmtree`` runs
+        # the fd-based walker which calls ``os.fsdecode(path)`` at entry
+        # before invoking ``onexc`` (CPython ``shutil.py``), so a bytes
+        # path the kernel surfaced on a non-UTF-8 filesystem never
+        # reaches this callback.
+        def _on_rmtree_error(func: Any, path: str, exc: BaseException) -> None:
             logger.warning(
                 "Failed to remove temp file during workspace cleanup",
                 extra={

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -546,7 +546,15 @@ class UserService:
         # original error — but records each failed entry so a permission
         # issue on a production volume is still observable in logs
         # instead of silently leaving orphaned files behind.
-        def _on_rmtree_error(func: Any, path: str, exc: BaseException) -> None:
+        def _on_rmtree_error(func: Any, path: str | bytes, exc: BaseException) -> None:
+            # ``shutil`` documents ``path`` as ``str`` for path-argument
+            # syscalls (``os.unlink``/``os.rmdir``) but it can arrive as
+            # ``bytes`` when ``os.scandir``/``os.lstat`` surfaces a path
+            # the filesystem returned in a non-UTF-8 encoding. Decode
+            # defensively so structured logs stay text and downstream
+            # log shippers do not have to special-case ``bytes``.
+            if isinstance(path, bytes):
+                path = path.decode("utf-8", errors="replace")
             logger.warning(
                 "Failed to remove temp file during workspace cleanup",
                 extra={

--- a/tests/routers/test_posts_router.py
+++ b/tests/routers/test_posts_router.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 
 from dyvine.core.exceptions import (
     DownloadError,
+    ServiceError,
     UserNotFoundError,
 )
 from dyvine.schemas.posts import (
@@ -178,22 +179,51 @@ async def test_download_user_posts_user_not_found(
 
 
 @pytest.mark.asyncio
-async def test_download_user_posts_download_error(
+async def test_download_user_posts_service_error_returns_502_with_detail(
     mock_post_service: MagicMock,
 ) -> None:
+    """``PostServiceError`` raised from ``start_bulk_download`` (the typical
+    path when the upstream profile fetch fails) must surface as a 502 with
+    the original message in ``detail`` rather than as the opaque 500 the
+    bare ``Exception`` branch emits.
+    """
+    from dyvine.routers.posts import download_user_posts
+
+    mock_post_service.start_bulk_download.side_effect = ServiceError(
+        "upstream profile fetch timed out"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await download_user_posts(service=mock_post_service, user_id="u1", max_cursor=0)
+    assert exc_info.value.status_code == 502
+    assert "upstream profile fetch timed out" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_download_user_posts_download_error_routes_through_service_error(
+    mock_post_service: MagicMock,
+) -> None:
+    """``DownloadError`` is a ``ServiceError`` subclass, so after the dead
+    ``except DownloadError`` branch was removed it must flow through the
+    ``ServiceError`` handler and land on 502 with the underlying detail.
+    """
     from dyvine.routers.posts import download_user_posts
 
     mock_post_service.start_bulk_download.side_effect = DownloadError("fail")
 
     with pytest.raises(HTTPException) as exc_info:
         await download_user_posts(service=mock_post_service, user_id="u1", max_cursor=0)
-    assert exc_info.value.status_code == 500
+    assert exc_info.value.status_code == 502
+    assert "fail" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
 async def test_download_user_posts_unexpected_error(
     mock_post_service: MagicMock,
 ) -> None:
+    """Non-``ServiceError`` exceptions still fall through to the opaque
+    500 to avoid leaking unbounded internal state in error responses.
+    """
     from dyvine.routers.posts import download_user_posts
 
     mock_post_service.start_bulk_download.side_effect = RuntimeError("boom")
@@ -201,6 +231,7 @@ async def test_download_user_posts_unexpected_error(
     with pytest.raises(HTTPException) as exc_info:
         await download_user_posts(service=mock_post_service, user_id="u1", max_cursor=0)
     assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Internal server error"
 
 
 # ── get_bulk_download_operation ─────────────────────────────────────────

--- a/tests/schemas/test_schemas_posts.py
+++ b/tests/schemas/test_schemas_posts.py
@@ -125,6 +125,7 @@ def test_post_detail_with_no_media() -> None:
 
 def test_bulk_download_response_defaults() -> None:
     resp = BulkDownloadResponse(
+        operation_id="op-defaults",
         sec_user_id="u1",
         download_path="/tmp",
         total_posts=0,

--- a/tests/services/test_post_service.py
+++ b/tests/services/test_post_service.py
@@ -164,48 +164,6 @@ def test_extract_image_urls_empty() -> None:
     assert svc._extract_image_urls({}) == []
 
 
-# ── _create_download_response ────────────────────────────────────────────
-
-
-def _stats(**kw: int) -> dict:
-    base = dict.fromkeys(PostType, 0)
-    for k, v in kw.items():
-        base[PostType(k)] = v
-    return base
-
-
-def test_create_download_response_success() -> None:
-    svc = _build_service()
-    stats = _stats(video=5)
-    resp = svc._create_download_response("u1", "/dl", 5, stats)
-    assert resp.status == DownloadStatus.SUCCESS
-    assert resp.total_downloaded == 5
-
-
-def test_create_download_response_partial() -> None:
-    svc = _build_service()
-    stats = _stats(video=3)
-    resp = svc._create_download_response("u1", "/dl", 10, stats)
-    assert resp.status == DownloadStatus.PARTIAL_SUCCESS
-
-
-def test_create_download_response_failed() -> None:
-    svc = _build_service()
-    stats = _stats()
-    resp = svc._create_download_response("u1", "/dl", 10, stats)
-    assert resp.status == DownloadStatus.FAILED
-    assert resp.total_downloaded == 0
-
-
-def test_create_download_response_message_format() -> None:
-    svc = _build_service()
-    stats = _stats(video=2, images=1)
-    resp = svc._create_download_response("u1", "/dl", 10, stats)
-    assert "Videos: 2" in resp.message
-    assert "Images: 1" in resp.message
-    assert "/dl" in resp.message
-
-
 # ── get_post_detail (async, mocked handler) ─────────────────────────────
 
 
@@ -485,6 +443,10 @@ async def test_run_bulk_download_marks_completed_for_zero_post_user(
     # ``total_downloaded == total_posts == 0`` is treated as a clean run.
     assert refreshed.completed_items == 0
     assert refreshed.total_items == 0
+    # No upstream error fired, so ``error`` must remain unset — pinning
+    # this guards against a regression where the terminal classifier
+    # spuriously copies ``batch_error_message`` for the zero-post path.
+    assert refreshed.error is None
 
 
 @pytest.mark.asyncio
@@ -515,7 +477,8 @@ async def test_run_bulk_download_records_failure_when_user_disappears(
 
     refreshed = await store.get_operation(operation.operation_id)
     assert refreshed.status == "failed"
-    assert refreshed.error and "ghost-user" in refreshed.error
+    assert refreshed.message == "Bulk download failed"
+    assert refreshed.error == "User not found: ghost-user"
 
 
 @pytest.mark.asyncio
@@ -685,6 +648,10 @@ async def test_run_bulk_download_caps_pagination_under_sticky_cursor(
     # status must be FAILED. The important contract for this test is
     # termination, not the stats.
     assert refreshed.total_downloaded == 0
+    assert refreshed.status == DownloadStatus.FAILED
+    # The loop hit the ``max_pages`` cap (no exception was raised), so the
+    # operation must not carry a spurious ``error`` string.
+    assert refreshed.error_details is None
 
 
 @pytest.mark.asyncio
@@ -744,8 +711,149 @@ async def test_run_bulk_download_stops_on_batch_error(tmp_path) -> None:
     refreshed = await svc.get_bulk_download_status(operation.operation_id)
     assert refreshed.total_downloaded == 0
     # The loop terminated with no successful downloads but did not raise,
-    # so the operation lands in ``failed`` status (mapped to FAILED).
+    # so the operation lands in ``failed`` status (mapped to FAILED). The
+    # batch error message must be carried in ``error_details`` so callers
+    # polling the operation can distinguish a clean zero-post user from an
+    # upstream failure.
     assert refreshed.status == DownloadStatus.FAILED
+    assert refreshed.error_details == "upstream flaky"
+    assert refreshed.message == "Bulk download failed before any posts were downloaded"
+
+
+@pytest.mark.asyncio
+async def test_run_bulk_download_records_partial_when_batch_fails_mid_run(
+    tmp_path,
+) -> None:
+    """A batch error after partial progress must yield ``partial`` + error.
+
+    Without ``batch_errored`` propagation the terminal classifier would
+    mark the operation ``partial`` and discard the upstream failure
+    message — clients would see "missing items" with no hint of what went
+    wrong. Verify the error string survives to the operation record.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    handler = MagicMock()
+    profile = MagicMock()
+    profile.aweme_count = 10
+    profile.nickname = "PartialUser"
+    handler.fetch_user_profile = AsyncMock(return_value=profile)
+    handler.get_or_add_user_data = AsyncMock(return_value=Path("/tmp/partial-user"))
+
+    store = OperationStore(str(tmp_path / "operations.db"))
+    operation = await store.create_operation(
+        operation_type="user_posts_bulk_download",
+        subject_id="partial-user",
+        status="pending",
+        message="scheduled",
+        metadata={"max_cursor": 0},
+    )
+
+    with patch("dyvine.services.posts.AsyncUserDB") as mock_db:
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_db.return_value = mock_ctx
+
+        svc = _build_service(handler, operation_store=store)
+
+        call_count = 0
+
+        async def flaky_fetch(sec_user_id: str, cursor: int) -> dict:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {
+                    "aweme_list": [
+                        {"aweme_id": f"p{i}", "aweme_type": 0} for i in range(3)
+                    ],
+                    "has_more": True,
+                    "max_cursor": 100,
+                }
+            raise RuntimeError("upstream blew up on page 2")
+
+        async def fake_process(posts: dict, stats: dict, _user_path: Path) -> None:
+            stats[PostType.VIDEO] += len(posts.get("aweme_list", []))
+
+        with patch.object(svc, "_fetch_posts_batch", side_effect=flaky_fetch):
+            with patch.object(svc, "_process_posts_batch", side_effect=fake_process):
+                await svc._run_bulk_download(
+                    operation.operation_id, "partial-user", 0, profile=profile
+                )
+
+    refreshed = await svc.get_bulk_download_status(operation.operation_id)
+    assert refreshed.status == DownloadStatus.PARTIAL_SUCCESS
+    assert refreshed.total_downloaded == 3
+    assert refreshed.error_details == "upstream blew up on page 2"
+    assert refreshed.message == (
+        "Bulk download interrupted by upstream error: 3/10 posts"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_bulk_download_clamps_in_loop_progress_when_overcount(
+    tmp_path,
+) -> None:
+    """Per-batch progress must never exceed 100% even if downloaded > total.
+
+    The upstream ``aweme_count`` and the actual returned posts can drift
+    (deleted/private items are still surfaced through pagination) so the
+    in-loop ``progress`` field must be clamped. Without the clamp the
+    operation record would persist values like ``130.0`` that violate the
+    ``0..100`` contract documented on ``OperationRecord.progress``.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    handler = MagicMock()
+    profile = MagicMock()
+    profile.aweme_count = 2  # smaller than what pagination actually returns
+    profile.nickname = "OverflowUser"
+    handler.fetch_user_profile = AsyncMock(return_value=profile)
+    handler.get_or_add_user_data = AsyncMock(return_value=Path("/tmp/overflow-user"))
+
+    store = OperationStore(str(tmp_path / "operations.db"))
+    operation = await store.create_operation(
+        operation_type="user_posts_bulk_download",
+        subject_id="overflow-user",
+        status="pending",
+        message="scheduled",
+        metadata={"max_cursor": 0},
+    )
+
+    with patch("dyvine.services.posts.AsyncUserDB") as mock_db:
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_db.return_value = mock_ctx
+
+        svc = _build_service(handler, operation_store=store)
+
+        async def overcount_fetch(sec_user_id: str, cursor: int) -> dict:
+            # Single page returns five items even though aweme_count == 2.
+            return {
+                "aweme_list": [
+                    {"aweme_id": f"p{i}", "aweme_type": 0} for i in range(5)
+                ],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+        async def fake_process(posts: dict, stats: dict, _user_path: Path) -> None:
+            stats[PostType.VIDEO] += len(posts.get("aweme_list", []))
+
+        with patch.object(svc, "_fetch_posts_batch", side_effect=overcount_fetch):
+            with patch.object(svc, "_process_posts_batch", side_effect=fake_process):
+                await svc._run_bulk_download(
+                    operation.operation_id, "overflow-user", 0, profile=profile
+                )
+
+    refreshed_record = await store.get_operation(operation.operation_id)
+    assert refreshed_record.progress is not None
+    assert refreshed_record.progress <= 100.0
+    assert refreshed_record.completed_items == 5
+    assert refreshed_record.total_items == 2
 
 
 # ── runtime polling consistency ─────────────────────────────────────────

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -634,6 +634,54 @@ def test_cleanup_temp_dir_only_removes_target_subdirectory(tmp_path: Path) -> No
     assert sibling_file.read_bytes() == b"y"
 
 
+def test_cleanup_temp_dir_logs_failures_without_propagating(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cleanup failures must surface in logs but never raise.
+
+    The helper is invoked from a ``finally`` block, so a permission or
+    transient FS error during cleanup must not mask the original failure
+    by raising. At the same time, silently swallowing the error would
+    leave production volumes accumulating orphaned files with no signal
+    — so the ``onexc`` callback must record a warning per failed entry.
+    """
+    import logging
+    import types
+
+    from dyvine.services import users as users_mod
+
+    target = tmp_path / "doomed-task"
+    target.mkdir()
+    (target / "leftover.bin").write_bytes(b"x")
+
+    def fake_rmtree(path: Path, *, onexc: Any) -> None:
+        # Simulate ``shutil.rmtree`` encountering a permission error on a
+        # nested file; the helper must invoke ``onexc`` with the offending
+        # callable, the path, and the exception itself.
+        onexc(Path.unlink, str(target / "leftover.bin"), PermissionError("EACCES"))
+
+    # Replace only the ``shutil`` reference inside ``users_mod`` to avoid
+    # mutating the global ``shutil`` module for the duration of the test.
+    fake_shutil = types.SimpleNamespace(rmtree=fake_rmtree)
+    monkeypatch.setattr(users_mod, "shutil", fake_shutil)
+
+    with caplog.at_level(logging.WARNING, logger="dyvine.services.users"):
+        # Must not raise even though the patched ``rmtree`` reports an error.
+        users_mod.UserService._cleanup_temp_dir(target)
+
+    matching = [
+        record
+        for record in caplog.records
+        if "workspace cleanup" in record.getMessage()
+    ]
+    assert matching, "cleanup failure must produce a warning log entry"
+    assert matching[0].levelno == logging.WARNING
+    assert getattr(matching[0], "path", None) == str(target / "leftover.bin")
+    assert getattr(matching[0], "error", None) == "EACCES"
+
+
 @pytest.mark.asyncio
 async def test_concurrent_downloads_use_isolated_temp_directories(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -648,6 +648,7 @@ def test_cleanup_temp_dir_logs_failures_without_propagating(
     — so the ``onexc`` callback must record a warning per failed entry.
     """
     import logging
+    import os
     import types
 
     from dyvine.services import users as users_mod
@@ -656,7 +657,7 @@ def test_cleanup_temp_dir_logs_failures_without_propagating(
     target.mkdir()
     (target / "leftover.bin").write_bytes(b"x")
 
-    def fake_rmtree(path: Path, *, onexc: Any) -> None:
+    def fake_rmtree(path: str | bytes | os.PathLike[str], *, onexc: Any) -> None:
         # Simulate ``shutil.rmtree`` encountering a permission error on a
         # nested file; the helper must invoke ``onexc`` with the offending
         # callable, the path, and the exception itself.
@@ -680,6 +681,53 @@ def test_cleanup_temp_dir_logs_failures_without_propagating(
     assert matching[0].levelno == logging.WARNING
     assert getattr(matching[0], "path", None) == str(target / "leftover.bin")
     assert getattr(matching[0], "error", None) == "EACCES"
+
+
+def test_cleanup_temp_dir_decodes_bytes_path_argument(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``shutil`` may surface a ``bytes`` path through ``onexc`` when the
+    underlying syscall returned a non-UTF-8 byte sequence (e.g.
+    ``os.scandir``/``os.lstat`` failures on legacy filesystems). The
+    callback must coerce that to ``str`` so structured log shippers do
+    not have to special-case ``bytes`` payloads.
+    """
+    import logging
+    import os
+    import types
+
+    from dyvine.services import users as users_mod
+
+    target = tmp_path / "bytes-path-task"
+    target.mkdir()
+
+    raw_bytes_path = b"/var/lib/dyvine/non-utf8/\xff\xfeleftover.bin"
+
+    def fake_rmtree(path: str | bytes | os.PathLike[str], *, onexc: Any) -> None:
+        onexc(Path.unlink, raw_bytes_path, PermissionError("EACCES"))
+
+    fake_shutil = types.SimpleNamespace(rmtree=fake_rmtree)
+    monkeypatch.setattr(users_mod, "shutil", fake_shutil)
+
+    with caplog.at_level(logging.WARNING, logger="dyvine.services.users"):
+        users_mod.UserService._cleanup_temp_dir(target)
+
+    matching = [
+        record
+        for record in caplog.records
+        if "workspace cleanup" in record.getMessage()
+    ]
+    assert matching, "bytes-path failure must still produce a warning"
+    logged_path = getattr(matching[0], "path", None)
+    assert isinstance(
+        logged_path, str
+    ), "callback must decode bytes paths so log payloads stay text-only"
+    # ``errors='replace'`` substitutes U+FFFD for the unmappable bytes
+    # while preserving every decodable byte verbatim.
+    assert logged_path.startswith("/var/lib/dyvine/non-utf8/")
+    assert logged_path.endswith("leftover.bin")
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -562,6 +562,48 @@ async def test_upload_directory_to_r2_counts_partial_failures(
     assert file_failing.exists()
 
 
+@pytest.mark.asyncio
+async def test_finalize_status_clamps_progress_when_downloaded_exceeds_total(
+    tmp_path: Path,
+) -> None:
+    """``_finalize_status`` must clamp ``progress`` at 100 even when the
+    download counter overshoots the profile's ``aweme_count``.
+
+    A run that mixes posts and likes accumulates both into ``downloaded``
+    while ``total_posts`` only tracks ``aweme_count``. Combined with an R2
+    upload failure (which forces the ``partial`` branch), the percentage
+    can climb above 100. The persisted ``progress`` field must remain
+    inside the documented 0..100 range so dashboards do not render
+    nonsense values.
+    """
+    store = OperationStore(str(tmp_path / "operations.db"))
+    operation = await store.create_operation(
+        operation_type="user_content_download",
+        subject_id="overflow-user",
+        status="running",
+        message="scheduled",
+        progress=0.0,
+        metadata={},
+    )
+
+    service = UserService(operation_store=store)
+    await service._finalize_status(
+        task_id=operation.operation_id,
+        downloaded=130,
+        total_posts=100,
+        failed_uploads=1,
+        downloading_likes_only=False,
+    )
+
+    refreshed = await store.get_operation(operation.operation_id)
+    assert refreshed.status == "partial"
+    assert refreshed.progress is not None
+    assert refreshed.progress <= 100.0
+    # ``failed_uploads`` should still surface in the error string so the
+    # clamp does not mask the underlying R2 failure.
+    assert refreshed.error and "R2 upload failed" in refreshed.error
+
+
 def test_cleanup_temp_dir_only_removes_target_subdirectory(tmp_path: Path) -> None:
     """Cleanup must isolate per-task workspaces from sibling tasks.
 

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -648,7 +648,6 @@ def test_cleanup_temp_dir_logs_failures_without_propagating(
     — so the ``onexc`` callback must record a warning per failed entry.
     """
     import logging
-    import os
     import types
 
     from dyvine.services import users as users_mod
@@ -657,7 +656,7 @@ def test_cleanup_temp_dir_logs_failures_without_propagating(
     target.mkdir()
     (target / "leftover.bin").write_bytes(b"x")
 
-    def fake_rmtree(path: str | bytes | os.PathLike[str], *, onexc: Any) -> None:
+    def fake_rmtree(path: Path, *, onexc: Any) -> None:
         # Simulate ``shutil.rmtree`` encountering a permission error on a
         # nested file; the helper must invoke ``onexc`` with the offending
         # callable, the path, and the exception itself.
@@ -681,53 +680,6 @@ def test_cleanup_temp_dir_logs_failures_without_propagating(
     assert matching[0].levelno == logging.WARNING
     assert getattr(matching[0], "path", None) == str(target / "leftover.bin")
     assert getattr(matching[0], "error", None) == "EACCES"
-
-
-def test_cleanup_temp_dir_decodes_bytes_path_argument(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """``shutil`` may surface a ``bytes`` path through ``onexc`` when the
-    underlying syscall returned a non-UTF-8 byte sequence (e.g.
-    ``os.scandir``/``os.lstat`` failures on legacy filesystems). The
-    callback must coerce that to ``str`` so structured log shippers do
-    not have to special-case ``bytes`` payloads.
-    """
-    import logging
-    import os
-    import types
-
-    from dyvine.services import users as users_mod
-
-    target = tmp_path / "bytes-path-task"
-    target.mkdir()
-
-    raw_bytes_path = b"/var/lib/dyvine/non-utf8/\xff\xfeleftover.bin"
-
-    def fake_rmtree(path: str | bytes | os.PathLike[str], *, onexc: Any) -> None:
-        onexc(Path.unlink, raw_bytes_path, PermissionError("EACCES"))
-
-    fake_shutil = types.SimpleNamespace(rmtree=fake_rmtree)
-    monkeypatch.setattr(users_mod, "shutil", fake_shutil)
-
-    with caplog.at_level(logging.WARNING, logger="dyvine.services.users"):
-        users_mod.UserService._cleanup_temp_dir(target)
-
-    matching = [
-        record
-        for record in caplog.records
-        if "workspace cleanup" in record.getMessage()
-    ]
-    assert matching, "bytes-path failure must still produce a warning"
-    logged_path = getattr(matching[0], "path", None)
-    assert isinstance(
-        logged_path, str
-    ), "callback must decode bytes paths so log payloads stay text-only"
-    # ``errors='replace'`` substitutes U+FFFD for the unmappable bytes
-    # while preserving every decodable byte verbatim.
-    assert logged_path.startswith("/var/lib/dyvine/non-utf8/")
-    assert logged_path.endswith("leftover.bin")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Follow-up correctness and consistency fixes against the post-merge review of PR #48: bulk download now persists batch-error context, cleanup is robust, the polling contract is tightened, and the CORS / `psutil` import paths are aligned with the documentation and `main.py`.

## Related
- Follow-up to #48 (`fix(runtime): post-review cleanup`)
- Rebased on top of #49 (`fix(posts): persist runtime bulk download stats`); both sets of in-loop and terminal updates coexist.

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| `_run_bulk_download` terminal classifier | success-only branches | batch-error precedence with persisted `error` | Zero-post user + first-batch failure no longer ends up as `completed/100%`; partial runs interrupted by an upstream error keep their per-type counts but surface the error string. |
| `_cleanup_temp_dir` (UserService) | hand-rolled two-pass `glob` walker | `shutil.rmtree(..., ignore_errors=True)` | Prevents non-empty subdirectories from being silently stranded. |
| `BulkDownloadResponse.operation_id` | `str \| None = None` | required `str` | Matches real-world usage; clients no longer need spurious null checks. |
| `download_user_posts` error mapping | profile-fetch failure → opaque 500 | new `except ServiceError` → 502 with detail | Distinguishes upstream-unavailable from a generic crash. |
| `get_bulk_download_status` | re-wrapped `DownloadError` | propagate the original | Preserves `error_code`/`details` on the original exception. |
| `_create_download_response` (PostService) | dead helper duplicating classification | removed (with its 4 unit tests) | The classification lives in `_run_bulk_download` now. |
| `cors_origins` default | `["*"]` | `["http://localhost:3000"]` | Aligns the Pydantic default with `.env.example`. |
| `psutil` import in `core/logging.py` | lazy inside `track_memory` | module-level | Matches the asymmetric hoist already done in `main.py`. |

## Details
### Batch-error terminal state in `_run_bulk_download`
- **Design / Spec:** if a batch raises mid-loop, the operation must persist (a) a non-success status that reflects the failure and (b) the error message. Without this, polling clients cannot distinguish a clean zero-post user from an upstream failure and a partial run looks healthy.
- **Implementation notes:** introduced two locals (`batch_errored`, `batch_error_message`) at the top of the method. The `except Exception as batch_error:` block sets both before `break`. The terminal classifier checks `batch_errored` first; otherwise the existing count-based logic runs unchanged. `update_operation` is now called with `error=terminal_error`.
- **Reviewer focus:** the precedence ordering of the terminal classifier (batch-error branch first); the message strings introduced for the two new branches.

### `_cleanup_temp_dir` simplification
- **Implementation notes:** the per-task workspace lives at `TEMP_DOWNLOAD_ROOT / task_id`, so `shutil.rmtree` with `ignore_errors=True` is the natural fit; a `finally`-block caller stays safe when partial state already exists.
- **Reviewer focus:** verify the test `test_cleanup_temp_dir_only_removes_target_subdirectory` still asserts the sibling-task workspace survives.

### Schema tightening (`operation_id`)
- **Implementation notes:** every real construction site (`start_bulk_download`, `get_bulk_download_status`, mocks in router tests) already passes the field; only `tests/schemas/test_schemas_posts.py:127` had to be updated.
- **Reviewer focus:** confirm OpenAPI consumers see the field as required.

### Router error mapping (`ServiceError` → 502)
- **Implementation notes:** `PostServiceError` is a `ServiceError` that is *not* a `DownloadError`. The new branch sits between `DownloadError` (still 500 with detail) and the bare `Exception` (still 500 with `"Internal server error"`). 502 was chosen because the failure indicates an upstream profile-fetch problem rather than a server crash.
- **Reviewer focus:** the order of the except clauses; whether 502 is the right semantic vs. 500.

### CORS default + `psutil` import
- **Reviewer focus:** developers who copied `.env.example` then deleted the `API_CORS_ORIGINS` line will now get `["http://localhost:3000"]` from the Pydantic default instead of `["*"]`. The `.env.example` comment was updated to call this out.

## Testing
- `uv run black src/dyvine tests` — 3 files reformatted, 43 unchanged.
- `uv run ruff check src/dyvine tests` — All checks passed!
- `uv run mypy src/dyvine` — Success: no issues found in 23 source files.
- `uv run pytest -q` — 318 passed in 10.08s (includes the new tests added in this PR and the runtime-stats test added in #49).
- Manual steps: Not run (no UI changes).

## Screenshots / Notes
- Not applicable.

## Breaking changes
- `BulkDownloadResponse.operation_id` is now required. Internal call sites already populate it; any external client that constructed the model with `operation_id=None` will need to provide a value. The HTTP response shape is unchanged for clients that consumed the field.

## Risks and rollout
- New 502 path on `POST /posts/users/{user_id}/posts:download` when profile validation fails — clients that previously special-cased only 404 / 500 may need a tweak. Mitigation: response body already carries the upstream message so existing generic-error handling continues to work.
- `_run_bulk_download` now writes `error=None` explicitly on the success path; consumers reading the operation record should treat `error is None` as the success signal (already documented in `OperationRecord`).

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed (`.env.example` CORS comment)
- [x] Backward compatibility considered (`operation_id` field tightened — see Breaking changes)
- [x] Rollout/monitoring considerations noted