### PR TITLE
docs: Refresh project documentation and test coverage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,12 +44,21 @@ logs/
 
 # Database files
 *.db
+*.db-shm
+*.db-wal
 *.sqlite3
+*.sqlite3-shm
+*.sqlite3-wal
 
 # Temporary files
 *.tmp
 *.temp
 temp_downloads/
+data/douyin/downloads/
+data/douyin/state/
+data/douyin/logs/
+data/temp/
+data/cache/
 
 # Test files
 tests/

--- a/.gitignore
+++ b/.gitignore
@@ -112,13 +112,18 @@ logs/
 
 # Database files
 *.db
+*.db-shm
+*.db-wal
 *.sqlite3
+*.sqlite3-shm
+*.sqlite3-wal
 *.sqlite3-journal
 douyin_users.db
 
 # Downloaded content and temp files
 downloads/
 data/douyin/downloads/
+data/douyin/state/
 data/douyin/logs/
 data/temp/
 data/cache/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,156 @@
 # Dyvine
 
-Dyvine is a FastAPI service for asynchronous Douyin content downloads, persistent operation tracking, and optional Cloudflare R2 archival.
+Dyvine is a Python 3.12 FastAPI service for asynchronous Douyin content
+downloads, persistent operation tracking, and optional Cloudflare R2 archival.
+It wraps the third-party `f2` Douyin SDK with a REST API for videos, image
+galleries, livestreams, and user content.
 
-Full project documentation is available in [docs/index.html](docs/index.html). Architecture diagrams are available in [docs/architecture/index.html](docs/architecture/index.html).
+Full project documentation is available in [docs/index.html](docs/index.html).
+Architecture diagrams are available in
+[docs/architecture/index.html](docs/architecture/index.html).
+
+## Features
+
+- Async download endpoints return an operation record immediately and continue
+  work on tracked background tasks.
+- SQLite operation state uses WAL mode, per-thread reader connections, and a
+  single guarded writer.
+- API-key authentication is enabled by default on feature routers through the
+  `X-API-Key` header.
+- User-supplied output paths are jailed inside `DOUYIN_DOWNLOAD_ROOT`, including
+  traversal and symlink-segment checks.
+- Optional Cloudflare R2 archival supports uploads, metadata lookup, listing,
+  and deletes.
+- Operational surfaces include `/livez`, `/readyz`, `/startupz`, `/health`, and
+  `/metrics`.
+
+## Quick Start
+
+Install dependencies:
+
+```bash
+uv sync --all-extras
+```
+
+Create a local environment file:
+
+```bash
+cp .env.example .env
+python -c "import secrets; print(secrets.token_urlsafe(48))"
+```
+
+Populate at least:
+
+```dotenv
+API_DEBUG=false
+SECURITY_SECRET_KEY=<48+ bytes of entropy>
+SECURITY_API_KEY=<48+ bytes of entropy>
+DOUYIN_COOKIE=<browser session cookie>
+```
+
+Run the API locally:
+
+```bash
+uv run uvicorn src.dyvine.main:app --reload
+```
+
+Useful local URLs:
+
+| Surface | URL |
+| --- | --- |
+| Swagger UI | `http://localhost:8000/docs` |
+| ReDoc | `http://localhost:8000/redoc` |
+| OpenAPI JSON | `http://localhost:8000/api/v1/openapi.json` |
+| Metrics | `http://localhost:8000/metrics` |
+
+## Configuration
+
+Configuration is environment-driven through `dyvine.core.settings`:
+
+| Prefix | Purpose |
+| --- | --- |
+| `API_` | Server bind settings, CORS, API prefix, operation DB path |
+| `SECURITY_` | Secret key, API key, and router auth gate |
+| `DOUYIN_` | Cookie, headers, proxy settings, download root, livestream headers |
+| `R2_` | Cloudflare R2 account, key, bucket, and endpoint |
+
+`API_DEBUG=false` rejects placeholder production secrets. R2 is optional, but
+`/readyz` reports `not_ready` until every R2 field and `DOUYIN_COOKIE` are set.
+`/health` remains informational and returns `200 OK` even when dependencies are
+missing.
+
+## Common Commands
+
+| Task | Command |
+| --- | --- |
+| Install runtime dependencies | `uv sync` |
+| Install development dependencies | `uv sync --all-extras` |
+| Run the API | `make run` |
+| Run tests | `make test` |
+| Run coverage gate | `uv run pytest --cov=src/dyvine --cov-fail-under=80` |
+| Lint | `make lint` |
+| Format | `make format` |
+| Clean local caches | `make clean` |
+
+## API Examples
+
+All feature-router requests require `X-API-Key` unless
+`SECURITY_REQUIRE_API_KEY=false` is set behind another authenticated layer.
+
+```bash
+curl -H "X-API-Key: $API_KEY" \
+  "http://localhost:8000/api/v1/users/USER_ID"
+
+curl -X POST -H "X-API-Key: $API_KEY" \
+  "http://localhost:8000/api/v1/posts/users/USER_ID/posts:download"
+
+curl -X POST -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://live.douyin.com/123456789"}' \
+  "http://localhost:8000/api/v1/livestreams/stream:download"
+```
+
+Poll operation status through the matching domain endpoint:
+
+```bash
+curl -H "X-API-Key: $API_KEY" \
+  "http://localhost:8000/api/v1/posts/operations/OPERATION_ID"
+```
+
+## Project Structure
+
+| Path | Purpose |
+| --- | --- |
+| `src/dyvine/main.py` | FastAPI app, middleware, routers, probes, metrics |
+| `src/dyvine/core/` | Settings, logging, dependency container, operation store, path safety |
+| `src/dyvine/routers/` | User, post, and livestream HTTP endpoints |
+| `src/dyvine/services/` | Douyin SDK orchestration, background work, R2 storage |
+| `src/dyvine/schemas/` | Pydantic request and response models |
+| `tests/` | Pytest suite mirroring the source tree |
+| `docs/` | Static HTML project documentation and Mermaid architecture diagrams |
+| `k8s/` | Base and production overlay manifests |
+| `.github/` | CI, image build, deployment, release, and security workflows |
+
+## Development Notes
+
+- Keep public documentation in static HTML under `docs/` and use
+  `docs/index.html` as the entry point.
+- Keep `README.md`, `AGENTS.md`, `CLAUDE.md`, `.env.example`, and
+  `docs/index.html` synchronized when configuration, commands, probes, or
+  deployment behavior changes.
+- Runtime downloads, logs, SQLite files, WAL/SHM files, and local credentials
+  are intentionally ignored.
+- The default SQLite operation store is pod-local. Do not scale beyond one
+  replica without replacing it with a shared backend.
+
+## Contributing
+
+1. Create a branch from `main`.
+2. Make the scoped change and update docs/tests that describe or cover it.
+3. Run `make format`, `make lint`, and `uv run pytest`.
+4. For behavior changes, also run the coverage gate:
+   `uv run pytest --cov=src/dyvine --cov-fail-under=80`.
+
+## License
+
+This project is licensed under Apache License 2.0. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ All feature-router requests require `X-API-Key` unless
 `SECURITY_REQUIRE_API_KEY=false` is set behind another authenticated layer.
 
 ```bash
-curl -H "X-API-Key: $API_KEY" \
+curl -H "X-API-Key: $SECURITY_API_KEY" \
   "http://localhost:8000/api/v1/users/USER_ID"
 
-curl -X POST -H "X-API-Key: $API_KEY" \
+curl -X POST -H "X-API-Key: $SECURITY_API_KEY" \
   "http://localhost:8000/api/v1/posts/users/USER_ID/posts:download"
 
-curl -X POST -H "X-API-Key: $API_KEY" \
+curl -X POST -H "X-API-Key: $SECURITY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://live.douyin.com/123456789"}' \
   "http://localhost:8000/api/v1/livestreams/stream:download"
@@ -113,7 +113,7 @@ curl -X POST -H "X-API-Key: $API_KEY" \
 Poll operation status through the matching domain endpoint:
 
 ```bash
-curl -H "X-API-Key: $API_KEY" \
+curl -H "X-API-Key: $SECURITY_API_KEY" \
   "http://localhost:8000/api/v1/posts/operations/OPERATION_ID"
 ```
 

--- a/docs/architecture/index.html
+++ b/docs/architecture/index.html
@@ -95,7 +95,7 @@
       <h1>Dyvine Architecture</h1>
       <p class="lede">Reference diagrams for the Dyvine FastAPI service.</p>
       <div class="pillrow">
-        <span class="pill">Last reviewed: 2026-05-29</span>
+        <span class="pill">Last reviewed: 2026-05-31</span>
         <span class="pill">Source layout: <code>src/dyvine/</code></span>
         <span class="pill">Entry point: <code>main.py</code></span>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -238,18 +238,18 @@ GET  /api/v1/livestreams/operations/{operation_id}</code></pre>
       <p>The URL endpoint validates the host against an allowlist of <code>*.douyin.com</code> domains to prevent SSRF.</p>
 
       <h3>Examples</h3>
-      <pre><code>curl -H "X-API-Key: $API_KEY" \
+      <pre><code>curl -H "X-API-Key: $SECURITY_API_KEY" \
      "http://localhost:8000/api/v1/users/USER_ID"
 
-curl -X POST -H "X-API-Key: $API_KEY" \
+curl -X POST -H "X-API-Key: $SECURITY_API_KEY" \
      "http://localhost:8000/api/v1/posts/users/USER_ID/posts:download"
 
-curl -X POST -H "X-API-Key: $API_KEY" \
+curl -X POST -H "X-API-Key: $SECURITY_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{"url": "https://live.douyin.com/123456789"}' \
      "http://localhost:8000/api/v1/livestreams/stream:download"
 
-curl -H "X-API-Key: $API_KEY" \
+curl -H "X-API-Key: $SECURITY_API_KEY" \
      "http://localhost:8000/api/v1/livestreams/operations/OPERATION_ID"</code></pre>
 
       <h3>Operation Response</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -96,7 +96,7 @@
         <span class="pill">FastAPI</span>
         <span class="pill">SQLite operation store</span>
         <span class="pill">Cloudflare R2 optional</span>
-        <span class="pill">Last reviewed: 2026-05-29</span>
+        <span class="pill">Last reviewed: 2026-05-31</span>
       </div>
     </header>
 
@@ -111,6 +111,7 @@
         <li><a href="#deployment">Deployment</a></li>
         <li><a href="#development">Development</a></li>
         <li><a href="#security-notes">Security Notes</a></li>
+        <li><a href="#maintenance-notes">Maintenance Notes</a></li>
       </ol>
     </nav>
 
@@ -397,6 +398,17 @@ make test          # pytest</code></pre>
       <p>
         License details are available in <a href="../LICENSE">LICENSE</a>.
       </p>
+    </section>
+
+    <section id="maintenance-notes">
+      <h2>Maintenance Notes</h2>
+      <ul>
+        <li><code>README.md</code> is the concise maintainer entry point; keep it in sync with this page.</li>
+        <li><code>AGENTS.md</code> and <code>CLAUDE.md</code> contain repository-local agent guidance and GitNexus workflow reminders.</li>
+        <li><code>.env.example</code> is the source of truth for supported environment variables and security defaults.</li>
+        <li>Runtime downloads, operation-store SQLite files, WAL/SHM files, logs, and generated caches are local artifacts and should not be committed.</li>
+        <li>For Python behavior changes, run focused tests first, then <code>uv run pytest --cov=src/dyvine --cov-fail-under=80</code> before preparing a commit.</li>
+      </ul>
     </section>
 
     <footer>

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from fastapi import HTTPException
 
 from dyvine.core import dependencies
 
@@ -58,6 +59,54 @@ def test_get_service_container_returns_singleton(
     container_two = dependencies.get_service_container()
 
     assert container_one is container_two
+
+
+def test_require_api_key_allows_missing_header_when_gate_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify the dependency is a no-op behind another auth layer."""
+    monkeypatch.setattr(dependencies.settings.security, "require_api_key", False)
+    monkeypatch.setattr(dependencies.settings.security, "api_key", "expected")
+
+    assert dependencies.require_api_key(None) is None
+
+
+def test_require_api_key_rejects_missing_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify missing API keys are rejected when the gate is enabled."""
+    monkeypatch.setattr(dependencies.settings.security, "require_api_key", True)
+    monkeypatch.setattr(dependencies.settings.security, "api_key", "expected")
+
+    with pytest.raises(HTTPException) as exc_info:
+        dependencies.require_api_key(None)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid or missing API key"
+    assert exc_info.value.headers == {"WWW-Authenticate": "ApiKey"}
+
+
+def test_require_api_key_rejects_wrong_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify non-matching API keys are rejected."""
+    monkeypatch.setattr(dependencies.settings.security, "require_api_key", True)
+    monkeypatch.setattr(dependencies.settings.security, "api_key", "expected")
+
+    with pytest.raises(HTTPException) as exc_info:
+        dependencies.require_api_key("wrong")
+
+    assert exc_info.value.status_code == 401
+
+
+def test_require_api_key_accepts_matching_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify matching API keys pass the dependency."""
+    monkeypatch.setattr(dependencies.settings.security, "require_api_key", True)
+    monkeypatch.setattr(dependencies.settings.security, "api_key", "expected")
+
+    assert dependencies.require_api_key("expected") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Refresh project documentation, runtime ignore rules, and direct API-key dependency tests so the repository guidance matches current Dyvine behavior.

## Related
- Not applicable

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| README | Minimal overview | Full maintainer entry point | Adds quickstart, configuration, commands, API examples, structure, contributing, and license notes |
| Static docs | Reviewed 2026-05-29 | Reviewed 2026-05-31 with maintenance notes | Keeps HTML docs aligned with current commands, tests, and local artifact rules |
| Runtime ignore rules | Partial database/download ignores | SQLite WAL/SHM and `data/douyin/state` ignored | Prevents local operation stores and runtime files from polluting git or Docker contexts |
| API-key tests | Indirect router coverage | Direct dependency branch coverage | Covers disabled gate, missing key, wrong key, and matching key |

## Details
### Updates README and static docs
- Design/Spec: Keep `README.md` as the concise maintainer entry point and `docs/index.html` as the static HTML reference.
- Implementation notes: Added current setup, configuration, command, API, structure, and maintenance guidance.
- Reviewer focus: Check that documented commands and operational behavior match the FastAPI app and existing CI.

### Updates runtime ignore rules
- Design/Spec: Runtime downloads, SQLite state, WAL/SHM files, logs, and cache artifacts should stay local.
- Implementation notes: Extended `.gitignore` and `.dockerignore` to cover SQLite sidecars and `data/douyin` runtime state paths.
- Reviewer focus: Confirm no required source/config files are excluded.

### Updates API-key dependency tests
- Design/Spec: Router authentication depends on `require_api_key`.
- Implementation notes: Added direct unit tests for enabled/disabled and success/failure paths.
- Reviewer focus: Verify the tests cover the intended security gate without changing runtime behavior.

## Testing
- `uv run ruff check .` — Passed
- `uv run mypy src/dyvine` — Passed
- `uv run black --check .` — Passed
- `uv run isort --check-only .` — Passed
- HTML parser sanity check — Passed
- Public docstring scan — Passed
- `uv run pytest tests/test_dependencies.py -q` — 9 passed
- `uv run pytest --cov=src/dyvine --cov-fail-under=80` — 356 passed, 90.06% coverage
- Manual steps: Not run

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable

## Risks and rollout
- Documentation drift — Mitigated by aligning README, static docs, ignore rules, and focused tests in one PR.
- Over-broad ignore rules — Mitigated by limiting additions to runtime state, SQLite sidecars, logs, cache, and download artifacts.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted
