### PR TITLE
feat(downloads): support local retention without R2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,19 @@ DOUYIN_REFERER=https://www.douyin.com/
 # downloads to a non-default volume.
 DOUYIN_DOWNLOAD_ROOT=data/douyin/downloads
 
+# Local-retention mode. When ``true`` the service keeps each task's
+# downloaded files under ``downloads/<task_id>`` instead of deleting them
+# after the run, and R2 stops gating the ``/readyz`` probe (it is reported
+# as ``disabled``). Retention is applied implicitly whenever R2 is left
+# unconfigured below, so a finished download is never discarded with nowhere
+# to archive it. Default ``false``: upload to R2, then sweep the workspace.
+DOUYIN_RETAIN_LOCAL_DOWNLOADS=false
+
+# Soft cap, in GiB, on the retained-downloads workspace. When greater than
+# zero, the oldest per-task directories are pruned after each run until the
+# total falls back under the cap; ``0`` leaves the workspace unbounded.
+DOUYIN_RETAIN_MAX_GB=0
+
 # Optional: Proxy configuration
 # DOUYIN_PROXY_HTTP=http://proxy.example.com:8080
 # DOUYIN_PROXY_HTTPS=https://proxy.example.com:8080

--- a/.env.example
+++ b/.env.example
@@ -59,11 +59,12 @@ DOUYIN_REFERER=https://www.douyin.com/
 DOUYIN_DOWNLOAD_ROOT=data/douyin/downloads
 
 # Local-retention mode. When ``true`` the service keeps each task's
-# downloaded files under ``downloads/<task_id>`` instead of deleting them
-# after the run, and R2 stops gating the ``/readyz`` probe (it is reported
-# as ``disabled``). Retention is applied implicitly whenever R2 is left
-# unconfigured below, so a finished download is never discarded with nowhere
-# to archive it. Default ``false``: upload to R2, then sweep the workspace.
+# downloaded files under ``DOUYIN_DOWNLOAD_ROOT/tasks/<task_id>`` instead
+# of deleting them after the run, and R2 stops gating the ``/readyz`` probe
+# (it is reported as ``disabled``). Retention is applied implicitly whenever
+# R2 is left unconfigured below, so a finished download is never discarded
+# with nowhere to archive it. Default ``false``: upload to R2, then sweep
+# the workspace.
 DOUYIN_RETAIN_LOCAL_DOWNLOADS=false
 
 # Soft cap, in GiB, on the retained-downloads workspace. When greater than

--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ Configuration is environment-driven through `dyvine.core.settings`:
 `API_DEBUG=false` rejects placeholder production secrets. R2 is optional: by
 default `/readyz` reports `not_ready` until every R2 field and `DOUYIN_COOKIE`
 are set, but enabling local-retention mode
-(`DOUYIN_RETAIN_LOCAL_DOWNLOADS=true`) keeps each download on the local volume,
-drops R2 from the readiness gate, and reports it as `disabled`. When R2 is left
-unconfigured the service retains downloads implicitly rather than discarding
-them. `/health` remains informational and returns `200 OK` even when
-dependencies are missing.
+(`DOUYIN_RETAIN_LOCAL_DOWNLOADS=true`) keeps each download under
+`DOUYIN_DOWNLOAD_ROOT/tasks/<task_id>`, drops R2 from the readiness gate, and
+reports it as `disabled`. When R2 is left unconfigured the service retains
+downloads implicitly rather than discarding them. `/readyz` also verifies that
+the retained workspace can be created and written. `/health` remains
+informational and returns `200 OK` even when dependencies are missing.
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -71,13 +71,17 @@ Configuration is environment-driven through `dyvine.core.settings`:
 | --- | --- |
 | `API_` | Server bind settings, CORS, API prefix, operation DB path |
 | `SECURITY_` | Secret key, API key, and router auth gate |
-| `DOUYIN_` | Cookie, headers, proxy settings, download root, livestream headers |
+| `DOUYIN_` | Cookie, headers, proxy, download root, livestream headers, local-retention mode |
 | `R2_` | Cloudflare R2 account, key, bucket, and endpoint |
 
-`API_DEBUG=false` rejects placeholder production secrets. R2 is optional, but
-`/readyz` reports `not_ready` until every R2 field and `DOUYIN_COOKIE` are set.
-`/health` remains informational and returns `200 OK` even when dependencies are
-missing.
+`API_DEBUG=false` rejects placeholder production secrets. R2 is optional: by
+default `/readyz` reports `not_ready` until every R2 field and `DOUYIN_COOKIE`
+are set, but enabling local-retention mode
+(`DOUYIN_RETAIN_LOCAL_DOWNLOADS=true`) keeps each download on the local volume,
+drops R2 from the readiness gate, and reports it as `disabled`. When R2 is left
+unconfigured the service retains downloads implicitly rather than discarding
+them. `/health` remains informational and returns `200 OK` even when
+dependencies are missing.
 
 ## Common Commands
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -197,9 +197,10 @@ DOUYIN_COOKIE=&lt;browser session cookie&gt;</code></pre>
       </p>
       <p>
         Set <code>DOUYIN_RETAIN_LOCAL_DOWNLOADS=true</code> to run in local-retention mode: each task's
-        files are kept under <code>downloads/&lt;task_id&gt;</code> instead of being swept after upload,
+        files are kept under <code>DOUYIN_DOWNLOAD_ROOT/tasks/&lt;task_id&gt;</code> instead of being swept after upload,
         R2 is dropped from the readiness gate (reported as <code>disabled</code>), and the upload step is
-        skipped while R2 is unconfigured. Retention also applies implicitly whenever R2 is unset, so a
+        skipped while R2 is unconfigured. <code>/readyz</code> also verifies that this retained workspace
+        can be created and written. Retention also applies implicitly whenever R2 is unset, so a
         finished download is never discarded. Bound the retained workspace with
         <code>DOUYIN_RETAIN_MAX_GB</code> (GiB; <code>0</code> disables pruning).
       </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -192,8 +192,16 @@ DOUYIN_COOKIE=&lt;browser session cookie&gt;</code></pre>
       <p>
         Optional R2 archival requires <code>R2_ACCOUNT_ID</code>, <code>R2_ACCESS_KEY_ID</code>,
         <code>R2_SECRET_ACCESS_KEY</code>, <code>R2_BUCKET_NAME</code>, and <code>R2_ENDPOINT</code>.
-        The storage service auto-disables when any R2 field is empty. The readiness probe fails until
-        all R2 fields and the Douyin cookie are set.
+        The storage service auto-disables when any R2 field is empty. By default the readiness probe
+        fails until all R2 fields and the Douyin cookie are set.
+      </p>
+      <p>
+        Set <code>DOUYIN_RETAIN_LOCAL_DOWNLOADS=true</code> to run in local-retention mode: each task's
+        files are kept under <code>downloads/&lt;task_id&gt;</code> instead of being swept after upload,
+        R2 is dropped from the readiness gate (reported as <code>disabled</code>), and the upload step is
+        skipped while R2 is unconfigured. Retention also applies implicitly whenever R2 is unset, so a
+        finished download is never discarded. Bound the retained workspace with
+        <code>DOUYIN_RETAIN_MAX_GB</code> (GiB; <code>0</code> disables pruning).
       </p>
     </section>
 

--- a/src/dyvine/core/dependencies.py
+++ b/src/dyvine/core/dependencies.py
@@ -275,7 +275,7 @@ class ServiceContainer:
             "mode": "all",
             "interval": "all",
             "cookie": settings.douyin.cookie,
-            "path": "downloads",
+            "path": settings.douyin.download_root,
             "max_retries": 5,
             "timeout": 30,
             "chunk_size": 1024 * 1024,

--- a/src/dyvine/core/dependencies.py
+++ b/src/dyvine/core/dependencies.py
@@ -273,6 +273,7 @@ class ServiceContainer:
             "headers": settings.douyin.headers,
             "proxies": settings.douyin.proxies,
             "mode": "all",
+            "interval": "all",
             "cookie": settings.douyin.cookie,
             "path": "downloads",
             "max_retries": 5,

--- a/src/dyvine/core/path_safety.py
+++ b/src/dyvine/core/path_safety.py
@@ -15,10 +15,17 @@ from pathlib import Path
 from .exceptions import ValidationError
 from .settings import settings
 
+TASK_WORKSPACE_SUBDIR = "tasks"
+
 
 def get_download_root() -> Path:
     """Return the absolute, normalised download jail root."""
     return Path(settings.douyin.download_root).expanduser().resolve()
+
+
+def get_task_workspace_root() -> Path:
+    """Return the root that holds operation-owned download workspaces."""
+    return get_download_root() / TASK_WORKSPACE_SUBDIR
 
 
 def _reject_symlink_segments(target: Path, root: Path) -> None:

--- a/src/dyvine/core/settings.py
+++ b/src/dyvine/core/settings.py
@@ -207,10 +207,15 @@ class DouyinSettings(BaseSettings):
         proxy_https: HTTPS proxy URL (optional).
         download_root: Filesystem root that bounds every user-supplied
             output path.
+        retain_local_downloads: Keep per-task files locally instead of
+            deleting them after each run (implied when R2 is unconfigured).
+        retain_max_gb: Optional GiB cap that prunes the oldest retained
+            workspaces once exceeded; ``0`` disables pruning.
 
     Environment Variables:
         DOUYIN_COOKIE, DOUYIN_USER_AGENT, DOUYIN_REFERER,
-        DOUYIN_PROXY_HTTP, DOUYIN_PROXY_HTTPS, DOUYIN_DOWNLOAD_ROOT.
+        DOUYIN_PROXY_HTTP, DOUYIN_PROXY_HTTPS, DOUYIN_DOWNLOAD_ROOT,
+        DOUYIN_RETAIN_LOCAL_DOWNLOADS, DOUYIN_RETAIN_MAX_GB.
 
     Note:
         A valid cookie is required for most Douyin API operations.
@@ -253,6 +258,25 @@ class DouyinSettings(BaseSettings):
     live_sec_ch_ua: str = Field(
         default='"Not A(Brand";v="99", "Google Chrome";v="131", "Chromium";v="131"',
         description="sec-ch-ua header value for livestream requests",
+    )
+    retain_local_downloads: bool = Field(
+        default=False,
+        description=(
+            "Keep each task's downloaded files in the local workspace "
+            "instead of deleting them after the run. Treated as enabled "
+            "whenever R2 is not configured, so a completed download is "
+            "never silently discarded with nowhere to archive it."
+        ),
+    )
+    retain_max_gb: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Soft cap, in GiB, on the retained-downloads workspace. When "
+            "greater than zero, the oldest per-task directories are pruned "
+            "after each run until the total falls back under the cap. Zero "
+            "leaves the workspace unbounded (pruning disabled)."
+        ),
     )
 
     @property

--- a/src/dyvine/main.py
+++ b/src/dyvine/main.py
@@ -66,6 +66,7 @@ from prometheus_client import Counter, Histogram, make_asgi_app
 from .core.dependencies import get_service_container
 from .core.error_handlers import register_error_handlers
 from .core.logging import ContextLogger, setup_logging
+from .core.path_safety import ensure_within_root, get_task_workspace_root
 from .core.settings import settings
 from .routers import livestreams, posts, users
 
@@ -79,6 +80,25 @@ http_request_duration_seconds = Histogram(
     "HTTP request duration for Dyvine",
     ["method", "route", "status_code"],
 )
+logger = ContextLogger(__name__)
+
+
+def _local_retention_workspace_ready() -> bool:
+    """Verify the configured task workspace root can be created and written."""
+    workspace_root = get_task_workspace_root()
+    probe = workspace_root / f".readyz-{uuid.uuid4().hex}"
+    try:
+        workspace_root.mkdir(parents=True, exist_ok=True)
+        ensure_within_root(workspace_root)
+        probe.write_text("", encoding="utf-8")
+        probe.unlink(missing_ok=True)
+    except Exception as exc:
+        logger.warning(
+            "Local retention workspace is not writable",
+            extra={"path": str(workspace_root), "error": str(exc)},
+        )
+        return False
+    return True
 
 
 @asynccontextmanager
@@ -526,6 +546,11 @@ async def readiness_probe(request: Request) -> JSONResponse:
     # whenever R2 is unconfigured. Keep readiness aligned with the effective
     # download path so a no-R2 deployment is not held out of service.
     local_retention_effective = settings.douyin.retain_local_downloads or not r2_ok
+    local_retention_ok = True
+    local_retention_status = "not_required"
+    if local_retention_effective:
+        local_retention_ok = _local_retention_workspace_ready()
+        local_retention_status = "available" if local_retention_ok else "unavailable"
     if r2_ok:
         r2_status = "configured"
     else:
@@ -536,6 +561,7 @@ async def readiness_probe(request: Request) -> JSONResponse:
         and container_ok
         and operation_store_ok
         and (r2_ok or local_retention_effective)
+        and (not local_retention_effective or local_retention_ok)
     )
     readiness_status_code = (
         status.HTTP_200_OK if ready else status.HTTP_503_SERVICE_UNAVAILABLE
@@ -549,6 +575,7 @@ async def readiness_probe(request: Request) -> JSONResponse:
                 "service_container": container_status,
                 "operation_store": operation_store_status,
                 "r2_storage": r2_status,
+                "local_retention_storage": local_retention_status,
             },
             "correlation_id": correlation_id,
         },

--- a/src/dyvine/main.py
+++ b/src/dyvine/main.py
@@ -521,22 +521,21 @@ async def readiness_probe(request: Request) -> JSONResponse:
     # persist downloaded content. Delegate to ``R2Settings.is_configured``
     # so ``/readyz`` and ``R2StorageService`` stay in lockstep on the
     # exact fields a real upload needs.
-    # R2 is the archival target, but a deployment can run in local-retention
-    # mode (DOUYIN_RETAIN_LOCAL_DOWNLOADS), keeping downloads on the local
-    # volume instead of pushing to R2. In that mode missing R2 credentials are
-    # expected, so R2 stops gating readiness and the Pod is not held out of the
-    # load balancer for an intentionally-absent dependency.
-    r2_required = not settings.douyin.retain_local_downloads
     r2_ok = settings.r2.is_configured
+    # R2 is the archival target, but downloads fall back to local retention
+    # whenever R2 is unconfigured. Keep readiness aligned with the effective
+    # download path so a no-R2 deployment is not held out of service.
+    local_retention_effective = settings.douyin.retain_local_downloads or not r2_ok
     if r2_ok:
         r2_status = "configured"
-    elif r2_required:
-        r2_status = "missing_credentials"
     else:
         r2_status = "disabled"
 
     ready = (
-        douyin_ok and container_ok and operation_store_ok and (r2_ok or not r2_required)
+        douyin_ok
+        and container_ok
+        and operation_store_ok
+        and (r2_ok or local_retention_effective)
     )
     readiness_status_code = (
         status.HTTP_200_OK if ready else status.HTTP_503_SERVICE_UNAVAILABLE
@@ -675,9 +674,11 @@ async def health_check(request: Request) -> JSONResponse:
     # configuration but never affect the HTTP status code. Use ``/readyz``
     # if you need the dependency-aware gate.
     douyin_status = "configured" if settings.douyin.cookie else "missing_credentials"
-    if settings.r2.is_configured:
+    r2_ok = settings.r2.is_configured
+    local_retention_effective = settings.douyin.retain_local_downloads or not r2_ok
+    if r2_ok:
         r2_status = "configured"
-    elif settings.douyin.retain_local_downloads:
+    elif local_retention_effective:
         # Intentionally absent in local-retention mode; not a fault.
         r2_status = "disabled"
     else:

--- a/src/dyvine/main.py
+++ b/src/dyvine/main.py
@@ -521,10 +521,23 @@ async def readiness_probe(request: Request) -> JSONResponse:
     # persist downloaded content. Delegate to ``R2Settings.is_configured``
     # so ``/readyz`` and ``R2StorageService`` stay in lockstep on the
     # exact fields a real upload needs.
+    # R2 is the archival target, but a deployment can run in local-retention
+    # mode (DOUYIN_RETAIN_LOCAL_DOWNLOADS), keeping downloads on the local
+    # volume instead of pushing to R2. In that mode missing R2 credentials are
+    # expected, so R2 stops gating readiness and the Pod is not held out of the
+    # load balancer for an intentionally-absent dependency.
+    r2_required = not settings.douyin.retain_local_downloads
     r2_ok = settings.r2.is_configured
-    r2_status = "configured" if r2_ok else "missing_credentials"
+    if r2_ok:
+        r2_status = "configured"
+    elif r2_required:
+        r2_status = "missing_credentials"
+    else:
+        r2_status = "disabled"
 
-    ready = douyin_ok and container_ok and operation_store_ok and r2_ok
+    ready = (
+        douyin_ok and container_ok and operation_store_ok and (r2_ok or not r2_required)
+    )
     readiness_status_code = (
         status.HTTP_200_OK if ready else status.HTTP_503_SERVICE_UNAVAILABLE
     )
@@ -662,7 +675,13 @@ async def health_check(request: Request) -> JSONResponse:
     # configuration but never affect the HTTP status code. Use ``/readyz``
     # if you need the dependency-aware gate.
     douyin_status = "configured" if settings.douyin.cookie else "missing_credentials"
-    r2_status = "configured" if settings.r2.is_configured else "missing_credentials"
+    if settings.r2.is_configured:
+        r2_status = "configured"
+    elif settings.douyin.retain_local_downloads:
+        # Intentionally absent in local-retention mode; not a fault.
+        r2_status = "disabled"
+    else:
+        r2_status = "missing_credentials"
     dependencies = {
         "douyin_api": douyin_status,
         "r2_storage": r2_status,

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -774,7 +774,22 @@ class PostService:
                 posts_filter = await posts_iterator.__anext__()
             except StopAsyncIteration:
                 return {}
-            return dict(posts_filter._to_dict())
+
+            raw_data = _mapping_from(posts_filter, "_to_raw")
+            list_data = _list_from(posts_filter, "_to_list")
+            if list_data:
+                batch_data = dict(raw_data or {})
+                batch_data["aweme_list"] = list_data
+                return batch_data
+
+            dict_data = _mapping_from(posts_filter, "_to_dict")
+            if raw_data is not None and (
+                raw_data.get("aweme_list")
+                or dict_data is None
+                or not dict_data.get("aweme_list")
+            ):
+                return raw_data
+            return dict_data or {}
         finally:
             aclose = getattr(posts_iterator, "aclose", None)
             if callable(aclose):
@@ -878,8 +893,9 @@ class PostService:
         )
 
         try:
+            post_payload = _prepare_post_for_downloader(post)
             await self.handler.downloader.create_download_tasks(
-                self.handler.kwargs, [post], user_path
+                self.handler.kwargs, [post_payload], user_path
             )
 
         except Exception as e:
@@ -970,6 +986,138 @@ class PostService:
 # serialization shape easy to unit test and avoids leaking sqlite-aware
 # logic into the response model.
 # ----------------------------------------------------------------------
+
+
+def _mapping_from(obj: Any, method_name: str) -> dict[str, Any] | None:
+    """Return a dict from a zero-argument conversion method when available."""
+    method = getattr(obj, method_name, None)
+    if not callable(method):
+        return None
+    value = method()
+    if isinstance(value, dict):
+        return dict(value)
+    return None
+
+
+def _list_from(obj: Any, method_name: str) -> list[dict[str, Any]] | None:
+    """Return a list of dictionaries from a zero-argument conversion method."""
+    method = getattr(obj, method_name, None)
+    if not callable(method):
+        return None
+    value = method()
+    if not isinstance(value, list):
+        return None
+    items = [dict(item) for item in value if isinstance(item, dict)]
+    return items or None
+
+
+def _prepare_post_for_downloader(post: dict[str, Any]) -> dict[str, Any]:
+    """Adapt raw Douyin post payloads to the f2 downloader field contract."""
+    prepared = dict(post)
+
+    author = prepared.get("author")
+    if not prepared.get("sec_user_id") and isinstance(author, dict):
+        sec_user_id = author.get("sec_uid") or author.get("sec_user_id")
+        if isinstance(sec_user_id, str) and sec_user_id:
+            prepared["sec_user_id"] = sec_user_id
+
+    status = prepared.get("status")
+    if isinstance(status, dict):
+        if "private_status" not in prepared:
+            prepared["private_status"] = status.get("private_status")
+        if "is_prohibited" not in prepared:
+            prepared["is_prohibited"] = status.get("is_prohibited")
+
+    if not prepared.get("video_play_addr"):
+        video_urls = _video_urls_from_raw_post(prepared)
+        if video_urls:
+            prepared["video_play_addr"] = video_urls
+
+    normalized_images = _image_urls_from_raw_post(prepared)
+    if normalized_images:
+        prepared["images"] = normalized_images
+
+    normalized_live_images = _image_video_urls_from_raw_post(prepared)
+    if normalized_live_images:
+        prepared["images_video"] = normalized_live_images
+
+    return prepared
+
+
+def _video_urls_from_raw_post(post: dict[str, Any]) -> list[str]:
+    """Extract playable video URLs from raw or semi-normalized post data."""
+    video = post.get("video")
+    if not isinstance(video, dict):
+        return []
+
+    bit_rates = video.get("bit_rate")
+    if isinstance(bit_rates, list):
+        for bit_rate in bit_rates:
+            if isinstance(bit_rate, dict):
+                urls = _url_list_from(bit_rate.get("play_addr"))
+                if urls:
+                    return urls
+
+    return _url_list_from(video.get("play_addr"))
+
+
+def _image_urls_from_raw_post(post: dict[str, Any]) -> list[str | list[str]]:
+    """Extract image URLs in the shape expected by f2's image downloader."""
+    images = post.get("images")
+    if not isinstance(images, list):
+        return []
+
+    normalized: list[str | list[str]] = []
+    for image in images:
+        urls = _url_list_from(image)
+        if urls:
+            normalized.append(_url_or_urls(urls))
+    return normalized
+
+
+def _image_video_urls_from_raw_post(post: dict[str, Any]) -> list[str | list[str]]:
+    """Extract live-photo video URLs from raw image entries."""
+    existing = post.get("images_video")
+    if isinstance(existing, list):
+        normalized_existing = [
+            _url_or_urls(urls) for item in existing if (urls := _url_list_from(item))
+        ]
+        if normalized_existing:
+            return normalized_existing
+
+    images = post.get("images")
+    if not isinstance(images, list):
+        return []
+
+    normalized: list[str | list[str]] = []
+    for image in images:
+        if not isinstance(image, dict):
+            continue
+        video = image.get("video")
+        if not isinstance(video, dict):
+            continue
+        urls = _url_list_from(video.get("play_addr"))
+        if urls:
+            normalized.append(_url_or_urls(urls))
+    return normalized
+
+
+def _url_list_from(value: Any) -> list[str]:
+    """Return HTTP URLs from a string, list, or Douyin URL container dict."""
+    if isinstance(value, str):
+        return [value] if value.startswith("http") else []
+    if isinstance(value, list):
+        return [
+            item for item in value if isinstance(item, str) and item.startswith("http")
+        ]
+    if isinstance(value, dict):
+        return _url_list_from(value.get("url_list"))
+    return []
+
+
+def _url_or_urls(urls: list[str]) -> str | list[str]:
+    """Collapse single-link fallbacks while preserving multi-link alternatives."""
+    return urls[0] if len(urls) == 1 else urls
 
 
 def _serialize_download_stats(stats: dict[PostType, int]) -> dict[str, int]:

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -1033,13 +1033,13 @@ def _prepare_post_for_downloader(post: dict[str, Any]) -> dict[str, Any]:
         if video_urls:
             prepared["video_play_addr"] = video_urls
 
-    normalized_images = _image_urls_from_raw_post(prepared)
-    if normalized_images:
-        prepared["images"] = normalized_images
-
     normalized_live_images = _image_video_urls_from_raw_post(prepared)
     if normalized_live_images:
         prepared["images_video"] = normalized_live_images
+
+    normalized_images = _image_urls_from_raw_post(prepared)
+    if normalized_images:
+        prepared["images"] = normalized_images
 
     return prepared
 

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -12,7 +12,7 @@
 
 The fetch loop (`_process_download`) walks the f2 paginated feed,
 downloads each batch into a per-task workspace under
-``downloads/<task_id>``, optionally pushes every artefact into
+``DOUYIN_DOWNLOAD_ROOT/tasks/<task_id>``, optionally pushes every artefact into
 Cloudflare R2 via the shared ``R2StorageService``, and finalises the
 operation row with a clamped ``progress`` value plus a terminal
 ``status``. In R2-archival mode the workspace is removed in a
@@ -48,6 +48,11 @@ from ..core.exceptions import (
 from ..core.logging import ContextLogger
 from ..core.operations import OperationStore
 from ..core.pagination import MAX_PAGES_FALLBACK, PAGE_MULTIPLIER, PAGE_SLACK
+from ..core.path_safety import (
+    ensure_within_root,
+    get_task_workspace_root,
+    relative_to_download_root,
+)
 from ..core.settings import settings
 from ..schemas.users import DownloadResponse, UserResponse
 from .storage import ContentType, R2StorageService
@@ -64,14 +69,9 @@ PAGE_SIZE = 100
 # the loop body.
 PAGE_FETCH_DELAY_SECONDS = 5.0
 
-# Parent directory that holds per-task download workspaces. Each running
-# ``_process_download`` invocation gets its own ``TEMP_DOWNLOAD_ROOT /
-# <task_id>`` subdirectory so two concurrent tasks cannot stomp on each
-# other's files or have the cleanup branch in one task delete the other's
-# in-flight downloads. In R2-archival mode each workspace is swept once
-# its files are uploaded; in local-retention mode the files are kept here
-# instead (see ``_should_retain_workspace``).
-TEMP_DOWNLOAD_ROOT = Path("downloads")
+# Name of the marker file placed in operation-owned workspaces. It lets the
+# retention cap prune only Dyvine task directories under the configured
+# download root, leaving unrelated user/bulk-download directories alone.
 TASK_WORKSPACE_MARKER = ".dyvine-task-workspace"
 
 
@@ -201,10 +201,10 @@ class UserService:
         - ``get_download_status(task_id)`` — current persisted state.
 
     Internal state is otherwise stateless: every download starts in a
-    fresh per-task workspace under ``downloads/<task_id>`` so two
-    concurrent downloads cannot stomp on each other's files. The
-    workspace is removed in a ``finally`` branch even on failure, unless
-    local-retention mode is active (see ``_should_retain_workspace``).
+    fresh per-task workspace under ``DOUYIN_DOWNLOAD_ROOT/tasks/<task_id>``
+    so two concurrent downloads cannot stomp on each other's files. The
+    workspace is removed after successful archival unless local-retention
+    mode is active (see ``_should_retain_workspace``).
     """
 
     def __init__(
@@ -605,8 +605,8 @@ class UserService:
         """Remove a per-task download workspace and all of its contents.
 
         Only the workspace itself is touched; the shared
-        ``TEMP_DOWNLOAD_ROOT`` parent is preserved so concurrent tasks
-        keep their own ``downloads/<task_id>`` siblings intact.
+        configured task workspace parent is preserved so concurrent tasks
+        keep their own ``tasks/<task_id>`` siblings intact.
 
         Args:
             temp_dir: Per-task workspace path. ``None`` and missing
@@ -820,10 +820,11 @@ class UserService:
         downloading_likes_only = not include_posts and include_likes
         mode_label = "like" if downloading_likes_only else "post"
 
-        # Each task gets its own workspace under ``TEMP_DOWNLOAD_ROOT`` so
-        # concurrent downloads cannot share files, and the cleanup branch
-        # only ever touches one task's directory.
+        # Each task gets its own workspace under the configured task root so
+        # concurrent downloads cannot share files, and the cleanup branch only
+        # ever touches one task's directory.
         temp_dir: Path | None = None
+        user_dir: Path | None = None
         downloaded_count = 0
         total_posts = 0
         failed_uploads = 0
@@ -842,9 +843,12 @@ class UserService:
                 error=None,
             )
 
-            TEMP_DOWNLOAD_ROOT.mkdir(exist_ok=True)
-            temp_dir = TEMP_DOWNLOAD_ROOT / task_id
+            workspace_root = get_task_workspace_root()
+            workspace_root.mkdir(parents=True, exist_ok=True)
+            ensure_within_root(workspace_root)
+            temp_dir = workspace_root / task_id
             temp_dir.mkdir(parents=True, exist_ok=True)
+            ensure_within_root(temp_dir)
             (temp_dir / TASK_WORKSPACE_MARKER).touch()
 
             handler_kwargs = self._build_handler_kwargs(
@@ -892,6 +896,12 @@ class UserService:
             # Create user directory inside the per-task workspace.
             user_dir = temp_dir / user_data.nickname
             user_dir.mkdir(exist_ok=True)
+            ensure_within_root(user_dir)
+            retained_download_path = relative_to_download_root(user_dir)
+            if retain_workspace:
+                await self.operation_store.update_operation(
+                    task_id, download_path=retained_download_path
+                )
 
             # Use the handler to download user posts.
             max_cursor = 0
@@ -1110,6 +1120,11 @@ class UserService:
                     },
                 )
 
+            if failed_uploads > 0 and user_dir is not None:
+                await self.operation_store.update_operation(
+                    task_id, download_path=relative_to_download_root(user_dir)
+                )
+
             await self._finalize_status(
                 task_id=task_id,
                 downloaded=downloaded_count,
@@ -1137,7 +1152,7 @@ class UserService:
                 # R2 upload failures are also retained so the only local copy is
                 # not discarded by the cleanup branch.
                 self._prune_retained_workspace(
-                    TEMP_DOWNLOAD_ROOT,
+                    get_task_workspace_root(),
                     settings.douyin.retain_max_gb,
                     protect=temp_dir,
                 )

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -12,11 +12,13 @@
 
 The fetch loop (`_process_download`) walks the f2 paginated feed,
 downloads each batch into a per-task workspace under
-``temp_downloads/<task_id>``, optionally pushes every artefact into
+``downloads/<task_id>``, optionally pushes every artefact into
 Cloudflare R2 via the shared ``R2StorageService``, and finalises the
 operation row with a clamped ``progress`` value plus a terminal
-``status``. The workspace is removed in a ``finally`` branch so a
-failed run does not leave files on disk.
+``status``. In R2-archival mode the workspace is removed in a
+``finally`` branch so a failed run does not leave files on disk; in
+local-retention mode (``DOUYIN_RETAIN_LOCAL_DOWNLOADS``, or whenever R2
+is unconfigured) it is kept and trimmed to an optional size cap instead.
 
 External dependencies are wrapped in `try`/`finally`:
 ``DouyinHandler`` is closed via ``_safely_close_handler`` to avoid
@@ -29,6 +31,7 @@ import asyncio
 import json
 import re
 import shutil
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, cast
 
@@ -65,8 +68,10 @@ PAGE_FETCH_DELAY_SECONDS = 5.0
 # ``_process_download`` invocation gets its own ``TEMP_DOWNLOAD_ROOT /
 # <task_id>`` subdirectory so two concurrent tasks cannot stomp on each
 # other's files or have the cleanup branch in one task delete the other's
-# in-flight downloads.
-TEMP_DOWNLOAD_ROOT = Path("temp_downloads")
+# in-flight downloads. In R2-archival mode each workspace is swept once
+# its files are uploaded; in local-retention mode the files are kept here
+# instead (see ``_should_retain_workspace``).
+TEMP_DOWNLOAD_ROOT = Path("downloads")
 
 
 def sanitize_filename(filename: str) -> str:
@@ -195,9 +200,10 @@ class UserService:
         - ``get_download_status(task_id)`` — current persisted state.
 
     Internal state is otherwise stateless: every download starts in a
-    fresh per-task workspace under ``temp_downloads/<task_id>`` so two
+    fresh per-task workspace under ``downloads/<task_id>`` so two
     concurrent downloads cannot stomp on each other's files. The
-    workspace is removed in a ``finally`` branch even on failure.
+    workspace is removed in a ``finally`` branch even on failure, unless
+    local-retention mode is active (see ``_should_retain_workspace``).
     """
 
     def __init__(
@@ -433,22 +439,35 @@ class UserService:
         return int(aweme_count) if isinstance(aweme_count, int) else 0
 
     async def _upload_directory_to_r2(
-        self, user_dir: Path, user_id: str, user_data: Any
+        self,
+        user_dir: Path,
+        user_id: str,
+        user_data: Any,
+        *,
+        delete_after_upload: bool = True,
+        file_paths: Iterable[Path] | None = None,
     ) -> tuple[int, int]:
         """Upload every file under ``user_dir`` to R2 storage.
 
         Walks the directory recursively, derives a content type from each
         file extension, generates the corresponding R2 path/metadata, and
-        uploads. Local files are deleted only after a successful upload so
-        a failed upload leaves the file on disk for the cleanup step to
-        sweep -- this keeps the download workspace empty between batches
-        without losing the file when the user retries.
+        uploads. When ``delete_after_upload`` is true a file is deleted only
+        after a successful upload so a failed upload leaves it on disk for
+        the cleanup step to sweep -- this keeps the download workspace empty
+        between batches without losing the file when the user retries.
+        Local-retention mode passes ``delete_after_upload=False`` so a local
+        copy survives even after a successful archival upload.
 
         Args:
             user_dir: Local directory holding files just produced by f2.
             user_id: Douyin user identifier used to derive R2 paths.
             user_data: Profile payload supplying the author name for
                 metadata.
+            delete_after_upload: Remove each local file once it uploads
+                successfully. Disabled in local-retention mode so the file
+                stays on the local volume.
+            file_paths: Optional explicit file set to upload. When omitted,
+                every file under ``user_dir`` is uploaded.
 
         Returns:
             Tuple of ``(uploaded_count, failed_count)`` so the caller can
@@ -456,7 +475,8 @@ class UserService:
         """
         uploaded_count = 0
         failed_count = 0
-        for file_path in user_dir.glob("**/*"):
+        candidates = file_paths if file_paths is not None else user_dir.glob("**/*")
+        for file_path in sorted(candidates):
             if not file_path.is_file():
                 continue
             try:
@@ -476,7 +496,8 @@ class UserService:
                 await self.storage.upload_file(
                     file_path, r2_path, metadata, content_type
                 )
-                file_path.unlink()
+                if delete_after_upload:
+                    file_path.unlink()
                 uploaded_count += 1
             except Exception as e:
                 failed_count += 1
@@ -578,7 +599,7 @@ class UserService:
 
         Only the workspace itself is touched; the shared
         ``TEMP_DOWNLOAD_ROOT`` parent is preserved so concurrent tasks
-        keep their own ``temp_downloads/<task_id>`` siblings intact.
+        keep their own ``downloads/<task_id>`` siblings intact.
 
         Args:
             temp_dir: Per-task workspace path. ``None`` and missing
@@ -613,6 +634,138 @@ class UserService:
             )
 
         shutil.rmtree(temp_dir, onexc=_on_rmtree_error)
+
+    @staticmethod
+    def _r2_upload_enabled() -> bool:
+        """Whether finished files should be pushed to R2.
+
+        Uploading needs complete R2 credentials; without them every upload
+        would fail, so the loop skips the attempt entirely (and keeps files
+        locally) rather than flooding the logs with upload errors.
+        """
+        return settings.r2.is_configured
+
+    @staticmethod
+    def _should_retain_workspace() -> bool:
+        """Whether to keep per-task files after the run instead of deleting them.
+
+        True when ``DOUYIN_RETAIN_LOCAL_DOWNLOADS`` is set, or whenever R2 is
+        not configured -- in that case the files have nowhere to be archived,
+        so deleting them in the ``finally`` branch would discard the only
+        copy.
+        """
+        return settings.douyin.retain_local_downloads or not settings.r2.is_configured
+
+    @staticmethod
+    def _dir_size_bytes(path: Path) -> int:
+        """Return the recursive on-disk size of ``path`` in bytes.
+
+        Files that vanish mid-walk (a concurrent task sweeping its own
+        workspace) are skipped rather than raising, so the size estimate is
+        safe to compute from the download ``finally`` branch.
+        """
+        total = 0
+        for child in path.glob("**/*"):
+            try:
+                if child.is_file():
+                    total += child.stat().st_size
+            except OSError:
+                continue
+        return total
+
+    @staticmethod
+    def _file_snapshot(path: Path) -> dict[Path, tuple[int, int, int]]:
+        """Capture file fingerprints under ``path`` keyed by relative path."""
+        snapshot: dict[Path, tuple[int, int, int]] = {}
+        for child in path.glob("**/*"):
+            try:
+                if not child.is_file():
+                    continue
+                stat = child.stat()
+                snapshot[child.relative_to(path)] = (
+                    stat.st_size,
+                    stat.st_mtime_ns,
+                    stat.st_ctime_ns,
+                )
+            except OSError:
+                continue
+        return snapshot
+
+    @staticmethod
+    def _files_changed_since(
+        path: Path, before: dict[Path, tuple[int, int, int]]
+    ) -> list[Path]:
+        """Return files that are new or changed compared with ``before``."""
+        changed: list[Path] = []
+        for child in path.glob("**/*"):
+            try:
+                if not child.is_file():
+                    continue
+                stat = child.stat()
+                fingerprint = (stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns)
+                if before.get(child.relative_to(path)) != fingerprint:
+                    changed.append(child)
+            except OSError:
+                continue
+        return changed
+
+    @staticmethod
+    def _prune_retained_workspace(
+        root: Path, max_gb: float, protect: Path | None = None
+    ) -> None:
+        """Evict the oldest retained workspaces until the tree fits ``max_gb``.
+
+        Local-retention mode keeps every task's files under ``root`` instead
+        of deleting them, so left unbounded the tree grows until the volume
+        fills. When ``max_gb`` is positive this trims it back under the cap by
+        removing the least-recently-modified task directories first; ``protect``
+        (the just-finished task) is never evicted so a run cannot delete the
+        files it just produced. ``max_gb <= 0`` disables pruning.
+
+        Like ``_cleanup_temp_dir`` this runs from the download ``finally``
+        branch and must never raise: a prune failure is logged and swallowed
+        so it cannot mask the task's real outcome.
+        """
+        if max_gb <= 0 or not root.exists():
+            return
+        cap_bytes = int(max_gb * 1024**3)
+        try:
+            entries = [child for child in root.iterdir() if child.is_dir()]
+        except OSError as exc:
+            logger.warning(
+                "Failed to scan retained workspace for pruning",
+                extra={"root": str(root), "error": str(exc)},
+            )
+            return
+
+        protected = protect.resolve() if protect is not None else None
+        sized = [(entry, UserService._dir_size_bytes(entry)) for entry in entries]
+        total = sum(size for _, size in sized)
+        if total <= cap_bytes:
+            return
+
+        def _mtime(entry: Path) -> float:
+            try:
+                return entry.stat().st_mtime
+            except OSError:
+                return 0.0
+
+        # Oldest first so the freshest downloads survive the trim.
+        for entry, size in sorted(sized, key=lambda item: _mtime(item[0])):
+            if total <= cap_bytes:
+                break
+            if protected is not None and entry.resolve() == protected:
+                continue
+            UserService._cleanup_temp_dir(entry)
+            total -= size
+            logger.info(
+                "Pruned retained workspace to respect size cap",
+                extra={
+                    "path": str(entry),
+                    "freed_bytes": size,
+                    "cap_bytes": cap_bytes,
+                },
+            )
 
     async def _process_download(
         self,
@@ -663,6 +816,10 @@ class UserService:
         downloaded_count = 0
         total_posts = 0
         failed_uploads = 0
+        # Decide upload/retention up front so the ``finally`` branch can pick
+        # cleanup vs. retention even if the run aborts before the first batch.
+        upload_enabled = self._r2_upload_enabled()
+        retain_workspace = self._should_retain_workspace()
         try:
             await self.operation_store.update_operation(
                 task_id,
@@ -818,26 +975,52 @@ class UserService:
                             progress,
                         )
 
+                    batch_snapshot = (
+                        self._file_snapshot(user_dir) if upload_enabled else {}
+                    )
+
                     # Download files to the per-task workspace.
                     await handler.downloader.create_download_tasks(
                         handler_kwargs, aweme_data._to_list(), user_dir
                     )
 
-                    # Push the freshly downloaded files to R2 and track
-                    # any failures so the final status can be downgraded.
-                    batch_uploaded, batch_failed = await self._upload_directory_to_r2(
-                        user_dir, user_id, user_data
-                    )
-                    failed_uploads += batch_failed
-                    logger.debug(
-                        "R2 upload batch finished",
-                        extra={
-                            "task_id": task_id,
-                            "user_id": user_id,
-                            "uploaded": batch_uploaded,
-                            "failed": batch_failed,
-                        },
-                    )
+                    # Push the freshly downloaded files to R2 and track any
+                    # failures so the final status can be downgraded. When R2
+                    # is unconfigured the upload is skipped entirely (it would
+                    # only fail) and the files are kept locally instead.
+                    if upload_enabled:
+                        batch_files = self._files_changed_since(
+                            user_dir, batch_snapshot
+                        )
+                        batch_uploaded, batch_failed = (
+                            await self._upload_directory_to_r2(
+                                user_dir,
+                                user_id,
+                                user_data,
+                                delete_after_upload=not retain_workspace,
+                                file_paths=batch_files,
+                            )
+                        )
+                        failed_uploads += batch_failed
+                        logger.debug(
+                            "R2 upload batch finished",
+                            extra={
+                                "task_id": task_id,
+                                "user_id": user_id,
+                                "uploaded": batch_uploaded,
+                                "failed": batch_failed,
+                                "candidate_files": len(batch_files),
+                            },
+                        )
+                    else:
+                        logger.debug(
+                            "R2 upload skipped; retaining files locally",
+                            extra={
+                                "task_id": task_id,
+                                "user_id": user_id,
+                                "retain_workspace": retain_workspace,
+                            },
+                        )
 
                     # Update cursor for next page
                     if (
@@ -901,4 +1084,15 @@ class UserService:
             )
 
         finally:
-            self._cleanup_temp_dir(temp_dir)
+            if retain_workspace:
+                # Local-retention mode (explicit DOUYIN_RETAIN_LOCAL_DOWNLOADS,
+                # or R2 unconfigured): keep the per-task workspace so downloads
+                # are never silently discarded, then enforce the optional size
+                # cap so the retained tree cannot grow without bound.
+                self._prune_retained_workspace(
+                    TEMP_DOWNLOAD_ROOT,
+                    settings.douyin.retain_max_gb,
+                    protect=temp_dir,
+                )
+            else:
+                self._cleanup_temp_dir(temp_dir)

--- a/src/dyvine/services/users.py
+++ b/src/dyvine/services/users.py
@@ -16,9 +16,9 @@ downloads each batch into a per-task workspace under
 Cloudflare R2 via the shared ``R2StorageService``, and finalises the
 operation row with a clamped ``progress`` value plus a terminal
 ``status``. In R2-archival mode the workspace is removed in a
-``finally`` branch so a failed run does not leave files on disk; in
-local-retention mode (``DOUYIN_RETAIN_LOCAL_DOWNLOADS``, or whenever R2
-is unconfigured) it is kept and trimmed to an optional size cap instead.
+``finally`` branch after successful archival; in local-retention mode
+(``DOUYIN_RETAIN_LOCAL_DOWNLOADS``, or whenever R2 is unconfigured) it is
+kept and trimmed to an optional size cap instead.
 
 External dependencies are wrapped in `try`/`finally`:
 ``DouyinHandler`` is closed via ``_safely_close_handler`` to avoid
@@ -72,6 +72,7 @@ PAGE_FETCH_DELAY_SECONDS = 5.0
 # its files are uploaded; in local-retention mode the files are kept here
 # instead (see ``_should_retain_workspace``).
 TEMP_DOWNLOAD_ROOT = Path("downloads")
+TASK_WORKSPACE_MARKER = ".dyvine-task-workspace"
 
 
 def sanitize_filename(filename: str) -> str:
@@ -446,6 +447,7 @@ class UserService:
         *,
         delete_after_upload: bool = True,
         file_paths: Iterable[Path] | None = None,
+        failed_paths: set[Path] | None = None,
     ) -> tuple[int, int]:
         """Upload every file under ``user_dir`` to R2 storage.
 
@@ -468,6 +470,9 @@ class UserService:
                 stays on the local volume.
             file_paths: Optional explicit file set to upload. When omitted,
                 every file under ``user_dir`` is uploaded.
+            failed_paths: Optional mutable set populated with files that did
+                not upload successfully. Callers use it to retry stale upload
+                failures before cleaning up a workspace.
 
         Returns:
             Tuple of ``(uploaded_count, failed_count)`` so the caller can
@@ -501,6 +506,8 @@ class UserService:
                 uploaded_count += 1
             except Exception as e:
                 failed_count += 1
+                if failed_paths is not None:
+                    failed_paths.add(file_path)
                 logger.error(
                     "Failed to upload file to R2",
                     extra={"file_path": str(file_path), "error": str(e)},
@@ -730,7 +737,11 @@ class UserService:
             return
         cap_bytes = int(max_gb * 1024**3)
         try:
-            entries = [child for child in root.iterdir() if child.is_dir()]
+            entries = [
+                child
+                for child in root.iterdir()
+                if child.is_dir() and (child / TASK_WORKSPACE_MARKER).is_file()
+            ]
         except OSError as exc:
             logger.warning(
                 "Failed to scan retained workspace for pruning",
@@ -816,6 +827,7 @@ class UserService:
         downloaded_count = 0
         total_posts = 0
         failed_uploads = 0
+        pending_upload_files: set[Path] = set()
         # Decide upload/retention up front so the ``finally`` branch can pick
         # cleanup vs. retention even if the run aborts before the first batch.
         upload_enabled = self._r2_upload_enabled()
@@ -833,6 +845,7 @@ class UserService:
             TEMP_DOWNLOAD_ROOT.mkdir(exist_ok=True)
             temp_dir = TEMP_DOWNLOAD_ROOT / task_id
             temp_dir.mkdir(parents=True, exist_ok=True)
+            (temp_dir / TASK_WORKSPACE_MARKER).touch()
 
             handler_kwargs = self._build_handler_kwargs(
                 user_id=user_id,
@@ -992,16 +1005,25 @@ class UserService:
                         batch_files = self._files_changed_since(
                             user_dir, batch_snapshot
                         )
+                        candidate_files = {
+                            path for path in pending_upload_files if path.exists()
+                        }
+                        candidate_files.update(batch_files)
+                        batch_failed_paths: set[Path] = set()
                         batch_uploaded, batch_failed = (
                             await self._upload_directory_to_r2(
                                 user_dir,
                                 user_id,
                                 user_data,
                                 delete_after_upload=not retain_workspace,
-                                file_paths=batch_files,
+                                file_paths=candidate_files,
+                                failed_paths=batch_failed_paths,
                             )
                         )
-                        failed_uploads += batch_failed
+                        pending_upload_files = {
+                            path for path in batch_failed_paths if path.exists()
+                        }
+                        failed_uploads = len(pending_upload_files)
                         logger.debug(
                             "R2 upload batch finished",
                             extra={
@@ -1009,7 +1031,7 @@ class UserService:
                                 "user_id": user_id,
                                 "uploaded": batch_uploaded,
                                 "failed": batch_failed,
-                                "candidate_files": len(batch_files),
+                                "candidate_files": len(candidate_files),
                             },
                         )
                     else:
@@ -1063,6 +1085,31 @@ class UserService:
                     # loop spins.
                     has_more = False
 
+            if upload_enabled and pending_upload_files:
+                retry_failed_paths: set[Path] = set()
+                retry_uploaded, retry_failed = await self._upload_directory_to_r2(
+                    user_dir,
+                    user_id,
+                    user_data,
+                    delete_after_upload=not retain_workspace,
+                    file_paths={path for path in pending_upload_files if path.exists()},
+                    failed_paths=retry_failed_paths,
+                )
+                pending_upload_files = {
+                    path for path in retry_failed_paths if path.exists()
+                }
+                failed_uploads = len(pending_upload_files)
+                logger.debug(
+                    "R2 upload retry finished",
+                    extra={
+                        "task_id": task_id,
+                        "user_id": user_id,
+                        "uploaded": retry_uploaded,
+                        "failed": retry_failed,
+                        "remaining_failed_files": failed_uploads,
+                    },
+                )
+
             await self._finalize_status(
                 task_id=task_id,
                 downloaded=downloaded_count,
@@ -1084,11 +1131,11 @@ class UserService:
             )
 
         finally:
-            if retain_workspace:
+            if retain_workspace or failed_uploads > 0:
                 # Local-retention mode (explicit DOUYIN_RETAIN_LOCAL_DOWNLOADS,
-                # or R2 unconfigured): keep the per-task workspace so downloads
-                # are never silently discarded, then enforce the optional size
-                # cap so the retained tree cannot grow without bound.
+                # or R2 unconfigured) keeps the per-task workspace. Unresolved
+                # R2 upload failures are also retained so the only local copy is
+                # not discarded by the cleanup branch.
                 self._prune_retained_workspace(
                     TEMP_DOWNLOAD_ROOT,
                     settings.douyin.retain_max_gb,

--- a/tests/core/test_path_safety.py
+++ b/tests/core/test_path_safety.py
@@ -153,6 +153,13 @@ def test_relative_to_download_root_relative_input(jail_root: Path) -> None:
     )
 
 
+def test_get_task_workspace_root_uses_download_root(jail_root: Path) -> None:
+    """Task workspaces live under the configured download root."""
+    assert path_safety.get_task_workspace_root() == (
+        jail_root / path_safety.TASK_WORKSPACE_SUBDIR
+    )
+
+
 def test_relative_to_download_root_absolute_inside_root(jail_root: Path) -> None:
     """Verify relative to download root absolute inside root."""
     inside = jail_root / "livestreams" / "abc.flv"

--- a/tests/services/test_post_service.py
+++ b/tests/services/test_post_service.py
@@ -15,6 +15,7 @@ from dyvine.core.exceptions import (
 )
 from dyvine.core.operations import OperationStore
 from dyvine.schemas.posts import DownloadStatus, PostType
+from dyvine.services import posts as posts_mod
 from dyvine.services.posts import PostService
 
 
@@ -517,6 +518,89 @@ async def test_download_post_content_normalizes_raw_video_payload() -> None:
     assert sent_post["private_status"] == 0
     assert sent_post["is_prohibited"] is False
     assert sent_post["video_play_addr"] == ["https://example.com/video.mp4"]
+
+
+def test_downloader_payload_helpers_cover_nested_media_shapes() -> None:
+    """Raw media helpers normalize images, live photos, and URL containers."""
+    raw_post = {
+        "aweme_id": "mixed-media",
+        "author": {"sec_user_id": "sec-from-author"},
+        "status": {"private_status": 1, "is_prohibited": True},
+        "video": {"play_addr": {"url_list": ["https://example.com/fallback.mp4"]}},
+        "images": [
+            {
+                "url_list": [
+                    "https://example.com/one.webp",
+                    "https://example.com/two.webp",
+                ],
+                "video": {"play_addr": {"url_list": ["https://example.com/live.mp4"]}},
+            },
+            {"url_list": ["https://example.com/three.webp"]},
+            "not-a-dict",
+            {"video": {}},
+        ],
+    }
+
+    prepared = posts_mod._prepare_post_for_downloader(raw_post)
+
+    assert prepared["sec_user_id"] == "sec-from-author"
+    assert prepared["private_status"] == 1
+    assert prepared["is_prohibited"] is True
+    assert prepared["video_play_addr"] == ["https://example.com/fallback.mp4"]
+    assert prepared["images"] == [
+        ["https://example.com/one.webp", "https://example.com/two.webp"],
+        "https://example.com/three.webp",
+    ]
+    assert prepared["images_video"] == ["https://example.com/live.mp4"]
+
+    prepared_existing = posts_mod._prepare_post_for_downloader(
+        {
+            "aweme_id": "existing-live-photo",
+            "images_video": [
+                {
+                    "url_list": [
+                        "https://example.com/existing-a.mp4",
+                        "https://example.com/existing-b.mp4",
+                    ]
+                }
+            ],
+        }
+    )
+    assert prepared_existing["images_video"] == [
+        ["https://example.com/existing-a.mp4", "https://example.com/existing-b.mp4"]
+    ]
+
+
+def test_downloader_payload_helpers_ignore_invalid_shapes() -> None:
+    """Helper adapters return empty values for unsupported SDK shapes."""
+
+    class MissingConverters:
+        """Object without f2 conversion helpers."""
+
+    class InvalidConverters:
+        """Object whose conversion helpers return unsupported shapes."""
+
+        def _to_raw(self) -> list[str]:
+            return ["not", "a", "mapping"]
+
+        def _to_list(self) -> str:
+            return "not-a-list"
+
+    assert posts_mod._mapping_from(MissingConverters(), "_to_raw") is None
+    assert posts_mod._mapping_from(InvalidConverters(), "_to_raw") is None
+    assert posts_mod._list_from(MissingConverters(), "_to_list") is None
+    assert posts_mod._list_from(InvalidConverters(), "_to_list") is None
+    assert posts_mod._list_from(
+        type("MixedList", (), {"_to_list": lambda self: [{"ok": 1}, "bad"]})(),
+        "_to_list",
+    ) == [{"ok": 1}]
+
+    assert posts_mod._video_urls_from_raw_post({"video": "bad"}) == []
+    assert posts_mod._url_list_from("ftp://example.com/file.mp4") == []
+    assert posts_mod._url_list_from({"url_list": "https://example.com/file.mp4"}) == [
+        "https://example.com/file.mp4"
+    ]
+    assert posts_mod._url_list_from(123) == []
 
 
 # ── start_bulk_download (async, mocked) ─────────────────────────────────

--- a/tests/services/test_post_service.py
+++ b/tests/services/test_post_service.py
@@ -385,6 +385,78 @@ async def test_fetch_posts_batch_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_posts_batch_prefers_raw_aweme_list() -> None:
+    """Use raw f2 payloads when normalized dict output drops aweme_list."""
+    handler = MagicMock()
+    posts_filter = MagicMock()
+    posts_filter._to_raw.return_value = {
+        "aweme_list": [{"aweme_id": "raw-post"}],
+        "has_more": False,
+        "max_cursor": 0,
+    }
+    posts_filter._to_dict.return_value = {"aweme_list": []}
+
+    async def _iter(*a, **kw):
+        """Test helper for test_fetch_posts_batch_prefers_raw_aweme_list."""
+        yield posts_filter
+
+    handler.fetch_user_post_videos = _iter
+    svc = _build_service(handler)
+    result = await svc._fetch_posts_batch("u1", 0)
+    assert result["aweme_list"] == [{"aweme_id": "raw-post"}]
+
+
+@pytest.mark.asyncio
+async def test_fetch_posts_batch_prefers_to_list_downloader_shape() -> None:
+    """Use f2's per-post list projection when available for bulk downloads."""
+    handler = MagicMock()
+    posts_filter = MagicMock()
+    posts_filter._to_raw.return_value = {
+        "aweme_list": [
+            {
+                "aweme_id": "raw-post",
+                "video": {
+                    "bit_rate": [
+                        {"play_addr": {"url_list": ["https://example.com/raw.mp4"]}}
+                    ]
+                },
+            }
+        ],
+        "has_more": False,
+        "max_cursor": 0,
+    }
+    posts_filter._to_list.return_value = [
+        {
+            "aweme_id": "flat-post",
+            "aweme_type": 0,
+            "private_status": 0,
+            "video_play_addr": ["https://example.com/flat.mp4"],
+        }
+    ]
+    posts_filter._to_dict.return_value = {}
+
+    async def _iter(*a, **kw):
+        """Test helper for
+        test_fetch_posts_batch_prefers_to_list_downloader_shape.
+        """
+        yield posts_filter
+
+    handler.fetch_user_post_videos = _iter
+    svc = _build_service(handler)
+    result = await svc._fetch_posts_batch("u1", 0)
+    assert result["aweme_list"] == [
+        {
+            "aweme_id": "flat-post",
+            "aweme_type": 0,
+            "private_status": 0,
+            "video_play_addr": ["https://example.com/flat.mp4"],
+        }
+    ]
+    assert result["has_more"] is False
+    assert result["max_cursor"] == 0
+
+
+@pytest.mark.asyncio
 async def test_fetch_posts_batch_empty() -> None:
     """Verify fetch posts batch empty."""
     handler = MagicMock()
@@ -415,6 +487,36 @@ async def test_download_post_content_success() -> None:
     svc = _build_service(handler)
     await svc._download_post_content({"aweme_id": "123"}, PostType.VIDEO, Path("/tmp"))
     handler.downloader.create_download_tasks.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_download_post_content_normalizes_raw_video_payload() -> None:
+    """Raw Douyin posts are adapted before they are passed to f2."""
+    handler = MagicMock()
+    handler.downloader = MagicMock()
+    handler.downloader.create_download_tasks = AsyncMock()
+    handler.kwargs = {}
+    from pathlib import Path
+
+    raw_post = {
+        "aweme_id": "123",
+        "aweme_type": 0,
+        "author": {"sec_uid": "sec-user"},
+        "status": {"private_status": 0, "is_prohibited": False},
+        "video": {
+            "bit_rate": [{"play_addr": {"url_list": ["https://example.com/video.mp4"]}}]
+        },
+    }
+
+    svc = _build_service(handler)
+    await svc._download_post_content(raw_post, PostType.VIDEO, Path("/tmp"))
+
+    _, payload, _ = handler.downloader.create_download_tasks.await_args.args
+    sent_post = payload[0]
+    assert sent_post["sec_user_id"] == "sec-user"
+    assert sent_post["private_status"] == 0
+    assert sent_post["is_prohibited"] is False
+    assert sent_post["video_play_addr"] == ["https://example.com/video.mp4"]
 
 
 # ── start_bulk_download (async, mocked) ─────────────────────────────────

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -621,8 +621,12 @@ async def test_upload_directory_to_r2_counts_partial_failures(
     user_data = MagicMock()
     user_data.nickname = "nick"
 
+    failed_paths: set[Path] = set()
     uploaded, failed = await service._upload_directory_to_r2(
-        user_dir, user_id="user-123", user_data=user_data
+        user_dir,
+        user_id="user-123",
+        user_data=user_data,
+        failed_paths=failed_paths,
     )
 
     assert (uploaded, failed) == (2, 1)
@@ -631,6 +635,7 @@ async def test_upload_directory_to_r2_counts_partial_failures(
     assert not file_ok_one.exists()
     assert not file_ok_two.exists()
     assert file_failing.exists()
+    assert failed_paths == {file_failing}
 
 
 @pytest.mark.asyncio
@@ -783,6 +788,112 @@ async def test_process_download_uploads_only_files_changed_in_current_batch(
 
 
 @pytest.mark.asyncio
+async def test_process_download_retries_stale_upload_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Failed uploads from earlier pages are retried before cleanup."""
+    from dyvine.services import users as users_mod
+
+    monkeypatch.chdir(tmp_path)
+
+    mock_user_data = MagicMock()
+    mock_user_data.nickname = "retry-user"
+    mock_user_data.aweme_count = 2
+
+    first_batch = MagicMock()
+    first_batch.has_aweme = True
+    first_batch.aweme_id = ["aw1"]
+    first_batch.has_more = True
+    first_batch.max_cursor = 1
+    first_batch._to_list = MagicMock(return_value=[])
+
+    second_batch = MagicMock()
+    second_batch.has_aweme = True
+    second_batch.aweme_id = ["aw2"]
+    second_batch.has_more = False
+    second_batch.max_cursor = 2
+    second_batch._to_list = MagicMock(return_value=[])
+
+    async def fake_fetch_posts(*_args: Any, max_cursor: int, **_kwargs: Any) -> Any:
+        """Yield two pages so the first page's failed file can be retried."""
+        if max_cursor == 0:
+            yield first_batch
+        elif max_cursor == 1:
+            yield second_batch
+
+    class FakeDownloader:
+        """Downloader double that writes one file per page."""
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def create_download_tasks(
+            self, _kwargs: dict[str, Any], _items: list[Any], user_dir: Path
+        ) -> None:
+            """Write a deterministic page file for upload retry assertions."""
+            self.calls += 1
+            filename = "first.mp4" if self.calls == 1 else "second.mp4"
+            (Path(user_dir) / filename).write_bytes(filename.encode("utf-8"))
+
+    class FakeHandler:
+        """Handler double exposing the fake profile, fetch, and downloader."""
+
+        def __init__(self, _kwargs: dict[str, Any]) -> None:
+            self.downloader = FakeDownloader()
+
+        fetch_user_profile = AsyncMock(return_value=mock_user_data)
+        fetch_user_post_videos = staticmethod(fake_fetch_posts)
+
+    upload_attempts: list[str] = []
+    first_upload_failed = False
+
+    async def fake_upload_file(
+        local_path: Path,
+        _r2_path: str,
+        _metadata: dict[str, str],
+        _content_type: str,
+    ) -> None:
+        """Fail the first file once, then allow the retry to archive it."""
+        nonlocal first_upload_failed
+        name = Path(local_path).name
+        upload_attempts.append(name)
+        if name == "first.mp4" and not first_upload_failed:
+            first_upload_failed = True
+            raise users_mod.ServiceError("transient upload outage")
+
+    monkeypatch.setattr(users_mod, "DouyinHandler", FakeHandler)
+    monkeypatch.setattr(users_mod.asyncio, "sleep", AsyncMock())
+
+    service = UserService()
+    monkeypatch.setattr(service, "_r2_upload_enabled", lambda: True)
+    monkeypatch.setattr(service, "_should_retain_workspace", lambda: False)
+    service.storage.generate_ugc_path = MagicMock(return_value="r2/path")
+    service.storage.generate_metadata = MagicMock(return_value={"category": "posts"})
+    monkeypatch.setattr(service.storage, "upload_file", fake_upload_file)
+
+    operation = await service.operation_store.create_operation(
+        operation_type="user_content_download",
+        subject_id="retry-user",
+        status="pending",
+        message="scheduled",
+    )
+
+    await service._process_download(
+        operation.operation_id,
+        user_id="retry-user",
+        include_posts=True,
+        include_likes=False,
+        max_items=None,
+    )
+
+    assert upload_attempts == ["first.mp4", "first.mp4", "second.mp4"]
+    refreshed = await service.operation_store.get_operation(operation.operation_id)
+    assert refreshed.status == "completed"
+    task_dir = tmp_path / users_mod.TEMP_DOWNLOAD_ROOT / operation.operation_id
+    assert not task_dir.exists(), "clean archival runs still sweep the workspace"
+
+
+@pytest.mark.asyncio
 async def test_process_download_retains_workspace_when_r2_unconfigured(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -878,11 +989,16 @@ def test_prune_retained_workspace_evicts_oldest_over_cap(tmp_path: Path) -> None
         """Test helper for test_prune_retained_workspace_evicts_oldest_over_cap."""
         task = root / name
         task.mkdir()
+        (task / users_mod.TASK_WORKSPACE_MARKER).touch()
         (task / "blob.bin").write_bytes(b"x" * size)
         os.utime(task, (mtime, mtime))
         return task
 
     one_mib = 1024 * 1024
+    unrelated = root / "bulk-post-user"
+    unrelated.mkdir()
+    (unrelated / "old-download.mp4").write_bytes(b"x" * one_mib)
+    os.utime(unrelated, (500.0, 500.0))
     oldest = make_task("oldest", one_mib, mtime=1_000.0)
     newer = make_task("newer", one_mib, mtime=2_000.0)
     newest = make_task("newest", one_mib, mtime=3_000.0)
@@ -895,6 +1011,7 @@ def test_prune_retained_workspace_evicts_oldest_over_cap(tmp_path: Path) -> None
     assert oldest.exists(), "the protected current task must never be evicted"
     assert not newer.exists(), "the next-oldest unprotected workspace is evicted"
     assert newest.exists(), "newer workspaces survive once the tree fits the cap"
+    assert unrelated.exists(), "unmarked download directories are outside prune scope"
 
 
 def test_prune_retained_workspace_noop_when_cap_zero(tmp_path: Path) -> None:
@@ -905,6 +1022,7 @@ def test_prune_retained_workspace_noop_when_cap_zero(tmp_path: Path) -> None:
     root.mkdir()
     task = root / "task-1"
     task.mkdir()
+    (task / users_mod.TASK_WORKSPACE_MARKER).touch()
     (task / "blob.bin").write_bytes(b"x" * 4096)
 
     users_mod.UserService._prune_retained_workspace(root, 0.0)

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -191,9 +192,13 @@ async def test_get_user_info_with_room_data(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 @pytest.mark.asyncio
-async def test_process_download_no_posts(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_process_download_no_posts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Verify process download no posts."""
     from dyvine.services import users as users_mod
+
+    monkeypatch.chdir(tmp_path)
 
     mock_user_data = MagicMock()
     mock_user_data.nickname = "NoPostUser"
@@ -233,10 +238,12 @@ async def test_process_download_no_posts(monkeypatch: pytest.MonkeyPatch) -> Non
 
 @pytest.mark.asyncio
 async def test_process_download_sets_failed_on_error(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Verify process download sets failed on error."""
     from dyvine.services import users as users_mod
+
+    monkeypatch.chdir(tmp_path)
 
     class FakeHandler:
         """Test double used by test_process_download_sets_failed_on_error."""
@@ -272,10 +279,12 @@ async def test_process_download_sets_failed_on_error(
 
 @pytest.mark.asyncio
 async def test_process_download_skips_when_nothing_requested(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """A request with neither posts nor likes should complete immediately."""
     from dyvine.services import users as users_mod
+
+    monkeypatch.chdir(tmp_path)
 
     fetch_profile = AsyncMock()
 
@@ -316,7 +325,7 @@ async def test_process_download_skips_when_nothing_requested(
 
 @pytest.mark.asyncio
 async def test_process_download_runs_when_only_likes_requested(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """``include_posts=False`` with ``include_likes=True`` routes to likes.
 
@@ -326,6 +335,8 @@ async def test_process_download_runs_when_only_likes_requested(
     the posts feed.
     """
     from dyvine.services import users as users_mod
+
+    monkeypatch.chdir(tmp_path)
 
     mock_user_data = MagicMock()
     mock_user_data.nickname = "likes-only-user"
@@ -521,7 +532,7 @@ async def test_process_download_likes_reports_progress_as_indeterminate(
 
     monkeypatch.setattr(users_mod, "DouyinHandler", FakeHandler)
 
-    # Redirect the working directory so ``temp_downloads`` is created
+    # Redirect the working directory so ``downloads`` is created
     # inside ``tmp_path`` and we never touch the repo tree.
     monkeypatch.chdir(tmp_path)
 
@@ -623,6 +634,285 @@ async def test_upload_directory_to_r2_counts_partial_failures(
 
 
 @pytest.mark.asyncio
+async def test_upload_directory_to_r2_keeps_files_when_delete_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``delete_after_upload=False`` keeps local copies after a clean upload.
+
+    Local-retention mode still archives to R2 when it is configured, but must
+    leave the file on the local volume so a durable copy survives. Verifies
+    the helper reports every file as uploaded while none are unlinked.
+    """
+    user_dir = tmp_path / "nick"
+    user_dir.mkdir()
+    file_one = user_dir / "video1.mp4"
+    file_one.write_bytes(b"a")
+    file_two = user_dir / "image1.jpg"
+    file_two.write_bytes(b"c")
+
+    uploaded_paths: list[Path] = []
+
+    async def fake_upload_file(
+        local_path: Path,
+        _r2_path: str,
+        _metadata: dict[str, str],
+        _content_type: str,
+    ) -> None:
+        """Record the upload without unlinking the local file."""
+        uploaded_paths.append(Path(local_path))
+
+    service = UserService()
+    service.storage.generate_ugc_path = MagicMock(return_value="r2/path")
+    service.storage.generate_metadata = MagicMock(return_value={"category": "posts"})
+    monkeypatch.setattr(service.storage, "upload_file", fake_upload_file)
+
+    user_data = MagicMock()
+    user_data.nickname = "nick"
+
+    uploaded, failed = await service._upload_directory_to_r2(
+        user_dir,
+        user_id="user-123",
+        user_data=user_data,
+        delete_after_upload=False,
+    )
+
+    assert (uploaded, failed) == (2, 0)
+    # Retention mode keeps the local copies despite the successful upload.
+    assert file_one.exists()
+    assert file_two.exists()
+    assert len(uploaded_paths) == 2
+
+
+@pytest.mark.asyncio
+async def test_process_download_uploads_only_files_changed_in_current_batch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Retained files from earlier batches must not be re-uploaded."""
+    from dyvine.services import users as users_mod
+
+    monkeypatch.chdir(tmp_path)
+
+    mock_user_data = MagicMock()
+    mock_user_data.nickname = "retain-r2-user"
+    mock_user_data.aweme_count = 2
+
+    first_batch = MagicMock()
+    first_batch.has_aweme = True
+    first_batch.aweme_id = ["aw1"]
+    first_batch.has_more = True
+    first_batch.max_cursor = 1
+    first_batch._to_list = MagicMock(return_value=[])
+
+    second_batch = MagicMock()
+    second_batch.has_aweme = True
+    second_batch.aweme_id = ["aw2"]
+    second_batch.has_more = False
+    second_batch.max_cursor = 2
+    second_batch._to_list = MagicMock(return_value=[])
+
+    async def fake_fetch_posts(*_args: Any, max_cursor: int, **_kwargs: Any) -> Any:
+        """Yield one batch per cursor so the loop performs two uploads."""
+        if max_cursor == 0:
+            yield first_batch
+        elif max_cursor == 1:
+            yield second_batch
+
+    class FakeDownloader:
+        """Downloader double that leaves prior batch files on disk."""
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def create_download_tasks(
+            self, _kwargs: dict[str, Any], _items: list[Any], user_dir: Path
+        ) -> None:
+            """Write one new file per batch into the retained workspace."""
+            self.calls += 1
+            filename = "first.mp4" if self.calls == 1 else "second.mp4"
+            (Path(user_dir) / filename).write_bytes(filename.encode("utf-8"))
+
+    class FakeHandler:
+        """Handler double exposing the fake profile, fetch, and downloader."""
+
+        def __init__(self, _kwargs: dict[str, Any]) -> None:
+            self.downloader = FakeDownloader()
+
+        fetch_user_profile = AsyncMock(return_value=mock_user_data)
+        fetch_user_post_videos = staticmethod(fake_fetch_posts)
+
+    uploaded_names: list[str] = []
+
+    async def fake_upload_file(
+        local_path: Path,
+        _r2_path: str,
+        _metadata: dict[str, str],
+        _content_type: str,
+    ) -> None:
+        """Record the file names selected for upload."""
+        uploaded_names.append(Path(local_path).name)
+
+    monkeypatch.setattr(users_mod, "DouyinHandler", FakeHandler)
+    monkeypatch.setattr(users_mod.asyncio, "sleep", AsyncMock())
+
+    service = UserService()
+    monkeypatch.setattr(service, "_r2_upload_enabled", lambda: True)
+    monkeypatch.setattr(service, "_should_retain_workspace", lambda: True)
+    service.storage.generate_ugc_path = MagicMock(return_value="r2/path")
+    service.storage.generate_metadata = MagicMock(return_value={"category": "posts"})
+    monkeypatch.setattr(service.storage, "upload_file", fake_upload_file)
+
+    operation = await service.operation_store.create_operation(
+        operation_type="user_content_download",
+        subject_id="retain-r2-user",
+        status="pending",
+        message="scheduled",
+    )
+
+    await service._process_download(
+        operation.operation_id,
+        user_id="retain-r2-user",
+        include_posts=True,
+        include_likes=False,
+        max_items=None,
+    )
+
+    assert uploaded_names == ["first.mp4", "second.mp4"]
+    task_dir = tmp_path / users_mod.TEMP_DOWNLOAD_ROOT / operation.operation_id
+    assert (task_dir / "retain-r2-user" / "first.mp4").exists()
+    assert (task_dir / "retain-r2-user" / "second.mp4").exists()
+
+
+@pytest.mark.asyncio
+async def test_process_download_retains_workspace_when_r2_unconfigured(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With R2 unconfigured the per-task workspace is kept, not swept.
+
+    R2 is the archival target; when it is not configured a finished download
+    has nowhere to go, so the ``finally`` branch must retain the local files
+    instead of deleting the only copy. Verifies the task directory and its
+    downloaded file survive the run.
+    """
+    from dyvine.services import users as users_mod
+
+    monkeypatch.chdir(tmp_path)
+
+    mock_user_data = MagicMock()
+    mock_user_data.nickname = "retain-user"
+    mock_user_data.aweme_count = 1
+
+    aweme_batch = MagicMock()
+    aweme_batch.has_aweme = True
+    aweme_batch.aweme_id = ["aw1"]
+    aweme_batch.has_more = False
+    aweme_batch.max_cursor = 0
+    aweme_batch._to_list = MagicMock(return_value=[])
+
+    async def fake_fetch_posts(*_args: Any, **_kwargs: Any) -> Any:
+        """Yield a single post batch for the retention test."""
+        yield aweme_batch
+
+    class FakeDownloader:
+        """Downloader double that writes one file into the workspace."""
+
+        async def create_download_tasks(
+            self, _kwargs: dict[str, Any], _items: list[Any], user_dir: Path
+        ) -> None:
+            """Test helper for FakeDownloader."""
+            (Path(user_dir) / "clip.mp4").write_bytes(b"x")
+
+    class FakeHandler:
+        """Handler double exposing the fake profile, fetch, and downloader."""
+
+        def __init__(self, _kwargs: dict) -> None:
+            """Test helper for FakeHandler."""
+            self.downloader = FakeDownloader()
+
+        fetch_user_profile = AsyncMock(return_value=mock_user_data)
+        fetch_user_post_videos = staticmethod(fake_fetch_posts)
+
+    monkeypatch.setattr(users_mod, "DouyinHandler", FakeHandler)
+    monkeypatch.setattr(users_mod.asyncio, "sleep", AsyncMock())
+
+    service = UserService()
+    # Pin the unconfigured-R2 retain path so a developer ``.env`` with real R2
+    # credentials cannot flip this test onto the cleanup branch.
+    monkeypatch.setattr(service, "_r2_upload_enabled", lambda: False)
+    monkeypatch.setattr(service, "_should_retain_workspace", lambda: True)
+
+    operation = await service.operation_store.create_operation(
+        operation_type="user_content_download",
+        subject_id="retain-user",
+        status="pending",
+        message="scheduled",
+    )
+
+    await service._process_download(
+        operation.operation_id,
+        user_id="retain-user",
+        include_posts=True,
+        include_likes=False,
+        max_items=1,
+    )
+
+    workspace_root = (tmp_path / users_mod.TEMP_DOWNLOAD_ROOT).resolve()
+    task_dir = workspace_root / operation.operation_id
+    assert task_dir.exists(), "retain mode must keep the per-task workspace"
+    assert list(task_dir.glob("**/*.mp4")), "the downloaded file must survive"
+
+
+def test_prune_retained_workspace_evicts_oldest_over_cap(tmp_path: Path) -> None:
+    """Pruning removes the oldest task dirs until the tree fits the cap.
+
+    A positive ``retain_max_gb`` must bound the workspace by evicting the
+    least-recently-modified directories first, while never touching the
+    ``protect`` directory (the task that just finished) even when it is the
+    oldest entry.
+    """
+    from dyvine.services import users as users_mod
+
+    root = tmp_path / "downloads"
+    root.mkdir()
+
+    def make_task(name: str, size: int, mtime: float) -> Path:
+        """Test helper for test_prune_retained_workspace_evicts_oldest_over_cap."""
+        task = root / name
+        task.mkdir()
+        (task / "blob.bin").write_bytes(b"x" * size)
+        os.utime(task, (mtime, mtime))
+        return task
+
+    one_mib = 1024 * 1024
+    oldest = make_task("oldest", one_mib, mtime=1_000.0)
+    newer = make_task("newer", one_mib, mtime=2_000.0)
+    newest = make_task("newest", one_mib, mtime=3_000.0)
+
+    # ~3 MiB total against a ~2 MiB cap: one directory must be evicted. The
+    # oldest is protected, so the next-oldest (``newer``) is taken instead.
+    cap_gb = (2 * one_mib) / 1024**3
+    users_mod.UserService._prune_retained_workspace(root, cap_gb, protect=oldest)
+
+    assert oldest.exists(), "the protected current task must never be evicted"
+    assert not newer.exists(), "the next-oldest unprotected workspace is evicted"
+    assert newest.exists(), "newer workspaces survive once the tree fits the cap"
+
+
+def test_prune_retained_workspace_noop_when_cap_zero(tmp_path: Path) -> None:
+    """A zero cap disables pruning: every retained workspace survives."""
+    from dyvine.services import users as users_mod
+
+    root = tmp_path / "downloads"
+    root.mkdir()
+    task = root / "task-1"
+    task.mkdir()
+    (task / "blob.bin").write_bytes(b"x" * 4096)
+
+    users_mod.UserService._prune_retained_workspace(root, 0.0)
+
+    assert task.exists(), "pruning must be disabled when the cap is zero"
+
+
+@pytest.mark.asyncio
 async def test_finalize_status_clamps_progress_when_downloaded_exceeds_total(
     tmp_path: Path,
 ) -> None:
@@ -669,12 +959,12 @@ def test_cleanup_temp_dir_only_removes_target_subdirectory(tmp_path: Path) -> No
 
     The helper is invoked from a ``finally`` block so it has to be safe
     against concurrent tasks owning their own siblings under the shared
-    ``temp_downloads`` parent. Verifies that wiping one task's directory
+    ``downloads`` parent. Verifies that wiping one task's directory
     leaves the parent and the other task's workspace untouched.
     """
     from dyvine.services import users as users_mod
 
-    parent = tmp_path / "temp_downloads"
+    parent = tmp_path / "downloads"
     parent.mkdir()
     target = parent / "task-target"
     target.mkdir()
@@ -752,7 +1042,7 @@ async def test_concurrent_downloads_use_isolated_temp_directories(
     Schedules two downloads through ``asyncio.gather`` with distinct
     ``user_id`` values and a stub fetcher that records which directory
     f2 was asked to write into. Both invocations must see workspaces
-    rooted at ``temp_downloads/<task_id>`` and the cleanup branch must
+    rooted at ``downloads/<task_id>`` and the cleanup branch must
     leave neither task's files behind.
     """
     from dyvine.services import users as users_mod
@@ -822,6 +1112,12 @@ async def test_concurrent_downloads_use_isolated_temp_directories(
     monkeypatch.setattr(users_mod.asyncio, "sleep", AsyncMock())
 
     service = UserService()
+    # Exercise the R2-archival cleanup branch deterministically: force
+    # archival mode (not local retention) so each per-task workspace is
+    # removed after the run regardless of whether R2 is configured in the
+    # test environment.
+    monkeypatch.setattr(service, "_r2_upload_enabled", lambda: True)
+    monkeypatch.setattr(service, "_should_retain_workspace", lambda: False)
     # Avoid contacting R2 in the concurrency test; the helper is unit
     # tested directly above.
     monkeypatch.setattr(
@@ -861,7 +1157,7 @@ async def test_concurrent_downloads_use_isolated_temp_directories(
     )
 
     # The downloader was handed two distinct per-task workspaces, each
-    # rooted at ``temp_downloads/<task_id>``. ``TEMP_DOWNLOAD_ROOT`` is a
+    # rooted at ``downloads/<task_id>``. ``TEMP_DOWNLOAD_ROOT`` is a
     # relative path, so resolve both sides against the cwd before
     # comparing.
     assert len(seen_dirs) == 2

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -12,7 +12,14 @@ import pytest
 
 from dyvine.core.exceptions import OperationNotFoundError
 from dyvine.core.operations import OperationStore
+from dyvine.core.settings import settings
 from dyvine.services.users import DownloadResponse, UserService
+
+
+@pytest.fixture(autouse=True)
+def isolate_download_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point user download workspaces at each test's temporary directory."""
+    monkeypatch.setattr(settings.douyin, "download_root", str(tmp_path / "downloads"))
 
 
 @pytest.mark.asyncio
@@ -782,7 +789,7 @@ async def test_process_download_uploads_only_files_changed_in_current_batch(
     )
 
     assert uploaded_names == ["first.mp4", "second.mp4"]
-    task_dir = tmp_path / users_mod.TEMP_DOWNLOAD_ROOT / operation.operation_id
+    task_dir = users_mod.get_task_workspace_root() / operation.operation_id
     assert (task_dir / "retain-r2-user" / "first.mp4").exists()
     assert (task_dir / "retain-r2-user" / "second.mp4").exists()
 
@@ -889,7 +896,7 @@ async def test_process_download_retries_stale_upload_failures(
     assert upload_attempts == ["first.mp4", "first.mp4", "second.mp4"]
     refreshed = await service.operation_store.get_operation(operation.operation_id)
     assert refreshed.status == "completed"
-    task_dir = tmp_path / users_mod.TEMP_DOWNLOAD_ROOT / operation.operation_id
+    task_dir = users_mod.get_task_workspace_root() / operation.operation_id
     assert not task_dir.exists(), "clean archival runs still sweep the workspace"
 
 
@@ -966,10 +973,14 @@ async def test_process_download_retains_workspace_when_r2_unconfigured(
         max_items=1,
     )
 
-    workspace_root = (tmp_path / users_mod.TEMP_DOWNLOAD_ROOT).resolve()
+    workspace_root = users_mod.get_task_workspace_root()
     task_dir = workspace_root / operation.operation_id
     assert task_dir.exists(), "retain mode must keep the per-task workspace"
     assert list(task_dir.glob("**/*.mp4")), "the downloaded file must survive"
+    refreshed = await service.operation_store.get_operation(operation.operation_id)
+    assert refreshed.download_path == str(
+        Path("tasks") / operation.operation_id / "retain-user"
+    )
 
 
 def test_prune_retained_workspace_evicts_oldest_over_cap(tmp_path: Path) -> None:
@@ -1182,7 +1193,7 @@ async def test_concurrent_downloads_use_isolated_temp_directories(
     Schedules two downloads through ``asyncio.gather`` with distinct
     ``user_id`` values and a stub fetcher that records which directory
     f2 was asked to write into. Both invocations must see workspaces
-    rooted at ``downloads/<task_id>`` and the cleanup branch must
+    rooted at ``DOUYIN_DOWNLOAD_ROOT/tasks/<task_id>`` and the cleanup branch must
     leave neither task's files behind.
     """
     from dyvine.services import users as users_mod
@@ -1297,12 +1308,10 @@ async def test_concurrent_downloads_use_isolated_temp_directories(
     )
 
     # The downloader was handed two distinct per-task workspaces, each
-    # rooted at ``downloads/<task_id>``. ``TEMP_DOWNLOAD_ROOT`` is a
-    # relative path, so resolve both sides against the cwd before
-    # comparing.
+    # rooted at ``DOUYIN_DOWNLOAD_ROOT/tasks/<task_id>``.
     assert len(seen_dirs) == 2
     assert seen_dirs[0] != seen_dirs[1]
-    workspace_root = (tmp_path / users_mod.TEMP_DOWNLOAD_ROOT).resolve()
+    workspace_root = users_mod.get_task_workspace_root()
     for directory in seen_dirs:
         assert directory.resolve().parent == workspace_root
         assert directory.name in {op_a.operation_id, op_b.operation_id}

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -912,6 +912,28 @@ def test_prune_retained_workspace_noop_when_cap_zero(tmp_path: Path) -> None:
     assert task.exists(), "pruning must be disabled when the cap is zero"
 
 
+def test_file_snapshot_reports_only_new_or_changed_files(tmp_path: Path) -> None:
+    """Snapshot helpers ignore directories and return changed file paths."""
+    root = tmp_path / "downloads"
+    root.mkdir()
+    (root / "nested").mkdir()
+    existing = root / "nested" / "existing.mp4"
+    existing.write_bytes(b"first")
+
+    before = UserService._file_snapshot(root)
+    assert UserService._files_changed_since(root, before) == []
+
+    existing.write_bytes(b"changed")
+    new_file = root / "new.webp"
+    new_file.write_bytes(b"new")
+
+    changed = {
+        path.relative_to(root)
+        for path in UserService._files_changed_since(root, before)
+    }
+    assert changed == {Path("nested/existing.mp4"), Path("new.webp")}
+
+
 @pytest.mark.asyncio
 async def test_finalize_status_clamps_progress_when_downloaded_exceeds_total(
     tmp_path: Path,

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -27,9 +27,11 @@ def reset_container_cache() -> None:
 @pytest.mark.asyncio
 async def test_service_container_initializes_with_douyin_handler(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
 ) -> None:
     """Verify service container initializes with douyin handler."""
     captured_kwargs: dict[str, object] = {}
+    monkeypatch.setattr(dependencies.settings.douyin, "download_root", str(tmp_path))
 
     def build_handler(kwargs: dict[str, object]) -> DummyHandler:
         """Test helper for test_service_container_initializes_with_douyin_handler."""
@@ -45,6 +47,7 @@ async def test_service_container_initializes_with_douyin_handler(
     assert isinstance(handler, DummyHandler)
     assert captured_kwargs.get("mode") == "all"
     assert captured_kwargs.get("interval") == "all"
+    assert captured_kwargs.get("path") == str(tmp_path)
     assert captured_kwargs.get("max_tasks") == 3
 
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -44,6 +44,7 @@ async def test_service_container_initializes_with_douyin_handler(
     handler = container.douyin_handler
     assert isinstance(handler, DummyHandler)
     assert captured_kwargs.get("mode") == "all"
+    assert captured_kwargs.get("interval") == "all"
     assert captured_kwargs.get("max_tasks") == 3
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -263,6 +263,30 @@ def test_health_check_returns_200_when_r2_missing(
         uuid.UUID(correlation_id)
 
 
+def test_health_check_reports_r2_disabled_in_local_retention_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``/health`` reports intentionally disabled R2 as informational."""
+    with TestClient(app) as client:
+        monkeypatch.setattr(settings.douyin, "cookie", "cookie")
+        monkeypatch.setattr(settings.douyin, "retain_local_downloads", True)
+        _configure_r2(
+            monkeypatch,
+            account_id="",
+            access_key_id="",
+            secret_access_key="",
+            bucket_name="",
+            endpoint="",
+        )
+
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["dependencies"]["r2_storage"] == "disabled"
+
+
 def test_health_check_returns_200_when_douyin_cookie_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -167,6 +167,38 @@ def test_readiness_probe_returns_not_ready_when_r2_missing(
         assert data["dependencies"]["r2_storage"] == "missing_credentials"
 
 
+def test_readiness_probe_ready_in_local_retention_mode_without_r2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local-retention mode makes R2 optional for readiness.
+
+    When ``DOUYIN_RETAIN_LOCAL_DOWNLOADS`` is enabled the service archives to
+    the local volume, so absent R2 credentials are expected and must not hold
+    the Pod out of the load balancer. ``/readyz`` must report ready with R2
+    marked ``disabled`` instead of failing with ``missing_credentials``.
+    """
+    monkeypatch.setattr(settings.douyin, "cookie", "dummy-cookie")
+    monkeypatch.setattr(settings.douyin, "retain_local_downloads", True)
+    _configure_r2(
+        monkeypatch,
+        account_id="",
+        access_key_id="",
+        secret_access_key="",
+        bucket_name="",
+        endpoint="",
+    )
+
+    with TestClient(app) as client:
+        container = app.state.container
+        monkeypatch.setattr(container.operation_store, "healthcheck", _async_noop)
+        response = client.get("/readyz")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ready"
+        assert data["dependencies"]["r2_storage"] == "disabled"
+
+
 def test_readiness_probe_returns_not_ready_when_r2_endpoint_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,6 +38,11 @@ def _configure_r2(
     monkeypatch.setattr(settings.r2, "endpoint", endpoint)
 
 
+def _configure_download_root(monkeypatch: pytest.MonkeyPatch, root: object) -> None:
+    """Point readiness checks at an isolated download root."""
+    monkeypatch.setattr(settings.douyin, "download_root", str(root))
+
+
 @pytest.fixture
 def prime_ready_dependencies(
     monkeypatch: pytest.MonkeyPatch,
@@ -85,6 +90,7 @@ def test_readiness_probe_returns_ready_when_all_dependencies_ok(
         "service_container": "initialized",
         "operation_store": "available",
         "r2_storage": "configured",
+        "local_retention_storage": "not_required",
     }
 
 
@@ -144,9 +150,11 @@ def test_readiness_probe_returns_not_ready_when_operation_store_broken(
 
 def test_readiness_probe_ready_when_r2_missing_uses_implicit_retention(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
 ) -> None:
     """R2 is optional when downloads implicitly retain local files."""
     monkeypatch.setattr(settings.douyin, "cookie", "dummy-cookie")
+    _configure_download_root(monkeypatch, tmp_path / "downloads")
     _configure_r2(
         monkeypatch,
         account_id="",
@@ -165,10 +173,12 @@ def test_readiness_probe_ready_when_r2_missing_uses_implicit_retention(
         data = response.json()
         assert data["status"] == "ready"
         assert data["dependencies"]["r2_storage"] == "disabled"
+        assert data["dependencies"]["local_retention_storage"] == "available"
 
 
 def test_readiness_probe_ready_in_local_retention_mode_without_r2(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
 ) -> None:
     """Local-retention mode makes R2 optional for readiness.
 
@@ -179,6 +189,7 @@ def test_readiness_probe_ready_in_local_retention_mode_without_r2(
     """
     monkeypatch.setattr(settings.douyin, "cookie", "dummy-cookie")
     monkeypatch.setattr(settings.douyin, "retain_local_downloads", True)
+    _configure_download_root(monkeypatch, tmp_path / "downloads")
     _configure_r2(
         monkeypatch,
         account_id="",
@@ -197,13 +208,16 @@ def test_readiness_probe_ready_in_local_retention_mode_without_r2(
         data = response.json()
         assert data["status"] == "ready"
         assert data["dependencies"]["r2_storage"] == "disabled"
+        assert data["dependencies"]["local_retention_storage"] == "available"
 
 
 def test_readiness_probe_ready_when_r2_endpoint_missing_uses_implicit_retention(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
 ) -> None:
     """Readiness mirrors the download path when R2 is not fully configured."""
     monkeypatch.setattr(settings.douyin, "cookie", "dummy-cookie")
+    _configure_download_root(monkeypatch, tmp_path / "downloads")
     _configure_r2(monkeypatch, endpoint="")
 
     with TestClient(app) as client:
@@ -215,6 +229,37 @@ def test_readiness_probe_ready_when_r2_endpoint_missing_uses_implicit_retention(
         data = response.json()
         assert data["status"] == "ready"
         assert data["dependencies"]["r2_storage"] == "disabled"
+        assert data["dependencies"]["local_retention_storage"] == "available"
+
+
+def test_readiness_probe_not_ready_when_local_retention_root_unwritable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """No-R2 readiness fails when retained files cannot be written locally."""
+    blocking_file = tmp_path / "downloads"
+    blocking_file.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr(settings.douyin, "cookie", "dummy-cookie")
+    _configure_download_root(monkeypatch, blocking_file)
+    _configure_r2(
+        monkeypatch,
+        account_id="",
+        access_key_id="",
+        secret_access_key="",
+        bucket_name="",
+        endpoint="",
+    )
+
+    with TestClient(app) as client:
+        container = app.state.container
+        monkeypatch.setattr(container.operation_store, "healthcheck", _async_noop)
+        response = client.get("/readyz")
+
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "not_ready"
+        assert data["dependencies"]["r2_storage"] == "disabled"
+        assert data["dependencies"]["local_retention_storage"] == "unavailable"
 
 
 def test_invalid_request_id_is_regenerated(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -142,10 +142,10 @@ def test_readiness_probe_returns_not_ready_when_operation_store_broken(
         assert data["dependencies"]["operation_store"] == "unavailable"
 
 
-def test_readiness_probe_returns_not_ready_when_r2_missing(
+def test_readiness_probe_ready_when_r2_missing_uses_implicit_retention(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify readiness probe returns not ready when R2 missing."""
+    """R2 is optional when downloads implicitly retain local files."""
     monkeypatch.setattr(settings.douyin, "cookie", "dummy-cookie")
     _configure_r2(
         monkeypatch,
@@ -161,10 +161,10 @@ def test_readiness_probe_returns_not_ready_when_r2_missing(
         monkeypatch.setattr(container.operation_store, "healthcheck", _async_noop)
         response = client.get("/readyz")
 
-        assert response.status_code == 503
+        assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "not_ready"
-        assert data["dependencies"]["r2_storage"] == "missing_credentials"
+        assert data["status"] == "ready"
+        assert data["dependencies"]["r2_storage"] == "disabled"
 
 
 def test_readiness_probe_ready_in_local_retention_mode_without_r2(
@@ -199,13 +199,10 @@ def test_readiness_probe_ready_in_local_retention_mode_without_r2(
         assert data["dependencies"]["r2_storage"] == "disabled"
 
 
-def test_readiness_probe_returns_not_ready_when_r2_endpoint_missing(
+def test_readiness_probe_ready_when_r2_endpoint_missing_uses_implicit_retention(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Covers the bug where /readyz passed while ``settings.R2.endpoint`` was
-    empty, even though ``R2StorageService`` disables itself in that state.
-
-    """
+    """Readiness mirrors the download path when R2 is not fully configured."""
     monkeypatch.setattr(settings.douyin, "cookie", "dummy-cookie")
     _configure_r2(monkeypatch, endpoint="")
 
@@ -214,10 +211,10 @@ def test_readiness_probe_returns_not_ready_when_r2_endpoint_missing(
         monkeypatch.setattr(container.operation_store, "healthcheck", _async_noop)
         response = client.get("/readyz")
 
-        assert response.status_code == 503
+        assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "not_ready"
-        assert data["dependencies"]["r2_storage"] == "missing_credentials"
+        assert data["status"] == "ready"
+        assert data["dependencies"]["r2_storage"] == "disabled"
 
 
 def test_invalid_request_id_is_regenerated(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -256,8 +253,9 @@ def test_health_check_returns_200_when_r2_missing(
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "ok"
-        # Dependency snapshot is informational only.
-        assert data["dependencies"]["r2_storage"] == "missing_credentials"
+        # Dependency snapshot is informational only; downloads retain locally
+        # when no R2 configuration is available.
+        assert data["dependencies"]["r2_storage"] == "disabled"
         correlation_id = data["correlation_id"]
         assert correlation_id == response.headers["X-Correlation-ID"]
         uuid.UUID(correlation_id)


### PR DESCRIPTION
## Summary
Support local retained downloads when R2 is unavailable or intentionally disabled, while keeping R2 archival efficient and avoiding repeated uploads of files retained from earlier batches.

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| Download retention | Per-task workspace was always swept after upload | `DOUYIN_DOWNLOAD_ROOT/tasks/<task_id>` is retained when configured, or implicitly when R2 is unconfigured | Prevents silently discarding the only local copy |
| Configured workspace root | User downloads used a hard-coded relative `downloads` directory | f2 and retained task workspaces now use `DOUYIN_DOWNLOAD_ROOT` | Keeps runtime downloads inside the configured local storage root |
| Operation status | Retained user downloads could finish with `download_path` unset | Retained workspaces persist `tasks/<task_id>/<nickname>` on the operation | Lets clients/operators locate retained files after completion |
| Readiness and health | R2 missing always surfaced as a missing dependency unless retention was explicit | Effective local-retention mode reports R2 as `disabled`; `/readyz` also checks local workspace writability | Keeps probes aligned with the selected archive path |
| R2 uploads | Each batch could re-walk retained files or skip stale failures | Each batch uploads current new/changed files plus pending failed files | Avoids duplicate R2 uploads while retrying stale failures |
| Retention pruning | Size-cap pruning scanned every direct child of `downloads` | Pruning only considers operation-owned task workspaces under `DOUYIN_DOWNLOAD_ROOT/tasks` | Prevents deleting unrelated bulk-download directories |
| Post downloader payloads | Raw f2 payloads could miss fields expected by the downloader | Payloads are adapted to the downloader contract, including live-photo media | Improves bulk download compatibility |
| Documentation and env | Retention settings were undocumented | `.env.example`, README, and docs describe retention, workspace readiness, and cap settings | Docker image does not bake in local-retention mode |

## Details
### Local retention and R2 behavior
- `DOUYIN_RETAIN_LOCAL_DOWNLOADS=true` keeps per-task files locally; missing R2 also implies retention so completed downloads are not discarded.
- User downloads now create task workspaces under `DOUYIN_DOWNLOAD_ROOT/tasks/<task_id>` and pass the configured download root to f2.
- Retained user downloads persist a relative `download_path` of `tasks/<task_id>/<nickname>`.
- `/readyz` checks that the effective local-retention workspace can be created and written before reporting ready without R2.
- User downloads snapshot the batch directory before f2 writes files, then upload only new or changed files for that batch plus any unresolved upload failures from earlier batches.
- Failed uploads are retried before finalization. If failures remain unresolved, the workspace is retained instead of deleting the only local copy.
- Successful R2 uploads still delete local files in normal archival mode.
- Retained local trees are bounded by `DOUYIN_RETAIN_MAX_GB` pruning, limited to marked task workspaces.

### Bulk post download compatibility
- The public async operation contract remains unchanged.
- f2 raw post payloads are normalized before passing them to the downloader.
- Video, image, and live-photo URL containers are covered by focused tests.

## Testing
- `uv run pytest tests/test_main.py tests/services/test_user_service.py tests/test_dependencies.py tests/core/test_path_safety.py -q` - 64 passed
- `git diff --check` - passed
- `git diff --cached --check` - passed
- `uv run ruff check $(git ls-files '*.py')` - passed
- `uv run black --check src/dyvine/core/dependencies.py src/dyvine/core/path_safety.py src/dyvine/main.py src/dyvine/services/users.py tests/core/test_path_safety.py tests/services/test_user_service.py tests/test_dependencies.py tests/test_main.py` - passed
- `uv run isort --check-only src/dyvine/core/dependencies.py src/dyvine/core/path_safety.py src/dyvine/main.py src/dyvine/services/users.py tests/core/test_path_safety.py tests/services/test_user_service.py tests/test_dependencies.py tests/test_main.py` - passed
- `uv run mypy src/dyvine` - passed
- `uv run pytest --cov=src/dyvine --cov-fail-under=80` - 372 passed, 90.38% coverage
- GitNexus staged `detect_changes` reviewed; affected flows match download retention, readiness, service initialization, R2 upload retry, and pruning scope
- GitHub checks on PR head `80bd2ad`: quality, test (3.12), test (3.13), Container Vulnerability Scan, and codecov/patch passed; image build skipped as expected, Trivy returned neutral/skipped

## Breaking changes
- Not applicable

## Risks and rollout
- Local retention can grow disk usage if enabled without a cap; mitigated by `DOUYIN_RETAIN_MAX_GB` pruning and documentation.
- R2-disabled readiness now depends on local workspace writability; covered by `/readyz` tests.
- Persistent R2 upload failures now retain the task workspace rather than deleting failed local files; operators should inspect partial operation records and retained files before retrying or cleaning up.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted