### PR TITLE
feat(watch): auto-download new posts and livestreams per subscription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,29 @@ DOUYIN_RETAIN_MAX_GB=0
 DOUYIN_LIVE_SEC_CH_UA="Not A(Brand";v="99", "Google Chrome";v="131", "Chromium";v="131"
 
 # ================================
+# Watch Mode (auto-download) Configuration
+# ================================
+# The watcher polls users you subscribe to via the /watch API and
+# auto-downloads their new posts and livestreams. Every value below is a
+# default; per-subscription overrides are accepted on POST /watch within the
+# same bounds. Subscriptions persist in the operation database and resume on
+# restart. Single-replica only, like the rest of the service.
+#
+# Seconds between live-status checks (60..3600). Lower is more timely but
+# polls Douyin more aggressively, raising the cookie/account risk.
+DOUYIN_WATCH_LIVE_POLL_SECONDS=300
+# Seconds between new-post checks (300..86400).
+DOUYIN_WATCH_POST_POLL_SECONDS=2700
+# Max aweme_ids kept in each subscription's dedupe checkpoint (20..2000).
+DOUYIN_WATCH_RECENT_ID_CAP=200
+# Maximum number of concurrent watch subscriptions (1..10000).
+DOUYIN_WATCH_MAX_SUBSCRIPTIONS=50
+# When true, a new subscription downloads the user's existing posts once
+# before switching to incremental-only mode. Default false: only fetch
+# posts published after the subscription is created.
+DOUYIN_WATCH_BACKFILL_ON_CREATE=false
+
+# ================================
 # Cloudflare R2 Storage Configuration
 # ================================
 # Optional: Configure for automatic content uploads to R2

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,10 @@ temp_downloads/
 *.tmp
 *.temp
 
+# Local batch-download input list (real IDs) and outputs; commit users.txt.example only
+users.txt
+saved_downloads/
+
 # Test data
 test/data/
 tests/fixtures/data/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Architecture diagrams are available in
   traversal and symlink-segment checks.
 - Optional Cloudflare R2 archival supports uploads, metadata lookup, listing,
   and deletes.
+- Watch Mode automatically monitors subscribed Douyin users and downloads their
+  new posts and livestreams on configurable polling cadences.
 - Operational surfaces include `/livez`, `/readyz`, `/startupz`, `/health`, and
   `/metrics`.
 
@@ -72,6 +74,7 @@ Configuration is environment-driven through `dyvine.core.settings`:
 | `API_` | Server bind settings, CORS, API prefix, operation DB path |
 | `SECURITY_` | Secret key, API key, and router auth gate |
 | `DOUYIN_` | Cookie, headers, proxy, download root, livestream headers, local-retention mode |
+| `DOUYIN_WATCH_` | Watch Mode polling cadences, subscription cap, dedupe window, backfill flag |
 | `R2_` | Cloudflare R2 account, key, bucket, and endpoint |
 
 `API_DEBUG=false` rejects placeholder production secrets. R2 is optional: by
@@ -122,14 +125,34 @@ curl -H "X-API-Key: $SECURITY_API_KEY" \
   "http://localhost:8000/api/v1/posts/operations/OPERATION_ID"
 ```
 
+Create a Watch Mode subscription to auto-download a user's new posts and
+livestreams:
+
+```bash
+# Create a subscription (201 for new, 200 when one already exists for that user)
+curl -X POST -H "X-API-Key: $SECURITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": "SEC_USER_ID"}' \
+  "http://localhost:8000/api/v1/watch"
+
+# List all subscriptions
+curl -H "X-API-Key: $SECURITY_API_KEY" \
+  "http://localhost:8000/api/v1/watch"
+
+# Delete a subscription (stop future checks; any recording already in progress
+# runs to completion in its own background task)
+curl -X DELETE -H "X-API-Key: $SECURITY_API_KEY" \
+  "http://localhost:8000/api/v1/watch/SUBSCRIPTION_ID"
+```
+
 ## Project Structure
 
 | Path | Purpose |
 | --- | --- |
 | `src/dyvine/main.py` | FastAPI app, middleware, routers, probes, metrics |
 | `src/dyvine/core/` | Settings, logging, dependency container, operation store, path safety |
-| `src/dyvine/routers/` | User, post, and livestream HTTP endpoints |
-| `src/dyvine/services/` | Douyin SDK orchestration, background work, R2 storage |
+| `src/dyvine/routers/` | User, post, livestream, and watch HTTP endpoints |
+| `src/dyvine/services/` | Douyin SDK orchestration, background work, R2 storage, watch scheduling |
 | `src/dyvine/schemas/` | Pydantic request and response models |
 | `tests/` | Pytest suite mirroring the source tree |
 | `docs/` | Static HTML project documentation and Mermaid architecture diagrams |

--- a/batch_download.py
+++ b/batch_download.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Dyvine 批量用户作品下载脚本.
+
+用法:
+    python batch_download.py users.txt [--api-url http://localhost:8000] \
+        [--api-key your-key] [--include-likes] [--max-concurrent 3]
+
+说明:
+    从文本文件读取用户 ID（每行一个），向 Dyvine API 发起异步下载任务，
+    并轮询所有任务直到完成。支持并发提交和统一的进度报告。
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import aiohttp
+
+
+def _load_env_file(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    if not path.exists():
+        return env
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                key, value = line.split("=", 1)
+                env[key.strip()] = value.strip().strip('"').strip("'")
+    return env
+
+
+@dataclass
+class DownloadJob:
+    user_id: str
+    operation_id: str | None = None
+    status: str = "pending"
+    message: str = ""
+    progress: float = 0.0
+    total_posts: int = 0
+    total_downloaded: int = 0
+    failed_count: int = 0
+    error_details: str | None = None
+    submitted_at: float = field(default_factory=time.time)
+    completed_at: float | None = None
+
+
+class DyvineBatchDownloader:
+    def __init__(
+        self,
+        api_url: str,
+        api_key: str,
+        include_likes: bool = False,
+        max_concurrent: int = 3,
+        poll_interval: float = 5.0,
+        timeout: float = 30.0,
+    ):
+        self.api_url = api_url.rstrip("/")
+        self.api_key = api_key
+        self.include_likes = include_likes
+        self.max_concurrent = max_concurrent
+        self.poll_interval = poll_interval
+        self.timeout = timeout
+        self.headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
+
+    async def _submit_download(
+        self, session: aiohttp.ClientSession, user_id: str
+    ) -> DownloadJob:
+        if self.include_likes:
+            url = (
+                f"{self.api_url}/api/v1/users/{user_id}/content:download"
+                f"?include_posts=true&include_likes=true"
+            )
+        else:
+            url = f"{self.api_url}/api/v1/posts/users/{user_id}/posts:download"
+
+        try:
+            async with session.post(
+                url, headers=self.headers, timeout=self.timeout
+            ) as resp:
+                data = await resp.json()
+                if resp.status == 202:
+                    job = DownloadJob(
+                        user_id=user_id,
+                        operation_id=data.get("operation_id"),
+                        status="submitted",
+                        message=data.get("message", "Download scheduled"),
+                    )
+                    print(
+                        f"  [已提交] 用户 {user_id} -> operation_id: {job.operation_id}"
+                    )
+                    return job
+                else:
+                    return DownloadJob(
+                        user_id=user_id,
+                        status="failed",
+                        message=data.get("message", f"HTTP {resp.status}"),
+                        error_details=str(data),
+                    )
+        except TimeoutError:
+            return DownloadJob(
+                user_id=user_id,
+                status="failed",
+                message="提交超时",
+                error_details="Request timeout",
+            )
+        except Exception as e:
+            return DownloadJob(
+                user_id=user_id,
+                status="failed",
+                message=f"提交异常: {e}",
+                error_details=str(e),
+            )
+
+    async def _poll_status(
+        self, session: aiohttp.ClientSession, job: DownloadJob
+    ) -> DownloadJob:
+        if self.include_likes:
+            url = f"{self.api_url}/api/v1/users/operations/{job.operation_id}"
+        else:
+            url = f"{self.api_url}/api/v1/posts/operations/{job.operation_id}"
+
+        try:
+            async with session.get(
+                url, headers=self.headers, timeout=self.timeout
+            ) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+                    job.status = data.get("status", "unknown")
+                    job.message = data.get("message", "")
+                    job.progress = data.get("progress", 0.0)
+                    job.total_posts = data.get("total_posts", 0)
+                    job.total_downloaded = data.get("total_downloaded", 0)
+                    job.failed_count = data.get("failed_count", 0)
+                    job.error_details = data.get("error_details")
+
+                    if job.status in ("completed", "failed", "partial"):
+                        job.completed_at = time.time()
+                elif resp.status == 404:
+                    job.status = "not_found"
+                    job.message = "任务未找到"
+                    job.completed_at = time.time()
+                else:
+                    job.message = f"轮询 HTTP {resp.status}"
+        except TimeoutError:
+            job.message = "轮询超时"
+        except Exception as e:
+            job.message = f"轮询异常: {e}"
+
+        return job
+
+    async def run(self, user_ids: list[str]) -> list[DownloadJob]:
+        """执行完整的批量下载流程."""
+        print(f"\n{'='*60}")
+        print("Dyvine 批量下载启动")
+        print(f"  用户总数: {len(user_ids)}")
+        print(f"  并发数:   {self.max_concurrent}")
+        print(f"  API 地址: {self.api_url}")
+        print(f"  下载 likes: {self.include_likes}")
+        print(f"{'='*60}\n")
+
+        jobs: list[DownloadJob] = []
+        connector = aiohttp.TCPConnector(limit=self.max_concurrent * 2)
+        timeout = aiohttp.ClientTimeout(total=self.timeout)
+
+        async with aiohttp.ClientSession(
+            connector=connector, timeout=timeout
+        ) as session:
+            print("[阶段 1/2] 提交下载任务...")
+            semaphore = asyncio.Semaphore(self.max_concurrent)
+
+            async def submit_with_limit(user_id: str) -> DownloadJob:
+                async with semaphore:
+                    return await self._submit_download(session, user_id)
+
+            tasks = [submit_with_limit(uid) for uid in user_ids]
+            jobs = await asyncio.gather(*tasks)
+
+            submitted = [j for j in jobs if j.operation_id]
+            failed = [j for j in jobs if not j.operation_id]
+
+            print(f"\n  提交完成: {len(submitted)} 成功, {len(failed)} 失败")
+            for j in failed:
+                print(f"    - 用户 {j.user_id}: {j.message}")
+
+            if not submitted:
+                print("\n没有成功提交的任务，退出。")
+                return jobs
+
+            print(f"\n[阶段 2/2] 轮询任务进度 (每 {self.poll_interval:.0f}s)...")
+            pending = {j.operation_id: j for j in submitted}
+            completed: dict[str, DownloadJob] = {}
+            poll_round = 0
+
+            while pending:
+                poll_round += 1
+                await asyncio.sleep(self.poll_interval)
+
+                results = await asyncio.gather(
+                    *[self._poll_status(session, job) for job in pending.values()]
+                )
+
+                still_pending: dict[str, DownloadJob] = {}
+                for job in results:
+                    if job.status in ("completed", "failed", "partial", "not_found"):
+                        completed[job.operation_id] = job
+                        duration = ""
+                        if job.completed_at and job.submitted_at:
+                            secs = job.completed_at - job.submitted_at
+                            duration = f" ({secs:.0f}s)"
+                        print(
+                            f"  [{job.status.upper()}] 用户 {job.user_id} "
+                            f"{job.total_downloaded}/{job.total_posts} "
+                            f"失败:{job.failed_count}{duration}"
+                        )
+                        if job.error_details:
+                            print(f"      错误: {job.error_details}")
+                    else:
+                        still_pending[job.operation_id] = job
+
+                pending = still_pending
+
+                if pending and poll_round % 3 == 0:
+                    print(f"\n  --- 进行中 ({len(pending)} 个) ---")
+                    for job in pending.values():
+                        print(
+                            f"    {job.user_id}: {job.status} "
+                            f"({job.progress*100:.1f}%) {job.message}"
+                        )
+                    print("  ----------------------\n")
+
+        self._print_summary(jobs)
+        return jobs
+
+    def _print_summary(self, jobs: list[DownloadJob]) -> None:
+        total = len(jobs)
+        submitted = [j for j in jobs if j.operation_id]
+        completed_ok = [j for j in jobs if j.status == "completed"]
+        partial = [j for j in jobs if j.status == "partial"]
+        failed = [j for j in jobs if j.status in ("failed", "not_found")]
+        total_downloaded = sum(j.total_downloaded for j in submitted)
+        total_failed = sum(j.failed_count for j in submitted)
+
+        print(f"\n{'='*60}")
+        print("批量下载完成报告")
+        print(f"{'='*60}")
+        print(f"  总用户数:        {total}")
+        print(f"  成功提交:        {len(submitted)}")
+        print(f"  完全完成:        {len(completed_ok)}")
+        print(f"  部分完成:        {len(partial)}")
+        print(f"  失败/未找到:     {len(failed)}")
+        print(f"  总下载作品数:    {total_downloaded}")
+        print(f"  总失败数:        {total_failed}")
+        print(f"{'='*60}\n")
+
+        if failed:
+            print("失败详情:")
+            for j in failed:
+                print(f"  - {j.user_id}: {j.message}")
+            print()
+
+
+def read_user_ids(filepath: str) -> list[str]:
+    """从文件中读取用户 ID 列表."""
+    path = Path(filepath)
+    if not path.exists():
+        print(f"错误: 文件不存在 {filepath}", file=sys.stderr)
+        sys.exit(1)
+
+    user_ids = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            uid = line.strip()
+            if uid and not uid.startswith("#"):
+                user_ids.append(uid)
+
+    if not user_ids:
+        print(f"错误: 文件 {filepath} 中没有有效的用户 ID", file=sys.stderr)
+        sys.exit(1)
+
+    return user_ids
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Dyvine 批量用户作品下载脚本",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+示例:
+  # 基本用法：从文件读取用户ID并下载作品
+  python batch_download.py users.txt --api-key your-secret-key
+
+  # 同时下载用户的 likes
+  python batch_download.py users.txt --api-key key --include-likes
+
+  # 使用自定义 API 地址和更高并发
+  python batch_download.py users.txt \
+      --api-url http://dyvine.local:8000 \
+      --api-key key \
+      --max-concurrent 5
+
+  # 使用环境变量传入 API Key（更安全）
+  export DYVINE_API_KEY=your-key
+  python batch_download.py users.txt
+
+用户 ID 文件格式:
+  每行一个用户 ID，支持空行和以 # 开头的注释行。
+  示例:
+    MS4wLjABAAAA...
+    MS4wLjABAAAA...
+        """,
+    )
+    parser.add_argument(
+        "input_file",
+        help="包含用户 ID 的文本文件路径 (每行一个)",
+    )
+    parser.add_argument(
+        "--api-url",
+        default="http://localhost:8000",
+        help="Dyvine API 地址 (默认: http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default="",
+        help="API Key (也可通过 DYVINE_API_KEY 环境变量设置)",
+    )
+    parser.add_argument(
+        "--include-likes",
+        action="store_true",
+        help="同时下载用户喜欢的作品 (通过 /users/{id}/content:download 端点)",
+    )
+    parser.add_argument(
+        "--max-concurrent",
+        type=int,
+        default=3,
+        help="最大并发提交数 (默认: 3)",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=5.0,
+        help="轮询间隔秒数 (默认: 5)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="单次请求超时秒数 (默认: 30)",
+    )
+
+    args = parser.parse_args()
+
+    dotenv = _load_env_file(Path(".env"))
+
+    api_key = (
+        args.api_key
+        or os.environ.get("DYVINE_API_KEY")
+        or dotenv.get("SECURITY_API_KEY", "")
+    )
+
+    api_url = args.api_url
+    if not api_url or api_url == "http://localhost:8000":
+        env_url = os.environ.get("DYVINE_API_URL")
+        if env_url:
+            api_url = env_url
+        elif dotenv.get("API_HOST"):
+            host = dotenv.get("API_HOST", "0.0.0.0")
+            port = dotenv.get("API_PORT", "8000")
+            api_url = f"http://{host}:{port}"
+
+    if not api_key:
+        print(
+            "错误: 必须提供 --api-key、DYVINE_API_KEY 环境变量，"
+            "或在 .env 中设置 SECURITY_API_KEY",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    user_ids = read_user_ids(args.input_file)
+
+    downloader = DyvineBatchDownloader(
+        api_url=args.api_url,
+        api_key=api_key,
+        include_likes=args.include_likes,
+        max_concurrent=args.max_concurrent,
+        poll_interval=args.poll_interval,
+        timeout=args.timeout,
+    )
+
+    asyncio.run(downloader.run(user_ids))
+
+
+if __name__ == "__main__":
+    main()

--- a/batch_download.py
+++ b/batch_download.py
@@ -20,7 +20,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import aiohttp
+import httpx
 
 
 def _load_env_file(path: Path) -> dict[str, str]:
@@ -72,7 +72,7 @@ class DyvineBatchDownloader:
         self.headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
 
     async def _submit_download(
-        self, session: aiohttp.ClientSession, user_id: str
+        self, session: httpx.AsyncClient, user_id: str
     ) -> DownloadJob:
         if self.include_likes:
             url = (
@@ -83,29 +83,25 @@ class DyvineBatchDownloader:
             url = f"{self.api_url}/api/v1/posts/users/{user_id}/posts:download"
 
         try:
-            async with session.post(
-                url, headers=self.headers, timeout=self.timeout
-            ) as resp:
-                data = await resp.json()
-                if resp.status == 202:
-                    job = DownloadJob(
-                        user_id=user_id,
-                        operation_id=data.get("operation_id"),
-                        status="submitted",
-                        message=data.get("message", "Download scheduled"),
-                    )
-                    print(
-                        f"  [已提交] 用户 {user_id} -> operation_id: {job.operation_id}"
-                    )
-                    return job
-                else:
-                    return DownloadJob(
-                        user_id=user_id,
-                        status="failed",
-                        message=data.get("message", f"HTTP {resp.status}"),
-                        error_details=str(data),
-                    )
-        except TimeoutError:
+            resp = await session.post(url, headers=self.headers, timeout=self.timeout)
+            data = resp.json()
+            if resp.status_code == 202:
+                job = DownloadJob(
+                    user_id=user_id,
+                    operation_id=data.get("operation_id"),
+                    status="submitted",
+                    message=data.get("message", "Download scheduled"),
+                )
+                print(f"  [已提交] 用户 {user_id} -> operation_id: {job.operation_id}")
+                return job
+            else:
+                return DownloadJob(
+                    user_id=user_id,
+                    status="failed",
+                    message=data.get("message", f"HTTP {resp.status_code}"),
+                    error_details=str(data),
+                )
+        except (httpx.TimeoutException, TimeoutError):
             return DownloadJob(
                 user_id=user_id,
                 status="failed",
@@ -121,7 +117,7 @@ class DyvineBatchDownloader:
             )
 
     async def _poll_status(
-        self, session: aiohttp.ClientSession, job: DownloadJob
+        self, session: httpx.AsyncClient, job: DownloadJob
     ) -> DownloadJob:
         if self.include_likes:
             url = f"{self.api_url}/api/v1/users/operations/{job.operation_id}"
@@ -129,28 +125,37 @@ class DyvineBatchDownloader:
             url = f"{self.api_url}/api/v1/posts/operations/{job.operation_id}"
 
         try:
-            async with session.get(
-                url, headers=self.headers, timeout=self.timeout
-            ) as resp:
-                if resp.status == 200:
-                    data = await resp.json()
-                    job.status = data.get("status", "unknown")
-                    job.message = data.get("message", "")
+            resp = await session.get(url, headers=self.headers, timeout=self.timeout)
+            if resp.status_code == 200:
+                data = resp.json()
+                job.status = data.get("status", "unknown")
+                job.message = data.get("message", "")
+                if self.include_likes:
+                    # The likes path polls /users/operations/{id}, which returns
+                    # the generic OperationResponse (total_items / completed_items,
+                    # progress in 0-100, no per-post failed count). Map those onto
+                    # the job's bulk-style counters so progress is not stuck at 0/0.
+                    job.progress = data.get("progress", 0.0) / 100
+                    job.total_posts = data.get("total_items", 0) or 0
+                    job.total_downloaded = data.get("completed_items", 0) or 0
+                    job.failed_count = 0
+                    job.error_details = data.get("error")
+                else:
                     job.progress = data.get("progress", 0.0)
                     job.total_posts = data.get("total_posts", 0)
                     job.total_downloaded = data.get("total_downloaded", 0)
                     job.failed_count = data.get("failed_count", 0)
                     job.error_details = data.get("error_details")
 
-                    if job.status in ("completed", "failed", "partial"):
-                        job.completed_at = time.time()
-                elif resp.status == 404:
-                    job.status = "not_found"
-                    job.message = "任务未找到"
+                if job.status in ("completed", "failed", "partial"):
                     job.completed_at = time.time()
-                else:
-                    job.message = f"轮询 HTTP {resp.status}"
-        except TimeoutError:
+            elif resp.status_code == 404:
+                job.status = "not_found"
+                job.message = "任务未找到"
+                job.completed_at = time.time()
+            else:
+                job.message = f"轮询 HTTP {resp.status_code}"
+        except (httpx.TimeoutException, TimeoutError):
             job.message = "轮询超时"
         except Exception as e:
             job.message = f"轮询异常: {e}"
@@ -168,12 +173,10 @@ class DyvineBatchDownloader:
         print(f"{'='*60}\n")
 
         jobs: list[DownloadJob] = []
-        connector = aiohttp.TCPConnector(limit=self.max_concurrent * 2)
-        timeout = aiohttp.ClientTimeout(total=self.timeout)
+        limits = httpx.Limits(max_connections=self.max_concurrent * 2)
+        timeout = httpx.Timeout(self.timeout)
 
-        async with aiohttp.ClientSession(
-            connector=connector, timeout=timeout
-        ) as session:
+        async with httpx.AsyncClient(limits=limits, timeout=timeout) as session:
             print("[阶段 1/2] 提交下载任务...")
             semaphore = asyncio.Semaphore(self.max_concurrent)
 
@@ -387,7 +390,7 @@ def main() -> None:
     user_ids = read_user_ids(args.input_file)
 
     downloader = DyvineBatchDownloader(
-        api_url=args.api_url,
+        api_url=api_url,
         api_key=api_key,
         include_likes=args.include_likes,
         max_concurrent=args.max_concurrent,

--- a/docs/index.html
+++ b/docs/index.html
@@ -107,6 +107,7 @@
         <li><a href="#quick-start">Quick Start</a></li>
         <li><a href="#configuration">Configuration</a></li>
         <li><a href="#api-reference">API Reference</a></li>
+        <li><a href="#watch-mode">Watch Mode</a></li>
         <li><a href="#operations">Operations</a></li>
         <li><a href="#deployment">Deployment</a></li>
         <li><a href="#development">Development</a></li>
@@ -138,6 +139,7 @@
           <tr><td>Users</td><td>Profile lookup and bulk download of a user's posts or likes to R2.</td></tr>
           <tr><td>Posts</td><td>Per-post detail, paginated post listing, and bulk download of a user's posts.</td></tr>
           <tr><td>Livestreams</td><td>Active-room download by user ID or direct URL with deduplication.</td></tr>
+          <tr><td>Watch</td><td>Long-lived subscriptions that auto-download a user's new posts and record their livestreams on configurable polling cadences.</td></tr>
           <tr><td>System</td><td>Liveness, readiness, startup, health, and Prometheus metrics endpoints.</td></tr>
         </tbody>
       </table>
@@ -204,6 +206,24 @@ DOUYIN_COOKIE=&lt;browser session cookie&gt;</code></pre>
         finished download is never discarded. Bound the retained workspace with
         <code>DOUYIN_RETAIN_MAX_GB</code> (GiB; <code>0</code> disables pruning).
       </p>
+      <h3>Watch Mode configuration (<code>DOUYIN_WATCH_</code> prefix)</h3>
+      <p>
+        Watch Mode subscriptions are created through the <code>/api/v1/watch</code> API. The following
+        environment variables set the service-wide defaults; each variable can be overridden
+        per subscription when calling <code>POST /watch</code>.
+      </p>
+      <table>
+        <thead>
+          <tr><th>Variable</th><th>Default</th><th>Bounds</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>DOUYIN_WATCH_LIVE_POLL_SECONDS</code></td><td><code>300</code></td><td>60–3600</td><td>Seconds between live-status checks per subscription.</td></tr>
+          <tr><td><code>DOUYIN_WATCH_POST_POLL_SECONDS</code></td><td><code>2700</code></td><td>300–86400</td><td>Seconds between new-post checks per subscription.</td></tr>
+          <tr><td><code>DOUYIN_WATCH_RECENT_ID_CAP</code></td><td><code>200</code></td><td>20–2000</td><td>Maximum aweme_ids kept in each subscription's dedupe checkpoint.</td></tr>
+          <tr><td><code>DOUYIN_WATCH_MAX_SUBSCRIPTIONS</code></td><td><code>50</code></td><td>1–10000</td><td>Maximum number of concurrent watch subscriptions; <code>POST /watch</code> returns 429 when this cap is reached.</td></tr>
+          <tr><td><code>DOUYIN_WATCH_BACKFILL_ON_CREATE</code></td><td><code>false</code></td><td>—</td><td>When <code>true</code>, a new subscription downloads the user's existing posts once before switching to incremental-only mode.</td></tr>
+        </tbody>
+      </table>
     </section>
 
     <section id="api-reference">
@@ -246,6 +266,13 @@ POST /api/v1/livestreams/stream:download
 GET  /api/v1/livestreams/operations/{operation_id}</code></pre>
       <p>The URL endpoint validates the host against an allowlist of <code>*.douyin.com</code> domains to prevent SSRF.</p>
 
+      <h3>Watch</h3>
+      <pre><code>POST   /api/v1/watch
+GET    /api/v1/watch
+GET    /api/v1/watch/{subscription_id}
+DELETE /api/v1/watch/{subscription_id}</code></pre>
+      <p>See the <a href="#watch-mode">Watch Mode</a> section for full endpoint details.</p>
+
       <h3>Examples</h3>
       <pre><code>curl -H "X-API-Key: $SECURITY_API_KEY" \
      "http://localhost:8000/api/v1/users/USER_ID"
@@ -283,6 +310,121 @@ curl -H "X-API-Key: $SECURITY_API_KEY" \
         <code>completed</code>, <code>partial</code>, and <code>failed</code>. Bulk-download responses extend this
         shape with per-<code>PostType</code> counters and <code>failed_count</code>.
       </p>
+    </section>
+
+    <section id="watch-mode">
+      <h2>Watch Mode</h2>
+      <p>
+        Watch Mode turns Dyvine from a request-driven downloader into a monitor. Each
+        <em>subscription</em> targets one Douyin user and runs a long-lived
+        <code>asyncio</code> loop with two independent polling cadences: a
+        <em>live-status check</em> and a <em>new-post check</em>. When a live check
+        finds the user streaming, it delegates to <code>LivestreamService.download_stream</code>
+        (deduped by <code>room_id</code>). When a post check finds new content, it delegates
+        to <code>PostService.download_new_posts</code>. Both paths create normal operation
+        rows observable through the existing operation-polling endpoints.
+      </p>
+
+      <h3>Endpoints</h3>
+      <table>
+        <thead>
+          <tr><th>Method</th><th>Path</th><th>Status</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>POST</code></td>
+            <td><code>/api/v1/watch</code></td>
+            <td>201 / 200 / 429</td>
+            <td>
+              Create a subscription. Idempotent on <code>user_id</code>: returns 201 for
+              a new subscription and 200 when one already exists for that user. Returns 429
+              when the <code>DOUYIN_WATCH_MAX_SUBSCRIPTIONS</code> cap is reached.
+            </td>
+          </tr>
+          <tr>
+            <td><code>GET</code></td>
+            <td><code>/api/v1/watch</code></td>
+            <td>200</td>
+            <td>List all subscriptions. Response shape: <code>{"subscriptions": [...], "total": N}</code>.</td>
+          </tr>
+          <tr>
+            <td><code>GET</code></td>
+            <td><code>/api/v1/watch/{subscription_id}</code></td>
+            <td>200 / 404</td>
+            <td>Fetch one subscription by ID; 404 when unknown.</td>
+          </tr>
+          <tr>
+            <td><code>DELETE</code></td>
+            <td><code>/api/v1/watch/{subscription_id}</code></td>
+            <td>204 / 404</td>
+            <td>
+              Cancel the subscription's watcher loop and delete its record. A livestream
+              recording already in progress runs to completion in its own background
+              task; DELETE only stops <em>future</em> checks.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Request body (<code>POST /watch</code>)</h3>
+      <table>
+        <thead>
+          <tr><th>Field</th><th>Required</th><th>Bounds</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>user_id</code></td><td>Yes</td><td>6–128 alphanumeric/<code>_</code>/<code>-</code> chars</td><td>Douyin <code>sec_user_id</code> of the user to watch.</td></tr>
+          <tr><td><code>live_poll_seconds</code></td><td>No</td><td>60–3600</td><td>Seconds between live-status checks. Omit to use <code>DOUYIN_WATCH_LIVE_POLL_SECONDS</code>.</td></tr>
+          <tr><td><code>post_poll_seconds</code></td><td>No</td><td>300–86400</td><td>Seconds between new-post checks. Omit to use <code>DOUYIN_WATCH_POST_POLL_SECONDS</code>.</td></tr>
+          <tr><td><code>backfill_on_create</code></td><td>No</td><td>bool</td><td>Download the user's existing posts once on creation. Omit to use <code>DOUYIN_WATCH_BACKFILL_ON_CREATE</code> (default <code>false</code>).</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Subscription response fields</h3>
+      <table>
+        <thead>
+          <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>subscription_id</code></td><td>string</td><td>Unique subscription identifier.</td></tr>
+          <tr><td><code>user_id</code></td><td>string</td><td>Watched Douyin user identifier.</td></tr>
+          <tr><td><code>enabled</code></td><td>bool</td><td>Whether the watcher loop is active.</td></tr>
+          <tr><td><code>live_poll_seconds</code></td><td>int</td><td>Effective seconds between live-status checks.</td></tr>
+          <tr><td><code>post_poll_seconds</code></td><td>int</td><td>Effective seconds between new-post checks.</td></tr>
+          <tr><td><code>last_live_check</code></td><td>string | null</td><td>ISO 8601 timestamp of the last live-status check.</td></tr>
+          <tr><td><code>last_post_check</code></td><td>string | null</td><td>ISO 8601 timestamp of the last new-post check.</td></tr>
+          <tr><td><code>newest_aweme_id</code></td><td>string | null</td><td>Most recent downloaded aweme_id, surfaced from the checkpoint.</td></tr>
+          <tr><td><code>created_at</code></td><td>string</td><td>ISO 8601 creation timestamp.</td></tr>
+          <tr><td><code>updated_at</code></td><td>string</td><td>ISO 8601 last-update timestamp.</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Behavior and invariants</h3>
+      <ul>
+        <li>Each cadence uses monotonic due-times with +/&#x2212;10% jitter so multiple subscriptions never hammer the upstream API in lockstep.</li>
+        <li>With <code>backfill_on_create=false</code> (the default), the service snapshots the user's current first page of posts at creation time. The first post check then stops pagination at that boundary and downloads only posts published afterward.</li>
+        <li>New-post deduplication is membership-based using a bounded recent-aweme_id set (capped by <code>DOUYIN_WATCH_RECENT_ID_CAP</code>). The checkpoint is only advanced after a successful run so an interrupted cycle re-downloads at most the most-recent window, which the f2 downloader overwrites idempotently.</li>
+        <li>A live check delegates to the existing livestream downloader; a live-status miss or an already-in-progress recording is silently skipped.</li>
+        <li>Each triggered download creates a regular operation row (<code>livestream_download</code> or <code>user_posts_incremental_download</code>) that can be polled through the existing operation endpoints.</li>
+        <li>Subscriptions survive restarts: they are persisted in a dedicated <code>watch_subscriptions</code> SQLite table (sharing the operation database file) and all enabled subscriptions are re-armed automatically on startup.</li>
+        <li><code>/readyz</code> does not gate on watch health. A crashed watcher loop is logged and resumed on next restart without pulling the pod out of rotation.</li>
+        <li><code>/health</code> reports an informational <code>watch_subscriptions</code> field showing the count of currently active watcher loops.</li>
+        <li>Watch Mode shares the single-replica constraint of the rest of the service: subscriptions are stored in pod-local SQLite.</li>
+      </ul>
+
+      <h3>Example</h3>
+      <pre><code># Create a subscription (new-posts-only mode)
+curl -X POST -H "X-API-Key: $SECURITY_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"user_id": "SEC_USER_ID", "live_poll_seconds": 300, "post_poll_seconds": 2700}' \
+     "http://localhost:8000/api/v1/watch"
+
+# List all subscriptions
+curl -H "X-API-Key: $SECURITY_API_KEY" \
+     "http://localhost:8000/api/v1/watch"
+
+# Delete a subscription
+curl -X DELETE -H "X-API-Key: $SECURITY_API_KEY" \
+     "http://localhost:8000/api/v1/watch/SUBSCRIPTION_ID"</code></pre>
     </section>
 
     <section id="operations">

--- a/download_serial.py
+++ b/download_serial.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""串行下载脚本：逐个用户发起下载请求并轮询完成。"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+API_URL = os.environ.get("DYVINE_API_URL", "http://localhost:8000")
+
+dotenv = {}
+for line in Path(".env").read_text().splitlines():
+    line = line.strip()
+    if line and not line.startswith("#") and "=" in line:
+        k, v = line.split("=", 1)
+        dotenv[k.strip()] = v.strip().strip("\"'")
+
+API_KEY = os.environ.get("DYVINE_API_KEY") or dotenv.get("SECURITY_API_KEY", "")
+HEADERS = {"X-API-Key": API_KEY} if API_KEY else {}
+
+
+def submit(user_id: str) -> dict:
+    url = f"{API_URL}/api/v1/posts/users/{user_id}/posts:download"
+    r = requests.post(url, headers=HEADERS, timeout=30)
+    return r.json()
+
+
+def poll(operation_id: str) -> dict:
+    url = f"{API_URL}/api/v1/posts/operations/{operation_id}"
+    r = requests.get(url, headers=HEADERS, timeout=30)
+    return r.json()
+
+
+def download_user(user_id: str) -> dict:
+    print(f"\n{'='*50}")
+    print(f"用户: {user_id}")
+    print(f"{'='*50}")
+
+    resp = submit(user_id)
+    if "operation_id" not in resp:
+        print(f"  提交失败: {resp.get('message', resp)}")
+        return {"user_id": user_id, "status": "failed", "error": resp}
+
+    oid = resp["operation_id"]
+    print(f"  已提交, operation_id: {oid}")
+
+    while True:
+        time.sleep(5)
+        status = poll(oid)
+        s = status.get("status", "unknown")
+        downloaded = status.get("total_downloaded", 0)
+        total = status.get("total_posts", 0)
+        failed = status.get("failed_count", 0)
+        progress = status.get("progress", 0) * 100
+        msg = status.get("message", "")
+        print(
+            f"  状态: {s} | 已下载: {downloaded}/{total} | 失败: {failed} | "
+            f"进度: {progress:.1f}% | {msg}"
+        )
+        if s in ("completed", "failed", "partial"):
+            break
+
+    return {"user_id": user_id, **status}
+
+
+def main():
+    if not API_KEY:
+        print("错误: .env 中未找到 SECURITY_API_KEY", file=sys.stderr)
+        sys.exit(1)
+
+    users = [
+        line.strip()
+        for line in Path("users.txt").read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    print(f"共 {len(users)} 个用户，开始串行下载...")
+    results = []
+
+    for i, uid in enumerate(users, 1):
+        print(f"\n>>> [{i}/{len(users)}]")
+        try:
+            r = download_user(uid)
+            results.append(r)
+        except Exception as e:
+            print(f"  异常: {e}")
+            results.append({"user_id": uid, "status": "error", "error": str(e)})
+
+    print(f"\n{'='*50}")
+    print("汇总报告")
+    print(f"{'='*50}")
+    total_downloaded = 0
+    for r in results:
+        s = r.get("status", "error")
+        d = r.get("total_downloaded", 0)
+        total_downloaded += d
+        print(f"  {r['user_id'][:20]}...  状态={s}  已下载={d}")
+    print(f"\n总下载作品数: {total_downloaded}")
+
+
+if __name__ == "__main__":
+    main()

--- a/download_serial.py
+++ b/download_serial.py
@@ -6,16 +6,28 @@ import sys
 import time
 from pathlib import Path
 
-import requests
+import httpx
 
-API_URL = os.environ.get("DYVINE_API_URL", "http://localhost:8000")
 
-dotenv = {}
-for line in Path(".env").read_text().splitlines():
-    line = line.strip()
-    if line and not line.startswith("#") and "=" in line:
-        k, v = line.split("=", 1)
-        dotenv[k.strip()] = v.strip().strip("\"'")
+def _load_env_file(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    if not path.exists():
+        return env
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            k, v = line.split("=", 1)
+            env[k.strip()] = v.strip().strip("\"'")
+    return env
+
+
+dotenv = _load_env_file(Path(".env"))
+
+API_URL = os.environ.get("DYVINE_API_URL") or "http://localhost:8000"
+if API_URL == "http://localhost:8000" and dotenv.get("API_HOST"):
+    host = dotenv.get("API_HOST", "0.0.0.0")
+    port = dotenv.get("API_PORT", "8000")
+    API_URL = f"http://{host}:{port}"
 
 API_KEY = os.environ.get("DYVINE_API_KEY") or dotenv.get("SECURITY_API_KEY", "")
 HEADERS = {"X-API-Key": API_KEY} if API_KEY else {}
@@ -23,13 +35,13 @@ HEADERS = {"X-API-Key": API_KEY} if API_KEY else {}
 
 def submit(user_id: str) -> dict:
     url = f"{API_URL}/api/v1/posts/users/{user_id}/posts:download"
-    r = requests.post(url, headers=HEADERS, timeout=30)
+    r = httpx.post(url, headers=HEADERS, timeout=30)
     return r.json()
 
 
 def poll(operation_id: str) -> dict:
     url = f"{API_URL}/api/v1/posts/operations/{operation_id}"
-    r = requests.get(url, headers=HEADERS, timeout=30)
+    r = httpx.get(url, headers=HEADERS, timeout=30)
     return r.json()
 
 

--- a/src/dyvine/core/dependencies.py
+++ b/src/dyvine/core/dependencies.py
@@ -48,9 +48,12 @@ from ..services.posts import PostService
 from ..services.users import UserService
 from ..services.watch import WatchService
 from .background import BackgroundTaskRegistry
+from .logging import ContextLogger
 from .operations import OperationStore
 from .settings import settings
 from .watch_store import WatchSubscriptionStore
+
+logger = ContextLogger(__name__)
 
 # Dedicated thread pool sizes per IO domain. The defaults are tuned for the
 # single-worker uvicorn deployment: R2 uploads are the dominant long-running
@@ -216,22 +219,37 @@ class ServiceContainer:
 
         # Initialize the watch scheduler. It shares the sqlite executor and
         # the background-task registry so its watcher loops drain on
-        # shutdown like every other long-lived download task.
-        watch_store = WatchSubscriptionStore(executor=self._sqlite_executor)
-        self._watch_store = watch_store
-        self._services["watch_service"] = WatchService(
-            watch_store=watch_store,
-            livestream_service=self._services["livestream_service"],
-            post_service=self._services["post_service"],
-            task_registry=self._background_tasks,
-        )
+        # shutdown like every other long-lived download task. Watch mode is
+        # non-critical -- it never gates readiness -- so a failure to build it
+        # must not abort startup or leak the executors created above; log and
+        # continue without watch instead.
+        try:
+            watch_store = WatchSubscriptionStore(executor=self._sqlite_executor)
+            self._watch_store = watch_store
+            self._services["watch_service"] = WatchService(
+                watch_store=watch_store,
+                livestream_service=self._services["livestream_service"],
+                post_service=self._services["post_service"],
+                task_registry=self._background_tasks,
+            )
+        except Exception:
+            logger.exception(
+                "watch scheduler initialization failed; continuing without watch"
+            )
+            self._watch_store = None
 
         self._initialized = True
 
         # Re-arm watcher loops for persisted subscriptions only after the
         # container is marked ready, since resume schedules tasks that may
-        # resolve services back through the container.
-        await self._services["watch_service"].resume_persisted()
+        # resolve services back through the container. A resume failure is
+        # non-fatal for the same reason: log it and leave the container up.
+        watch_service = self._services.get("watch_service")
+        if isinstance(watch_service, WatchService):
+            try:
+                await watch_service.resume_persisted()
+            except Exception:
+                logger.exception("watch subscription resume failed; continuing startup")
 
     async def shutdown(self) -> None:
         """Release services and tear down the dedicated executor pools.

--- a/src/dyvine/core/dependencies.py
+++ b/src/dyvine/core/dependencies.py
@@ -46,9 +46,11 @@ from fastapi import Header, HTTPException, status
 from ..services.livestreams import LivestreamService
 from ..services.posts import PostService
 from ..services.users import UserService
+from ..services.watch import WatchService
 from .background import BackgroundTaskRegistry
 from .operations import OperationStore
 from .settings import settings
+from .watch_store import WatchSubscriptionStore
 
 # Dedicated thread pool sizes per IO domain. The defaults are tuned for the
 # single-worker uvicorn deployment: R2 uploads are the dominant long-running
@@ -111,6 +113,10 @@ class ServiceContainer:
         # of bare ``asyncio.create_task`` so the lifespan can drain them
         # before the executor pools are reaped.
         self._background_tasks = BackgroundTaskRegistry()
+        # Watch subscriptions persist in their own SQLite table (sharing the
+        # operation database and sqlite executor) so the operation store's
+        # restart sweep never fails a long-lived subscription row.
+        self._watch_store: WatchSubscriptionStore | None = None
 
     async def initialize(self) -> None:
         """Initialize all registered services with their configurations.
@@ -208,7 +214,24 @@ class ServiceContainer:
             task_registry=self._background_tasks,
         )
 
+        # Initialize the watch scheduler. It shares the sqlite executor and
+        # the background-task registry so its watcher loops drain on
+        # shutdown like every other long-lived download task.
+        watch_store = WatchSubscriptionStore(executor=self._sqlite_executor)
+        self._watch_store = watch_store
+        self._services["watch_service"] = WatchService(
+            watch_store=watch_store,
+            livestream_service=self._services["livestream_service"],
+            post_service=self._services["post_service"],
+            task_registry=self._background_tasks,
+        )
+
         self._initialized = True
+
+        # Re-arm watcher loops for persisted subscriptions only after the
+        # container is marked ready, since resume schedules tasks that may
+        # resolve services back through the container.
+        await self._services["watch_service"].resume_persisted()
 
     async def shutdown(self) -> None:
         """Release services and tear down the dedicated executor pools.
@@ -226,6 +249,12 @@ class ServiceContainer:
         if not self._initialized:
             return
 
+        # Stop watcher loops first so they cannot schedule new downloads
+        # while the background-task registry is being drained.
+        watch_service = self._services.get("watch_service")
+        if isinstance(watch_service, WatchService):
+            await watch_service.stop_all()
+
         # Drain fire-and-forget downloads before tearing down the executor
         # pools they dispatch onto. Any task still running after the
         # registry's drain timeout is cancelled so the shutdown cannot hang
@@ -237,6 +266,12 @@ class ServiceContainer:
         operation_store = self._services.get("operation_store")
         if isinstance(operation_store, OperationStore):
             operation_store.shutdown()
+
+        # Close the watch store's connections before the sqlite executor that
+        # owns its worker threads is reaped below.
+        if self._watch_store is not None:
+            self._watch_store.shutdown()
+            self._watch_store = None
 
         # Reverse of init order. The R2 head pool is drained first so any
         # ``list_objects`` follow-up still has a working main pool to
@@ -362,6 +397,14 @@ class ServiceContainer:
             raise TypeError("post_service is not a PostService instance")
         return service
 
+    @property
+    def watch_service(self) -> WatchService:
+        """Get the watch scheduler service."""
+        service = self.get_service("watch_service")
+        if not isinstance(service, WatchService):
+            raise TypeError("watch_service is not a WatchService instance")
+        return service
+
 
 @lru_cache
 def get_service_container() -> ServiceContainer:
@@ -442,6 +485,11 @@ def get_post_service() -> PostService:
     ``Annotated[PostService, Depends(get_post_service)]``.
     """
     return get_service_container().post_service
+
+
+def get_watch_service() -> WatchService:
+    """FastAPI dependency provider for the watch scheduler service."""
+    return get_service_container().watch_service
 
 
 def require_api_key(

--- a/src/dyvine/core/exceptions.py
+++ b/src/dyvine/core/exceptions.py
@@ -5,7 +5,8 @@ Every service-layer failure raises a subclass of `DyvineError`. The
 each subclass to an HTTP status code:
 
 - `NotFoundError` (and friends: `UserNotFoundError`, `PostNotFoundError`,
-  `LivestreamNotFoundError`, `OperationNotFoundError`) -> `404`.
+  `LivestreamNotFoundError`, `OperationNotFoundError`,
+  `WatchSubscriptionNotFoundError`) -> `404`.
 - `AuthenticationError` -> `401`.
 - `RateLimitError` -> `429`.
 - `ValidationError` -> `422`.
@@ -68,6 +69,12 @@ class LivestreamNotFoundError(NotFoundError):
 
 class OperationNotFoundError(NotFoundError):
     """Operation record not found in the persistent store."""
+
+    pass
+
+
+class WatchSubscriptionNotFoundError(NotFoundError):
+    """Watch subscription not found in the persistent store."""
 
     pass
 

--- a/src/dyvine/core/settings.py
+++ b/src/dyvine/core/settings.py
@@ -306,6 +306,76 @@ class DouyinSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="DOUYIN_")
 
 
+class WatchSettings(BaseSettings):
+    """Watch-mode scheduler configuration settings.
+
+    Controls the in-process watcher that polls subscribed Douyin users
+    and auto-downloads new posts and livestreams. Every interval is a
+    configurable default; per-subscription overrides supplied through the
+    ``/watch`` API are validated against the same bounds.
+
+    Attributes:
+        live_poll_seconds: Default cadence for live-status checks. The
+            60-second floor keeps aggressive polling from tripping
+            Douyin's rate limiting / cookie risk controls.
+        post_poll_seconds: Default cadence for new-post checks, kept much
+            longer than the live cadence because posts are durable.
+        recent_id_cap: Upper bound on the per-subscription ``aweme_id``
+            dedupe set persisted in the checkpoint so the JSON blob stays
+            small.
+        max_subscriptions: Guardrail on the number of concurrent watch
+            subscriptions; ``POST /watch`` is rejected past this count.
+        backfill_on_create: Whether a brand-new subscription downloads
+            the user's existing posts once before switching to
+            incremental-only mode.
+
+    Environment Variables:
+        DOUYIN_WATCH_LIVE_POLL_SECONDS, DOUYIN_WATCH_POST_POLL_SECONDS,
+        DOUYIN_WATCH_RECENT_ID_CAP, DOUYIN_WATCH_MAX_SUBSCRIPTIONS,
+        DOUYIN_WATCH_BACKFILL_ON_CREATE.
+
+    Note:
+        ``DOUYIN_WATCH_`` is a distinct prefix from ``DouyinSettings``'
+        ``DOUYIN_`` prefix. Pydantic resolves each settings class against
+        its own declared field names, so the two never collide as long as
+        ``DouyinSettings`` declares no ``watch_*`` field.
+    """
+
+    live_poll_seconds: int = Field(
+        default=300,
+        ge=60,
+        le=3600,
+        description="Default seconds between live-status checks (60s floor).",
+    )
+    post_poll_seconds: int = Field(
+        default=2700,
+        ge=300,
+        le=86400,
+        description="Default seconds between new-post checks.",
+    )
+    recent_id_cap: int = Field(
+        default=200,
+        ge=20,
+        le=2000,
+        description="Max aweme_id values kept in the per-subscription dedupe set.",
+    )
+    max_subscriptions: int = Field(
+        default=50,
+        ge=1,
+        le=10000,
+        description="Maximum number of concurrent watch subscriptions.",
+    )
+    backfill_on_create: bool = Field(
+        default=False,
+        description=(
+            "Download a user's existing posts once when a subscription is "
+            "created, instead of only fetching posts published afterwards."
+        ),
+    )
+
+    model_config = SettingsConfigDict(env_prefix="DOUYIN_WATCH_")
+
+
 class Settings(BaseSettings):
     """Composite settings container with nested configuration groups.
 
@@ -348,6 +418,7 @@ class Settings(BaseSettings):
     security: SecuritySettings = Field(default_factory=SecuritySettings)
     r2: R2Settings = Field(default_factory=R2Settings)
     douyin: DouyinSettings = Field(default_factory=DouyinSettings)
+    watch: WatchSettings = Field(default_factory=WatchSettings)
 
     @model_validator(mode="after")
     def _validate_security_in_production(self) -> Self:

--- a/src/dyvine/core/watch_store.py
+++ b/src/dyvine/core/watch_store.py
@@ -1,0 +1,496 @@
+"""Persistent storage for watch-mode subscriptions.
+
+A watch subscription is a long-lived, mutable configuration row: which
+Douyin user to monitor, how often to poll for live status and new posts,
+and an incremental-download checkpoint. Unlike :class:`OperationStore`
+records (one row per unit of background work), subscriptions must survive a
+process restart and be enumerated on startup so their watcher loops can be
+resumed. That is why they live in a dedicated ``watch_subscriptions`` table
+rather than the ``operations`` table, whose
+``mark_incomplete_operations_failed`` sweep flips every ``pending`` /
+``running`` row to ``failed`` on boot and would otherwise clobber a
+long-lived subscription.
+
+The store mirrors :class:`dyvine.core.operations.OperationStore`'s
+connection discipline: a single lazily-opened writer connection guarded by
+a ``threading.Lock`` plus one autocommit reader connection per worker
+thread, with every public coroutine dispatching its blocking ``sqlite3``
+call to the container-owned executor so the event loop never stalls. It
+shares the same SQLite file as the operation store (WAL is a
+database-level mode), adding its own table alongside ``operations``. The
+writer-slot holder and finalizer helper are reused from
+:mod:`dyvine.core.operations` so both stores release their handles the same
+way before Python flags an unclosed database under ``-W error``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import json
+import sqlite3
+import threading
+import uuid
+import weakref
+from collections.abc import Callable
+from concurrent.futures import Executor
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, TypeVar
+
+from .exceptions import WatchSubscriptionNotFoundError
+from .operations import _close_connections, _WriterSlot
+from .settings import settings
+
+_R = TypeVar("_R")
+
+# Columns a caller may update after creation. ``subject_id`` / ``user_id``
+# and the immutable identifiers are intentionally excluded so an update
+# cannot break the ``UNIQUE(user_id)`` invariant or repoint a row.
+_UPDATABLE_FIELDS = frozenset(
+    {
+        "enabled",
+        "live_poll_seconds",
+        "post_poll_seconds",
+        "checkpoint",
+        "last_live_check",
+        "last_post_check",
+    }
+)
+
+
+@dataclass(slots=True)
+class WatchSubscriptionRecord:
+    """Structured representation of a persisted watch subscription."""
+
+    subscription_id: str
+    user_id: str
+    enabled: bool
+    live_poll_seconds: int
+    post_poll_seconds: int
+    checkpoint: dict[str, Any]
+    last_live_check: str | None
+    last_post_check: str | None
+    created_at: str
+    updated_at: str
+
+
+class WatchSubscriptionStore:
+    """SQLite-backed persistence for watch subscriptions.
+
+    Public methods are coroutines that dispatch their blocking SQLite work
+    to the configured executor, exactly like :class:`OperationStore`. The
+    store keeps one writer connection guarded by a ``threading.Lock`` and
+    one reader connection per worker thread (opened lazily); readers never
+    take the lock so concurrent reads run in parallel.
+    """
+
+    def __init__(
+        self,
+        db_path: str | None = None,
+        *,
+        executor: Executor | None = None,
+    ) -> None:
+        """Initialize the SQLite watch-subscription store and schema.
+
+        Args:
+            db_path: Optional database path. Defaults to the same operation
+                state database the rest of the service uses.
+            executor: Optional executor for blocking SQLite calls.
+        """
+        # Default to the shared operation database so a single SQLite file
+        # (already in WAL mode) carries both tables; the container hands us
+        # the same dedicated sqlite executor for write serialisation.
+        self.db_path = Path(db_path or settings.operation_db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._executor: Executor | None = executor
+        self._reader_local = threading.local()
+        self._reader_connections: dict[int, sqlite3.Connection] = {}
+        self._reader_lock = threading.Lock()
+        self._writer_slot = _WriterSlot()
+        self._closed = False
+        self._finalizer = weakref.finalize(
+            self,
+            _close_connections,
+            self._reader_connections,
+            self._writer_slot,
+        )
+        self._initialize()
+
+    def set_executor(self, executor: Executor | None) -> None:
+        """Attach a dedicated executor after construction.
+
+        Late binding lets the store bootstrap synchronously inside
+        ``ServiceContainer`` (no running event loop yet) while still routing
+        every later async call through the dedicated worker pool.
+        """
+        self._executor = executor
+
+    @property
+    def is_closed(self) -> bool:
+        """Whether :meth:`shutdown` has been called."""
+        return self._closed
+
+    async def _run(self, func: Callable[..., _R], /, *args: Any, **kwargs: Any) -> _R:
+        """Dispatch a blocking SQLite call to the configured executor."""
+        if self._closed:
+            raise RuntimeError(
+                "WatchSubscriptionStore has been shut down; cannot dispatch new work"
+            )
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor, functools.partial(func, *args, **kwargs)
+        )
+
+    def _connect(self, *, autocommit: bool = False) -> sqlite3.Connection:
+        """Open and configure a SQLite connection for the store."""
+        isolation_level: str | None = None if autocommit else ""
+        connection = sqlite3.connect(
+            self.db_path,
+            check_same_thread=False,
+            isolation_level=isolation_level,  # type: ignore[arg-type]
+        )
+        try:
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA synchronous=NORMAL;")
+            connection.execute("PRAGMA busy_timeout=5000;")
+        except Exception:
+            connection.close()
+            raise
+        return connection
+
+    def _initialize(self) -> None:
+        """Create the watch_subscriptions table, index, and WAL journal mode."""
+        with self._lock, closing(self._connect()) as connection:
+            connection.execute("PRAGMA journal_mode=WAL;")
+            connection.execute("""
+                CREATE TABLE IF NOT EXISTS watch_subscriptions (
+                    subscription_id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL,
+                    enabled INTEGER NOT NULL,
+                    live_poll_seconds INTEGER NOT NULL,
+                    post_poll_seconds INTEGER NOT NULL,
+                    checkpoint TEXT NOT NULL,
+                    last_live_check TEXT,
+                    last_post_check TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """)
+            # One subscription per user. The UNIQUE constraint is the
+            # backstop that makes ``POST /watch`` idempotent even under a
+            # race between two concurrent creates for the same user.
+            connection.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_user
+                ON watch_subscriptions (user_id)
+                """)
+            connection.commit()
+
+    def _reader_connection(self) -> sqlite3.Connection:
+        """Return the current thread's reader connection, opening one lazily."""
+        existing: sqlite3.Connection | None = getattr(
+            self._reader_local, "connection", None
+        )
+        if existing is not None:
+            return existing
+        new_connection = self._connect(autocommit=True)
+        self._reader_local.connection = new_connection
+        with self._reader_lock:
+            self._reader_connections[threading.get_ident()] = new_connection
+        return new_connection
+
+    def _writer_connection(self) -> sqlite3.Connection:
+        """Return the shared writer connection, opening it on first use.
+
+        Callers must hold ``self._lock`` before invoking this.
+        """
+        if self._writer_slot.connection is None:
+            self._writer_slot.connection = self._connect()
+        return self._writer_slot.connection
+
+    def shutdown(self) -> None:
+        """Close every live reader connection and the writer connection.
+
+        Called from ``ServiceContainer.shutdown`` before the owning SQLite
+        executor reaps its worker threads. Safe to call multiple times.
+        """
+        with self._reader_lock:
+            self._closed = True
+            readers = list(self._reader_connections.values())
+            self._reader_connections.clear()
+        for connection in readers:
+            try:
+                connection.close()
+            except sqlite3.Error:
+                pass
+        if hasattr(self._reader_local, "connection"):
+            del self._reader_local.connection
+
+        with self._lock:
+            if self._writer_slot.connection is not None:
+                try:
+                    self._writer_slot.connection.close()
+                except sqlite3.Error:
+                    pass
+                self._writer_slot.connection = None
+
+        self._finalizer.detach()
+
+    @staticmethod
+    def _now() -> str:
+        """Return the current UTC timestamp in ISO 8601 format."""
+        return datetime.now(UTC).isoformat()
+
+    @staticmethod
+    def _from_row(row: sqlite3.Row | None) -> WatchSubscriptionRecord | None:
+        """Convert a SQLite row into a watch-subscription record."""
+        if row is None:
+            return None
+        checkpoint_raw = row["checkpoint"]
+        checkpoint = json.loads(str(checkpoint_raw)) if checkpoint_raw else {}
+        return WatchSubscriptionRecord(
+            subscription_id=str(row["subscription_id"]),
+            user_id=str(row["user_id"]),
+            enabled=bool(row["enabled"]),
+            live_poll_seconds=int(row["live_poll_seconds"]),
+            post_poll_seconds=int(row["post_poll_seconds"]),
+            checkpoint=checkpoint if isinstance(checkpoint, dict) else {},
+            last_live_check=(
+                str(row["last_live_check"])
+                if row["last_live_check"] is not None
+                else None
+            ),
+            last_post_check=(
+                str(row["last_post_check"])
+                if row["last_post_check"] is not None
+                else None
+            ),
+            created_at=str(row["created_at"]),
+            updated_at=str(row["updated_at"]),
+        )
+
+    async def create_subscription(
+        self,
+        *,
+        user_id: str,
+        live_poll_seconds: int,
+        post_poll_seconds: int,
+        enabled: bool = True,
+        checkpoint: dict[str, Any] | None = None,
+        subscription_id: str | None = None,
+    ) -> WatchSubscriptionRecord:
+        """Create and persist a new watch subscription.
+
+        Raises:
+            sqlite3.IntegrityError: If a subscription for ``user_id`` already
+                exists (the ``UNIQUE(user_id)`` backstop). Callers that want
+                idempotent behaviour should check
+                :meth:`get_subscription_by_user` under a lock first.
+        """
+        return await self._run(
+            self._create_subscription_sync,
+            user_id=user_id,
+            live_poll_seconds=live_poll_seconds,
+            post_poll_seconds=post_poll_seconds,
+            enabled=enabled,
+            checkpoint=checkpoint,
+            subscription_id=subscription_id,
+        )
+
+    def _create_subscription_sync(
+        self,
+        *,
+        user_id: str,
+        live_poll_seconds: int,
+        post_poll_seconds: int,
+        enabled: bool,
+        checkpoint: dict[str, Any] | None,
+        subscription_id: str | None,
+    ) -> WatchSubscriptionRecord:
+        """Synchronously insert and return a new subscription record."""
+        created_at = self._now()
+        record = WatchSubscriptionRecord(
+            subscription_id=subscription_id or str(uuid.uuid4()),
+            user_id=user_id,
+            enabled=enabled,
+            live_poll_seconds=live_poll_seconds,
+            post_poll_seconds=post_poll_seconds,
+            checkpoint=checkpoint or {},
+            last_live_check=None,
+            last_post_check=None,
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        with self._lock:
+            connection = self._writer_connection()
+            connection.execute(
+                """
+                INSERT INTO watch_subscriptions (
+                    subscription_id, user_id, enabled, live_poll_seconds,
+                    post_poll_seconds, checkpoint, last_live_check,
+                    last_post_check, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.subscription_id,
+                    record.user_id,
+                    1 if record.enabled else 0,
+                    record.live_poll_seconds,
+                    record.post_poll_seconds,
+                    json.dumps(record.checkpoint, sort_keys=True),
+                    record.last_live_check,
+                    record.last_post_check,
+                    record.created_at,
+                    record.updated_at,
+                ),
+            )
+            connection.commit()
+        return record
+
+    async def get_subscription(self, subscription_id: str) -> WatchSubscriptionRecord:
+        """Fetch a subscription by ID or raise ``WatchSubscriptionNotFoundError``."""
+        return await self._run(self._get_subscription_sync, subscription_id)
+
+    def _get_subscription_sync(self, subscription_id: str) -> WatchSubscriptionRecord:
+        """Synchronously fetch a subscription by ID or raise when missing."""
+        connection = self._reader_connection()
+        row = connection.execute(
+            "SELECT * FROM watch_subscriptions WHERE subscription_id = ?",
+            (subscription_id,),
+        ).fetchone()
+        record = self._from_row(row)
+        if record is None:
+            raise WatchSubscriptionNotFoundError(
+                f"Watch subscription {subscription_id} not found"
+            )
+        return record
+
+    async def get_subscription_by_user(
+        self, user_id: str
+    ) -> WatchSubscriptionRecord | None:
+        """Return the subscription for ``user_id``, or ``None`` when absent."""
+        return await self._run(self._get_subscription_by_user_sync, user_id)
+
+    def _get_subscription_by_user_sync(
+        self, user_id: str
+    ) -> WatchSubscriptionRecord | None:
+        """Synchronously fetch the subscription for a user without raising."""
+        connection = self._reader_connection()
+        row = connection.execute(
+            "SELECT * FROM watch_subscriptions WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()
+        return self._from_row(row)
+
+    async def list_subscriptions(
+        self, *, enabled_only: bool = False
+    ) -> list[WatchSubscriptionRecord]:
+        """Return all subscriptions, optionally only the enabled ones.
+
+        This is the enumeration the resume-on-restart path depends on; the
+        operation store has no equivalent query, which is one reason watch
+        subscriptions need their own table.
+        """
+        return await self._run(self._list_subscriptions_sync, enabled_only)
+
+    def _list_subscriptions_sync(
+        self, enabled_only: bool
+    ) -> list[WatchSubscriptionRecord]:
+        """Synchronously return subscriptions ordered by creation time."""
+        connection = self._reader_connection()
+        query = "SELECT * FROM watch_subscriptions"
+        if enabled_only:
+            query += " WHERE enabled = 1"
+        query += " ORDER BY created_at ASC, subscription_id ASC"
+        rows = connection.execute(query).fetchall()
+        records = [self._from_row(row) for row in rows]
+        return [record for record in records if record is not None]
+
+    async def count_subscriptions(self) -> int:
+        """Return the total number of persisted subscriptions."""
+        return await self._run(self._count_subscriptions_sync)
+
+    def _count_subscriptions_sync(self) -> int:
+        """Synchronously count persisted subscriptions."""
+        connection = self._reader_connection()
+        row = connection.execute(
+            "SELECT COUNT(*) AS total FROM watch_subscriptions"
+        ).fetchone()
+        return int(row["total"]) if row is not None else 0
+
+    async def update_subscription(
+        self, subscription_id: str, **fields: Any
+    ) -> WatchSubscriptionRecord:
+        """Update selected fields on a subscription and return the new state."""
+        return await self._run(
+            self._update_subscription_sync, subscription_id, **fields
+        )
+
+    def _update_subscription_sync(
+        self, subscription_id: str, **fields: Any
+    ) -> WatchSubscriptionRecord:
+        """Synchronously update allowed fields and return the new record."""
+        requested = {
+            key: value for key, value in fields.items() if key in _UPDATABLE_FIELDS
+        }
+        with self._lock:
+            connection = self._writer_connection()
+            if not requested:
+                # Nothing to change: verify the row exists under the lock so
+                # callers still serialise with concurrent writers.
+                row = connection.execute(
+                    "SELECT * FROM watch_subscriptions WHERE subscription_id = ?",
+                    (subscription_id,),
+                ).fetchone()
+                record = self._from_row(row)
+                if record is None:
+                    raise WatchSubscriptionNotFoundError(
+                        f"Watch subscription {subscription_id} not found"
+                    )
+                return record
+
+            updates: dict[str, Any] = {}
+            for key, value in requested.items():
+                if key == "checkpoint":
+                    updates[key] = json.dumps(value, sort_keys=True)
+                elif key == "enabled":
+                    updates[key] = 1 if value else 0
+                else:
+                    updates[key] = value
+            updates["updated_at"] = self._now()
+
+            assignments = ", ".join(f"{column} = ?" for column in updates)
+            values: list[Any] = list(updates.values())
+            values.append(subscription_id)
+
+            cursor = connection.execute(
+                f"UPDATE watch_subscriptions SET {assignments} "
+                f"WHERE subscription_id = ? RETURNING *",
+                values,
+            )
+            updated = cursor.fetchone()
+            connection.commit()
+            record = self._from_row(updated)
+            if record is None:
+                raise WatchSubscriptionNotFoundError(
+                    f"Watch subscription {subscription_id} not found"
+                )
+            return record
+
+    async def delete_subscription(self, subscription_id: str) -> bool:
+        """Delete a subscription, returning ``True`` when a row was removed."""
+        return await self._run(self._delete_subscription_sync, subscription_id)
+
+    def _delete_subscription_sync(self, subscription_id: str) -> bool:
+        """Synchronously delete a subscription and report whether it existed."""
+        with self._lock:
+            connection = self._writer_connection()
+            cursor = connection.execute(
+                "DELETE FROM watch_subscriptions WHERE subscription_id = ?",
+                (subscription_id,),
+            )
+            connection.commit()
+            return int(cursor.rowcount) > 0

--- a/src/dyvine/main.py
+++ b/src/dyvine/main.py
@@ -1,8 +1,8 @@
 """FastAPI entry point for Dyvine.
 
 Wires the Dyvine service: lifespan-driven `ServiceContainer` initialisation,
-the CORS + correlation-ID HTTP middleware, three feature routers
-(`users`, `posts`, `livestreams`), and the operational endpoints
+the CORS + correlation-ID HTTP middleware, four feature routers
+(`users`, `posts`, `livestreams`, `watch`), and the operational endpoints
 (`/livez`, `/readyz`, `/startupz`, `/health`, plus the Prometheus
 metrics ASGI app at `/metrics`).
 
@@ -68,7 +68,7 @@ from .core.error_handlers import register_error_handlers
 from .core.logging import ContextLogger, setup_logging
 from .core.path_safety import ensure_within_root, get_task_workspace_root
 from .core.settings import settings
-from .routers import livestreams, posts, users
+from .routers import livestreams, posts, users, watch
 
 http_requests_total = Counter(
     "dyvine_http_requests_total",
@@ -416,6 +416,8 @@ app.include_router(users.router, prefix=settings.prefix)
 
 app.include_router(livestreams.router, prefix=settings.prefix)
 
+app.include_router(watch.router, prefix=settings.prefix)
+
 metrics_app = make_asgi_app()
 app.mount("/metrics", metrics_app)
 
@@ -474,7 +476,7 @@ async def root() -> dict[str, Any]:
         "redoc": "/redoc",
         "status": "operational",
         "api_prefix": settings.prefix,
-        "features": ["users", "posts", "livestreams"],
+        "features": ["users", "posts", "livestreams", "watch"],
     }
 
 
@@ -710,10 +712,20 @@ async def health_check(request: Request) -> JSONResponse:
         r2_status = "disabled"
     else:
         r2_status = "missing_credentials"
+    # Watch scheduler is informational here; it never gates readiness, so a
+    # crashed watcher loop does not pull the Pod out of rotation.
+    watch_status = "disabled"
+    container = getattr(app.state, "container", None)
+    if container is not None:
+        try:
+            watch_status = f"{container.watch_service.active_count} active"
+        except Exception:
+            watch_status = "unavailable"
     dependencies = {
         "douyin_api": douyin_status,
         "r2_storage": r2_status,
         "logging_system": "operational",
+        "watch_subscriptions": watch_status,
     }
 
     rss_bytes = process.memory_info().rss

--- a/src/dyvine/routers/watch.py
+++ b/src/dyvine/routers/watch.py
@@ -1,0 +1,145 @@
+"""Watch-mode FastAPI router.
+
+Endpoints under ``/api/v1/watch`` manage long-lived watch subscriptions
+that auto-download a Douyin user's new posts and record their livestreams:
+
+- ``POST /watch`` — create a subscription (idempotent on ``user_id``: 201
+  for a new subscription, 200 when one already exists).
+- ``GET /watch`` — list every subscription.
+- ``GET /watch/{subscription_id}`` — fetch one subscription.
+- ``DELETE /watch/{subscription_id}`` — stop a subscription's watcher loop
+  and delete its record. A livestream recording already in progress runs in
+  its own background task and continues to completion; deletion only stops
+  future checks.
+
+``WatchSubscriptionNotFoundError`` (a ``NotFoundError``) maps to 404 and the
+``max_subscriptions`` guardrail raises ``RateLimitError`` (429) through the
+shared ``handle_errors`` decorator, so no per-handler error mapping is
+needed here.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, Response, status
+
+from ..core.decorators import handle_errors
+from ..core.dependencies import get_watch_service, require_api_key
+from ..core.logging import ContextLogger
+from ..schemas.watch import (
+    WatchSubscriptionCreate,
+    WatchSubscriptionList,
+    WatchSubscriptionResponse,
+)
+from ..services.watch import WatchService
+
+router = APIRouter(
+    prefix="/watch",
+    tags=["watch"],
+    dependencies=[Depends(require_api_key)],
+)
+logger = ContextLogger(__name__)
+
+_SUBSCRIPTION_ID_PATTERN = r"^[A-Za-z0-9_\-]{8,128}$"
+
+
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=WatchSubscriptionResponse,
+    responses={
+        200: {"description": "A subscription for this user already exists"},
+        401: {"description": "Missing or invalid API key"},
+        422: {"description": "Invalid user_id or poll interval"},
+        429: {"description": "Watch subscription limit reached"},
+    },
+)
+@handle_errors(logger=logger)
+async def create_watch_subscription(
+    request: WatchSubscriptionCreate,
+    service: Annotated[WatchService, Depends(get_watch_service)],
+    response: Response,
+) -> WatchSubscriptionResponse:
+    """Create a watch subscription for a user (idempotent on user_id)."""
+    logger.info(
+        "Processing create_watch_subscription request",
+        extra={"user_id": request.user_id},
+    )
+    async with logger.track_time("create_watch_subscription"):
+        record, created = await service.create_subscription(
+            user_id=request.user_id,
+            live_poll_seconds=request.live_poll_seconds,
+            post_poll_seconds=request.post_poll_seconds,
+            backfill_on_create=request.backfill_on_create,
+        )
+    response.status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+    return service.to_response(record)
+
+
+@router.get(
+    "",
+    response_model=WatchSubscriptionList,
+    responses={401: {"description": "Missing or invalid API key"}},
+)
+@handle_errors(logger=logger)
+async def list_watch_subscriptions(
+    service: Annotated[WatchService, Depends(get_watch_service)],
+) -> WatchSubscriptionList:
+    """List all watch subscriptions."""
+    logger.info("Processing list_watch_subscriptions request")
+    async with logger.track_time("list_watch_subscriptions"):
+        records = await service.list_subscriptions()
+    items = [service.to_response(record) for record in records]
+    return WatchSubscriptionList(subscriptions=items, total=len(items))
+
+
+@router.get(
+    "/{subscription_id}",
+    response_model=WatchSubscriptionResponse,
+    responses={
+        401: {"description": "Missing or invalid API key"},
+        404: {"description": "Subscription not found"},
+    },
+)
+@handle_errors(logger=logger)
+async def get_watch_subscription(
+    service: Annotated[WatchService, Depends(get_watch_service)],
+    subscription_id: str = Path(
+        ...,
+        pattern=_SUBSCRIPTION_ID_PATTERN,
+        description="The unique identifier of the watch subscription",
+    ),
+) -> WatchSubscriptionResponse:
+    """Get a single watch subscription by id."""
+    logger.info(
+        "Processing get_watch_subscription request",
+        extra={"subscription_id": subscription_id},
+    )
+    async with logger.track_time("get_watch_subscription"):
+        record = await service.get_subscription(subscription_id)
+    return service.to_response(record)
+
+
+@router.delete(
+    "/{subscription_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        401: {"description": "Missing or invalid API key"},
+        404: {"description": "Subscription not found"},
+    },
+)
+@handle_errors(logger=logger)
+async def delete_watch_subscription(
+    service: Annotated[WatchService, Depends(get_watch_service)],
+    subscription_id: str = Path(
+        ...,
+        pattern=_SUBSCRIPTION_ID_PATTERN,
+        description="The unique identifier of the watch subscription",
+    ),
+) -> None:
+    """Delete a watch subscription and stop its watcher loop."""
+    logger.info(
+        "Processing delete_watch_subscription request",
+        extra={"subscription_id": subscription_id},
+    )
+    async with logger.track_time("delete_watch_subscription"):
+        await service.delete_subscription(subscription_id)

--- a/src/dyvine/schemas/watch.py
+++ b/src/dyvine/schemas/watch.py
@@ -1,0 +1,91 @@
+"""Pydantic models for the watch-mode router.
+
+``WatchSubscriptionCreate`` is the request body for ``POST /watch``;
+``WatchSubscriptionResponse`` and ``WatchSubscriptionList`` are the read
+models. Interval overrides are optional: when omitted the service fills in
+the configured ``DOUYIN_WATCH_*`` defaults. The bounds mirror
+``WatchSettings`` so the schema rejects out-of-range values before they
+reach the service.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+# Matches the alphabet Douyin emits for sec_user_id values, mirroring the
+# livestream schema/router so a watch target validates the same way a
+# livestream download target does.
+_USER_ID_PATTERN = r"^[A-Za-z0-9_\-]{6,128}$"
+
+
+class WatchSubscriptionCreate(BaseModel):
+    """Request body for creating a watch subscription."""
+
+    user_id: str = Field(
+        ...,
+        pattern=_USER_ID_PATTERN,
+        description=(
+            "The Douyin user identifier (sec_user_id) to watch. Restricted "
+            "to the alphabet Douyin emits to prevent injection into "
+            "generated upstream URLs."
+        ),
+    )
+    live_poll_seconds: int | None = Field(
+        None,
+        ge=60,
+        le=3600,
+        description=(
+            "Seconds between live-status checks. Omit to use the configured "
+            "DOUYIN_WATCH_LIVE_POLL_SECONDS default."
+        ),
+    )
+    post_poll_seconds: int | None = Field(
+        None,
+        ge=300,
+        le=86400,
+        description=(
+            "Seconds between new-post checks. Omit to use the configured "
+            "DOUYIN_WATCH_POST_POLL_SECONDS default."
+        ),
+    )
+    backfill_on_create: bool | None = Field(
+        None,
+        description=(
+            "Download the user's existing posts once on creation instead of "
+            "only fetching posts published afterwards. Omit to use the "
+            "configured DOUYIN_WATCH_BACKFILL_ON_CREATE default."
+        ),
+    )
+
+
+class WatchSubscriptionResponse(BaseModel):
+    """Public representation of a watch subscription."""
+
+    subscription_id: str = Field(..., description="Unique subscription identifier")
+    user_id: str = Field(..., description="Watched Douyin user identifier")
+    enabled: bool = Field(..., description="Whether the watcher loop is active")
+    live_poll_seconds: int = Field(
+        ..., description="Seconds between live-status checks"
+    )
+    post_poll_seconds: int = Field(..., description="Seconds between new-post checks")
+    last_live_check: str | None = Field(
+        None, description="ISO 8601 timestamp of the last live-status check"
+    )
+    last_post_check: str | None = Field(
+        None, description="ISO 8601 timestamp of the last new-post check"
+    )
+    newest_aweme_id: str | None = Field(
+        None,
+        description="Most recent downloaded aweme_id, surfaced from the checkpoint",
+    )
+    created_at: str = Field(..., description="ISO 8601 creation timestamp")
+    updated_at: str = Field(..., description="ISO 8601 last update timestamp")
+
+
+class WatchSubscriptionList(BaseModel):
+    """Envelope for listing watch subscriptions."""
+
+    subscriptions: list[WatchSubscriptionResponse] = Field(
+        default_factory=list, description="All watch subscriptions"
+    )
+    total: int = Field(..., description="Total number of subscriptions")

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -85,6 +85,23 @@ class UserPostsPage:
     has_more: bool
 
 
+@dataclass(slots=True)
+class IncrementalDownloadResult:
+    """Outcome of an incremental new-post download for a watch cycle.
+
+    ``seen_aweme_ids`` lists the posts downloaded this run, newest first,
+    so a watch loop can fold them into its dedupe checkpoint.
+    ``newest_aweme_id`` is the first of that list (or ``None`` when nothing
+    new was found, in which case the caller keeps its existing sentinel).
+    """
+
+    operation_id: str
+    new_count: int
+    newest_aweme_id: str | None
+    seen_aweme_ids: list[str]
+    failed_count: int
+
+
 class PostService:
     """Domain logic for individual posts and bulk-download operations.
 
@@ -746,6 +763,197 @@ class PostService:
             message=message,
             error_details=op.error,
         )
+
+    async def download_new_posts(
+        self,
+        sec_user_id: str,
+        *,
+        since_aweme_id: str | None = None,
+        known_aweme_ids: set[str] | None = None,
+        subscription_id: str | None = None,
+    ) -> IncrementalDownloadResult:
+        """Download only the posts newer than the caller's checkpoint.
+
+        Unlike :meth:`start_bulk_download` (fire-and-forget), this coroutine
+        runs the incremental pagination + download inline and returns once
+        finished, so a watch loop can persist an updated checkpoint from the
+        result. Pagination walks newest-first and stops at the first post
+        whose ``aweme_id`` is already known, so a steady-state run exits
+        after one or two pages.
+
+        An operation row of type ``user_posts_incremental_download`` is
+        created and advanced to a terminal state so the work is auditable
+        through the operation store. On failure the operation is marked
+        ``failed`` and the error is re-raised, so the caller does not
+        advance its checkpoint past posts that were never fetched.
+
+        Args:
+            sec_user_id: Unique identifier of the user.
+            since_aweme_id: Newest aweme_id downloaded on a previous run;
+                pagination stops when it reappears upstream.
+            known_aweme_ids: Recently-downloaded aweme_ids used as the
+                authoritative dedupe set (membership, not ordering).
+            subscription_id: Optional watch subscription id stamped into the
+                operation metadata for correlation.
+
+        Returns:
+            IncrementalDownloadResult: counts plus the newly downloaded
+                aweme_ids (newest first) for checkpoint maintenance.
+
+        Raises:
+            UserNotFoundError: If the user cannot be found.
+            PostServiceError: If the profile lookup or download loop fails.
+        """
+        known = set(known_aweme_ids or set())
+
+        try:
+            profile = await self.handler.fetch_user_profile(sec_user_id)
+        except UserNotFoundError:
+            raise
+        except Exception as e:
+            raise PostServiceError(f"Failed to validate user profile: {str(e)}") from e
+        if not profile or not getattr(profile, "nickname", None):
+            raise UserNotFoundError(f"User not found: {sec_user_id}")
+
+        operation = await self.operation_store.create_operation(
+            operation_type="user_posts_incremental_download",
+            subject_id=sec_user_id,
+            status="running",
+            message="Incremental download in progress",
+            progress=0.0,
+            metadata={"subscription_id": subscription_id} if subscription_id else {},
+        )
+        operation_id = operation.operation_id
+
+        try:
+            # Resolve (and create) the per-user download directory the same
+            # way the bulk loop does so incremental files land alongside any
+            # prior backfill instead of in a second location.
+            async with AsyncUserDB("douyin_users.db") as db:
+                user_path = await self.handler.get_or_add_user_data(
+                    self.handler.kwargs, sec_user_id, db
+                )
+            download_path = relative_to_download_root(user_path)
+
+            new_aweme_ids, failed_count = await self._collect_new_posts(
+                sec_user_id,
+                user_path,
+                known=known,
+                since_aweme_id=since_aweme_id,
+            )
+        except UserNotFoundError as e:
+            await self.operation_store.update_operation(
+                operation_id,
+                status="failed",
+                message="Incremental download failed",
+                error=str(e),
+            )
+            raise
+        except Exception as e:
+            logger.exception(
+                "Incremental download failed",
+                extra={"sec_user_id": sec_user_id, "operation_id": operation_id},
+            )
+            await self.operation_store.update_operation(
+                operation_id,
+                status="failed",
+                message="Incremental download failed",
+                error=str(e),
+            )
+            raise PostServiceError(f"Incremental download failed: {str(e)}") from e
+
+        new_count = len(new_aweme_ids)
+        newest_aweme_id = new_aweme_ids[0] if new_aweme_ids else None
+        final_status = "partial" if failed_count else "completed"
+        message = (
+            f"Downloaded {new_count} new post(s)" if new_count else "No new posts found"
+        )
+        await self.operation_store.update_operation(
+            operation_id,
+            status=final_status,
+            message=message,
+            progress=100.0,
+            total_items=new_count,
+            completed_items=new_count,
+            download_path=download_path,
+            metadata={
+                "subscription_id": subscription_id,
+                "new_count": new_count,
+                "failed_count": failed_count,
+                "newest_aweme_id": newest_aweme_id,
+                "download_path": download_path,
+            },
+        )
+
+        return IncrementalDownloadResult(
+            operation_id=operation_id,
+            new_count=new_count,
+            newest_aweme_id=newest_aweme_id,
+            seen_aweme_ids=new_aweme_ids,
+            failed_count=failed_count,
+        )
+
+    async def _collect_new_posts(
+        self,
+        sec_user_id: str,
+        user_path: Path,
+        *,
+        known: set[str],
+        since_aweme_id: str | None,
+    ) -> tuple[list[str], int]:
+        """Paginate newest-first and download posts until a known id appears.
+
+        Returns the newly downloaded aweme_ids (newest first) and the count
+        of posts that failed to download. Stops at the first post whose
+        ``aweme_id`` is in ``known`` or equals ``since_aweme_id``; the
+        upstream feed is newest-first, so that boundary marks
+        previously-seen territory. ``MAX_PAGES_FALLBACK`` bounds a first run
+        with an empty checkpoint so a misbehaving cursor cannot pin the loop.
+        """
+        new_aweme_ids: list[str] = []
+        failed_count = 0
+        current_cursor = 0
+        page_count = 0
+
+        while page_count < MAX_PAGES_FALLBACK:
+            page_count += 1
+            batch = await self._fetch_posts_batch(sec_user_id, current_cursor)
+            if not batch:
+                break
+            aweme_list = batch.get("aweme_list") or []
+            if not aweme_list:
+                break
+
+            reached_known = False
+            for post in aweme_list:
+                aweme_id = str(post.get("aweme_id") or "")
+                if aweme_id and (aweme_id in known or aweme_id == since_aweme_id):
+                    # Newest-first feed: the first already-known post marks
+                    # the start of previously-downloaded territory.
+                    reached_known = True
+                    break
+                try:
+                    post_type = self._determine_post_type(post)
+                    await self._download_post_content(post, post_type, user_path)
+                    if aweme_id:
+                        new_aweme_ids.append(aweme_id)
+                except Exception as e:
+                    failed_count += 1
+                    logger.error(
+                        "Error downloading incremental post",
+                        extra={"aweme_id": post.get("aweme_id"), "error": str(e)},
+                    )
+
+            if reached_known:
+                break
+
+            has_more = batch.get("has_more", False)
+            next_cursor = batch.get("max_cursor", 0)
+            if not has_more or not next_cursor or next_cursor == current_cursor:
+                break
+            current_cursor = next_cursor
+
+        return new_aweme_ids, failed_count
 
     async def _fetch_posts_batch(
         self,

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -102,6 +102,10 @@ class IncrementalDownloadResult:
     newest_aweme_id: str | None
     seen_aweme_ids: list[str]
     failed_count: int
+    # True when pagination stopped at the MAX_PAGES_FALLBACK cap with more
+    # pages still available. The caller must NOT advance its checkpoint on a
+    # truncated run or it would skip every post past the cap permanently.
+    truncated: bool = False
 
 
 class PostService:
@@ -717,18 +721,23 @@ class PostService:
         )
 
     async def get_bulk_download_status(self, operation_id: str) -> BulkDownloadResponse:
-        """Get the current status of a bulk download operation.
+        """Get the current status of a bulk or incremental download operation.
+
+        Both the user-triggered bulk loop and the watch-mode incremental loop
+        persist their progress as operation rows, so this endpoint serves
+        either type and watch-created downloads remain observable through the
+        existing polling route.
 
         Args:
-            operation_id: The unique identifier of the bulk download operation.
+            operation_id: The unique identifier of the download operation.
 
         Returns:
             BulkDownloadResponse: Snapshot of the operation including the
                 per-PostType counts persisted in the operation metadata.
 
         Raises:
-            OperationNotFoundError: If no bulk download operation matches the
-                provided identifier.
+            OperationNotFoundError: If no bulk or incremental download
+                operation matches the provided identifier.
         """
         # ``OperationStore.get_operation`` already raises
         # ``OperationNotFoundError`` with a descriptive message when the
@@ -736,8 +745,11 @@ class PostService:
         # original ``error_code`` and ``details``.
         op = await self.operation_store.get_operation(operation_id)
 
-        if op.operation_type != "user_posts_bulk_download":
-            raise OperationNotFoundError(f"Bulk download task {operation_id} not found")
+        if op.operation_type not in (
+            "user_posts_bulk_download",
+            "user_posts_incremental_download",
+        ):
+            raise OperationNotFoundError(f"Download task {operation_id} not found")
 
         download_stats = _deserialize_download_stats(op.metadata)
         total_posts = int(op.total_items or op.metadata.get("total_posts") or 0)
@@ -837,7 +849,7 @@ class PostService:
                 )
             download_path = relative_to_download_root(user_path)
 
-            new_aweme_ids, failed_count = await self._collect_new_posts(
+            new_aweme_ids, failed_count, truncated = await self._collect_new_posts(
                 sec_user_id,
                 user_path,
                 known=known,
@@ -879,10 +891,14 @@ class PostService:
 
         new_count = len(new_aweme_ids)
         newest_aweme_id = new_aweme_ids[0] if new_aweme_ids else None
-        final_status = "partial" if failed_count else "completed"
+        # A truncated run is incomplete, so report it as "partial" rather than a
+        # clean, exhaustive pass.
+        final_status = "partial" if (failed_count or truncated) else "completed"
         message = (
             f"Downloaded {new_count} new post(s)" if new_count else "No new posts found"
         )
+        if truncated:
+            message += " (page cap reached; older posts not fetched this run)"
         await self.operation_store.update_operation(
             operation_id,
             status=final_status,
@@ -895,6 +911,7 @@ class PostService:
                 "subscription_id": subscription_id,
                 "new_count": new_count,
                 "failed_count": failed_count,
+                "truncated": truncated,
                 "newest_aweme_id": newest_aweme_id,
                 "download_path": download_path,
             },
@@ -906,6 +923,7 @@ class PostService:
             newest_aweme_id=newest_aweme_id,
             seen_aweme_ids=new_aweme_ids,
             failed_count=failed_count,
+            truncated=truncated,
         )
 
     async def _collect_new_posts(
@@ -915,11 +933,13 @@ class PostService:
         *,
         known: set[str],
         since_aweme_id: str | None,
-    ) -> tuple[list[str], int]:
+    ) -> tuple[list[str], int, bool]:
         """Paginate newest-first and download posts until a known id appears.
 
-        Returns the newly downloaded aweme_ids (newest first) and the count
-        of posts that failed to download. Stops at the first post whose
+        Returns the newly downloaded aweme_ids (newest first), the count of
+        posts that failed to download, and a truncation flag that is True when
+        pagination hit ``MAX_PAGES_FALLBACK`` with more pages still available.
+        Stops at the first post whose
         ``aweme_id`` is in ``known`` or equals ``since_aweme_id``; the
         upstream feed is newest-first, so that boundary marks
         previously-seen territory. ``MAX_PAGES_FALLBACK`` bounds a first run
@@ -929,6 +949,7 @@ class PostService:
         failed_count = 0
         current_cursor = 0
         page_count = 0
+        truncated = False
 
         while page_count < MAX_PAGES_FALLBACK:
             page_count += 1
@@ -970,8 +991,10 @@ class PostService:
         else:
             # Loop exhausted MAX_PAGES_FALLBACK without breaking, so the feed
             # still advertised more pages: posts beyond the cap were not
-            # fetched this run. Surface it like the bulk loop instead of
-            # truncating silently (the checkpoint will only cover what we saw).
+            # fetched this run. Signal truncation so the caller holds its
+            # checkpoint -- advancing it would stop the next newest-first scan
+            # at this run's newest post and skip every post past the cap.
+            truncated = True
             logger.warning(
                 "Incremental download hit max page fallback; posts beyond the "
                 "cap were not fetched this run",
@@ -982,7 +1005,7 @@ class PostService:
                 },
             )
 
-        return new_aweme_ids, failed_count
+        return new_aweme_ids, failed_count, truncated
 
     async def _fetch_posts_batch(
         self,

--- a/src/dyvine/services/posts.py
+++ b/src/dyvine/services/posts.py
@@ -28,6 +28,8 @@ when downloads already succeeded) rather than silently passing as
 ``completed``.
 """
 
+import asyncio
+import contextlib
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -841,6 +843,19 @@ class PostService:
                 known=known,
                 since_aweme_id=since_aweme_id,
             )
+        except asyncio.CancelledError:
+            # The watch loop was cancelled (DELETE or shutdown) mid-download.
+            # Mark the row terminal so it does not linger as "running" until
+            # the next boot sweep, then propagate the cancellation. The write
+            # is best-effort: a second cancellation must not mask the re-raise.
+            with contextlib.suppress(Exception):
+                await self.operation_store.update_operation(
+                    operation_id,
+                    status="failed",
+                    message="Incremental download cancelled",
+                    error="cancelled",
+                )
+            raise
         except UserNotFoundError as e:
             await self.operation_store.update_operation(
                 operation_id,
@@ -952,6 +967,20 @@ class PostService:
             if not has_more or not next_cursor or next_cursor == current_cursor:
                 break
             current_cursor = next_cursor
+        else:
+            # Loop exhausted MAX_PAGES_FALLBACK without breaking, so the feed
+            # still advertised more pages: posts beyond the cap were not
+            # fetched this run. Surface it like the bulk loop instead of
+            # truncating silently (the checkpoint will only cover what we saw).
+            logger.warning(
+                "Incremental download hit max page fallback; posts beyond the "
+                "cap were not fetched this run",
+                extra={
+                    "sec_user_id": sec_user_id,
+                    "max_pages": MAX_PAGES_FALLBACK,
+                    "downloaded": len(new_aweme_ids),
+                },
+            )
 
         return new_aweme_ids, failed_count
 

--- a/src/dyvine/services/watch.py
+++ b/src/dyvine/services/watch.py
@@ -191,11 +191,14 @@ class WatchService:
         Raises:
             WatchSubscriptionNotFoundError: If no subscription matches.
         """
-        # Validate existence first so an unknown id surfaces as 404 before we
-        # touch the loop registry.
-        await self.watch_store.get_subscription(subscription_id)
-        await self._cancel_loop(subscription_id)
-        await self.watch_store.delete_subscription(subscription_id)
+        # Serialise with create_subscription under the same lock so a
+        # concurrent POST for this user cannot observe (and re-arm) a row that
+        # this delete is removing. Validate existence first so an unknown id
+        # surfaces as 404 before we touch the loop registry.
+        async with self._get_lock():
+            await self.watch_store.get_subscription(subscription_id)
+            await self._cancel_loop(subscription_id)
+            await self.watch_store.delete_subscription(subscription_id)
         logger.info(
             "watch subscription deleted", extra={"subscription_id": subscription_id}
         )
@@ -402,6 +405,24 @@ class WatchService:
                 "watch post check failed",
                 extra={"subscription_id": record.subscription_id},
                 exc_info=True,
+            )
+            return
+
+        if result.failed_count:
+            # Hold the checkpoint whenever any post in the freshly-fetched
+            # window failed to download. The newest-first early-stop would
+            # otherwise advance the boundary past a never-stored post and skip
+            # it forever; instead the next cycle re-scans this window (f2
+            # overwrites already-fetched posts idempotently) and retries the
+            # failures. This is the "advanced only after a successful run"
+            # contract this method's docstring promises.
+            logger.warning(
+                "watch: holding checkpoint after partial post download",
+                extra={
+                    "subscription_id": record.subscription_id,
+                    "new_count": result.new_count,
+                    "failed_count": result.failed_count,
+                },
             )
             return
 

--- a/src/dyvine/services/watch.py
+++ b/src/dyvine/services/watch.py
@@ -1,0 +1,470 @@
+"""Watch-mode domain service.
+
+`WatchService` turns Dyvine from a request-driven downloader into a
+monitor: each subscription runs a long-lived ``asyncio`` loop that, on two
+independent cadences, checks whether a Douyin user is live (and records the
+stream) and fetches the user's new posts.
+
+Design:
+
+- **One loop task per subscription.** ``DELETE /watch/{id}`` cancels
+  exactly that task; an exception in one user's loop cannot stall another.
+  Tasks are scheduled through the shared ``BackgroundTaskRegistry`` so the
+  FastAPI lifespan drains them on shutdown.
+- **Persistence + resume.** Subscriptions live in ``WatchSubscriptionStore``
+  (a dedicated SQLite table), so ``resume_persisted`` can re-arm every
+  enabled subscription after a restart -- something the operation store
+  cannot do because it has no enumeration query and its boot sweep would
+  fail any long-lived row.
+- **Reuse, not reinvention.** Live recording delegates to
+  ``LivestreamService.download_stream`` (which dedupes by ``room_id`` and
+  rejects offline users), and incremental post fetching delegates to
+  ``PostService.download_new_posts``. Each triggered download therefore
+  creates its own regular operation row that existing polling endpoints can
+  observe.
+- **Monotonic scheduling.** Due-times use ``time.monotonic`` (consistent
+  with the app's uptime accounting) so NTP steps cannot cause negative
+  sleeps or catch-up storms. Each due-time carries +/-10% jitter so several
+  subscriptions never hammer upstream in lockstep.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import random
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+from ..core.background import BackgroundTaskRegistry, spawn_or_fallback
+from ..core.exceptions import (
+    LivestreamError,
+    RateLimitError,
+    ServiceError,
+    UserNotFoundError,
+    WatchSubscriptionNotFoundError,
+)
+from ..core.logging import ContextLogger
+from ..core.settings import settings
+from ..core.watch_store import WatchSubscriptionRecord, WatchSubscriptionStore
+from ..schemas.watch import WatchSubscriptionResponse
+from .livestreams import LivestreamService
+from .posts import PostService
+
+logger = ContextLogger(__name__)
+
+
+class WatchService:
+    """Schedule and persist per-user watch subscriptions.
+
+    The service owns a dict of ``subscription_id -> asyncio.Task`` watcher
+    loops plus an ``asyncio.Lock`` (created lazily, so the service stays
+    usable from ``object.__new__`` stubs in unit tests) that serialises the
+    check-and-create window for idempotent subscription creation.
+    """
+
+    # Class-level default so tests that build the service via
+    # ``object.__new__`` still see a ``None`` registry and fall through to
+    # the bare ``create_task`` branch in :func:`spawn_or_fallback`.
+    _task_registry: BackgroundTaskRegistry | None = None
+
+    def __init__(
+        self,
+        *,
+        watch_store: WatchSubscriptionStore,
+        livestream_service: LivestreamService,
+        post_service: PostService,
+        task_registry: BackgroundTaskRegistry | None = None,
+    ) -> None:
+        """Initialize the watch service from injected dependencies."""
+        self.settings = settings
+        self.watch_store = watch_store
+        self.livestream_service = livestream_service
+        self.post_service = post_service
+        self._task_registry = task_registry
+        self._loops: dict[str, asyncio.Task[Any]] = {}
+        self._lock: asyncio.Lock | None = None
+
+    # ------------------------------------------------------------------
+    # Public CRUD surface (called by the router)
+    # ------------------------------------------------------------------
+
+    async def create_subscription(
+        self,
+        *,
+        user_id: str,
+        live_poll_seconds: int | None = None,
+        post_poll_seconds: int | None = None,
+        backfill_on_create: bool | None = None,
+    ) -> tuple[WatchSubscriptionRecord, bool]:
+        """Create (or return the existing) watch subscription for a user.
+
+        Idempotent on ``user_id``: a second create for the same user returns
+        the existing subscription rather than erroring, backed by the
+        ``UNIQUE(user_id)`` index. When ``backfill_on_create`` is false the
+        current feed is snapshotted into the checkpoint up front so the
+        first post check skips the user's existing posts and downloads only
+        what is published afterwards.
+
+        Returns:
+            A ``(record, created)`` tuple; ``created`` is ``True`` for a new
+            subscription and ``False`` when an existing one was returned.
+
+        Raises:
+            RateLimitError: When the configured ``max_subscriptions`` cap is
+                reached (mapped to HTTP 429).
+            UserNotFoundError / PostServiceError: When a non-backfill
+                baseline snapshot cannot be taken (the user is unknown or
+                upstream failed), so a faulty subscription is never created.
+        """
+        watch_cfg = self.settings.watch
+        live = live_poll_seconds or watch_cfg.live_poll_seconds
+        post = post_poll_seconds or watch_cfg.post_poll_seconds
+        backfill = (
+            watch_cfg.backfill_on_create
+            if backfill_on_create is None
+            else backfill_on_create
+        )
+
+        # Snapshot the current feed BEFORE taking the lock so a non-backfill
+        # subscription records a baseline of existing aweme_ids without
+        # holding the lock across an upstream call. The newest-first feed
+        # means recording just the first page is enough: the first post
+        # check will early-exit at that boundary and download nothing older.
+        baseline: list[str] = []
+        if not backfill:
+            baseline = await self._snapshot_baseline(user_id)
+
+        async with self._get_lock():
+            existing = await self.watch_store.get_subscription_by_user(user_id)
+            if existing is not None:
+                # Self-heal: re-arm the loop if a prior one crashed/exited.
+                self._start_loop(existing)
+                return existing, False
+
+            count = await self.watch_store.count_subscriptions()
+            if count >= watch_cfg.max_subscriptions:
+                raise RateLimitError(
+                    "Watch subscription limit reached "
+                    f"({watch_cfg.max_subscriptions}); delete a subscription first"
+                )
+
+            checkpoint: dict[str, Any] = {
+                "newest_aweme_id": baseline[0] if baseline else None,
+                "recent_aweme_ids": baseline,
+                "first_run_complete": not backfill,
+            }
+            record = await self.watch_store.create_subscription(
+                user_id=user_id,
+                live_poll_seconds=live,
+                post_poll_seconds=post,
+                checkpoint=checkpoint,
+            )
+
+        self._start_loop(record)
+        logger.info(
+            "watch subscription created",
+            extra={
+                "subscription_id": record.subscription_id,
+                "user_id": user_id,
+                "backfill": backfill,
+            },
+        )
+        return record, True
+
+    async def get_subscription(self, subscription_id: str) -> WatchSubscriptionRecord:
+        """Return a subscription or raise ``WatchSubscriptionNotFoundError``."""
+        return await self.watch_store.get_subscription(subscription_id)
+
+    async def list_subscriptions(self) -> list[WatchSubscriptionRecord]:
+        """Return every persisted subscription."""
+        return await self.watch_store.list_subscriptions()
+
+    async def delete_subscription(self, subscription_id: str) -> None:
+        """Cancel a subscription's watcher loop and delete its record.
+
+        Note: a livestream recording already in progress runs in its own
+        background task and continues to completion; deleting the
+        subscription only stops *future* checks.
+
+        Raises:
+            WatchSubscriptionNotFoundError: If no subscription matches.
+        """
+        # Validate existence first so an unknown id surfaces as 404 before we
+        # touch the loop registry.
+        await self.watch_store.get_subscription(subscription_id)
+        await self._cancel_loop(subscription_id)
+        await self.watch_store.delete_subscription(subscription_id)
+        logger.info(
+            "watch subscription deleted", extra={"subscription_id": subscription_id}
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle (called by ServiceContainer)
+    # ------------------------------------------------------------------
+
+    async def resume_persisted(self) -> int:
+        """Re-arm a watcher loop for every enabled persisted subscription.
+
+        Returns the number of loops started. Called from
+        ``ServiceContainer.initialize`` after the container is marked ready.
+        """
+        records = await self.watch_store.list_subscriptions(enabled_only=True)
+        for record in records:
+            self._start_loop(record)
+        if records:
+            logger.info("resumed watch subscriptions", extra={"count": len(records)})
+        return len(records)
+
+    async def stop_all(self) -> None:
+        """Cancel every watcher loop.
+
+        Called at the very start of ``ServiceContainer.shutdown`` so the
+        loops stop scheduling new downloads before the background-task
+        registry is drained.
+        """
+        for subscription_id in list(self._loops):
+            await self._cancel_loop(subscription_id)
+
+    @property
+    def active_count(self) -> int:
+        """Number of watcher loops currently running."""
+        return sum(1 for task in self._loops.values() if not task.done())
+
+    def to_response(self, record: WatchSubscriptionRecord) -> WatchSubscriptionResponse:
+        """Render a subscription record as the public response model."""
+        checkpoint = record.checkpoint or {}
+        newest = checkpoint.get("newest_aweme_id")
+        return WatchSubscriptionResponse(
+            subscription_id=record.subscription_id,
+            user_id=record.user_id,
+            enabled=record.enabled,
+            live_poll_seconds=record.live_poll_seconds,
+            post_poll_seconds=record.post_poll_seconds,
+            last_live_check=record.last_live_check,
+            last_post_check=record.last_post_check,
+            newest_aweme_id=str(newest) if newest is not None else None,
+            created_at=record.created_at,
+            updated_at=record.updated_at,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _get_lock(self) -> asyncio.Lock:
+        """Return the create lock, creating it lazily on first use.
+
+        ``asyncio.Lock`` binds to the running event loop, so constructing it
+        on first access keeps the service usable from bare ``object.__new__``
+        stubs in unit tests and avoids tying it to a specific loop.
+        """
+        lock = self._lock
+        if lock is None:
+            lock = asyncio.Lock()
+            self._lock = lock
+        return lock
+
+    def _start_loop(self, record: WatchSubscriptionRecord) -> None:
+        """Spawn the watcher loop for a subscription if not already running."""
+        existing = self._loops.get(record.subscription_id)
+        if existing is not None and not existing.done():
+            return
+        task = spawn_or_fallback(
+            self._task_registry,
+            self._watch_loop(record.subscription_id),
+            name=f"watch-{record.subscription_id}",
+        )
+        self._loops[record.subscription_id] = task
+
+    async def _cancel_loop(self, subscription_id: str) -> None:
+        """Cancel and await a subscription's watcher loop if present."""
+        task = self._loops.pop(subscription_id, None)
+        if task is None or task.done():
+            return
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    async def _watch_loop(self, subscription_id: str) -> None:
+        """Drive one subscription's live + post cadences until cancelled.
+
+        Each cadence has its own monotonic due-time recomputed from the
+        moment work *starts*, so a slow check pushes the next tick later
+        rather than letting ticks pile up. Both due-times start "now" so a
+        freshly created or resumed subscription is checked immediately.
+        """
+        next_live = time.monotonic()
+        next_post = time.monotonic()
+        try:
+            while True:
+                try:
+                    record = await self.watch_store.get_subscription(subscription_id)
+                except WatchSubscriptionNotFoundError:
+                    return  # deleted out from under us
+                if not record.enabled:
+                    return
+
+                now = time.monotonic()
+                sleep_for = min(next_live - now, next_post - now)
+                if sleep_for > 0:
+                    await asyncio.sleep(sleep_for)
+
+                now = time.monotonic()
+                if now >= next_live:
+                    next_live = now + self._jittered_interval(record.live_poll_seconds)
+                    await self._do_live_check(record)
+                if now >= next_post:
+                    next_post = now + self._jittered_interval(record.post_poll_seconds)
+                    await self._do_post_check(record)
+        except asyncio.CancelledError:
+            # Graceful stop: do not persist a partial checkpoint here. Any
+            # download triggered this cycle is its own registry-tracked task
+            # and drains independently.
+            raise
+        except Exception:
+            logger.exception(
+                "watch loop crashed; it will be resumed on next restart",
+                extra={"subscription_id": subscription_id},
+            )
+        finally:
+            # Self-evict only if the registry slot is still us, mirroring the
+            # livestream downloader's successor-safe cleanup.
+            if self._loops.get(subscription_id) is asyncio.current_task():
+                self._loops.pop(subscription_id, None)
+
+    async def _do_live_check(self, record: WatchSubscriptionRecord) -> None:
+        """Check whether the user is live and, if so, start a recording.
+
+        Reuses ``LivestreamService.download_stream`` which raises
+        ``LivestreamError`` when the user is offline or already being
+        recorded (deduped by ``room_id``); both are normal and swallowed.
+        """
+        try:
+            await self.watch_store.update_subscription(
+                record.subscription_id, last_live_check=self._now_iso()
+            )
+            await self.livestream_service.download_stream(
+                url=f"https://www.douyin.com/user/{record.user_id}"
+            )
+            logger.info(
+                "watch: livestream recording started",
+                extra={
+                    "subscription_id": record.subscription_id,
+                    "user_id": record.user_id,
+                },
+            )
+        except asyncio.CancelledError:
+            raise
+        except WatchSubscriptionNotFoundError:
+            return
+        except LivestreamError:
+            return  # offline, no stream, or already recording -> skip
+        except RuntimeError:
+            return  # background registry closed during shutdown
+        except Exception:
+            logger.warning(
+                "watch live check failed",
+                extra={"subscription_id": record.subscription_id},
+                exc_info=True,
+            )
+
+    async def _do_post_check(self, record: WatchSubscriptionRecord) -> None:
+        """Download the user's new posts and advance the checkpoint.
+
+        The checkpoint is only advanced after a successful run, so an
+        interrupted cycle re-downloads at most the most-recent window (which
+        the f2 downloader overwrites idempotently) rather than skipping
+        posts that were never fetched.
+        """
+        checkpoint = record.checkpoint or {}
+        try:
+            await self.watch_store.update_subscription(
+                record.subscription_id, last_post_check=self._now_iso()
+            )
+            result = await self.post_service.download_new_posts(
+                record.user_id,
+                since_aweme_id=checkpoint.get("newest_aweme_id"),
+                known_aweme_ids=set(checkpoint.get("recent_aweme_ids") or []),
+                subscription_id=record.subscription_id,
+            )
+        except asyncio.CancelledError:
+            raise
+        except WatchSubscriptionNotFoundError:
+            return
+        except (UserNotFoundError, ServiceError):
+            return  # upstream/profile failure -> keep checkpoint, retry later
+        except RuntimeError:
+            return
+        except Exception:
+            logger.warning(
+                "watch post check failed",
+                extra={"subscription_id": record.subscription_id},
+                exc_info=True,
+            )
+            return
+
+        if result.new_count <= 0:
+            return
+
+        merged = self._merge_recent(
+            result.seen_aweme_ids, checkpoint.get("recent_aweme_ids") or []
+        )
+        with contextlib.suppress(WatchSubscriptionNotFoundError):
+            await self.watch_store.update_subscription(
+                record.subscription_id,
+                checkpoint={
+                    "newest_aweme_id": result.newest_aweme_id,
+                    "recent_aweme_ids": merged,
+                    "first_run_complete": True,
+                },
+            )
+        logger.info(
+            "watch: downloaded new posts",
+            extra={
+                "subscription_id": record.subscription_id,
+                "new_count": result.new_count,
+            },
+        )
+
+    async def _snapshot_baseline(self, user_id: str) -> list[str]:
+        """Return the current first page of aweme_ids (newest first).
+
+        Used to seed a non-backfill subscription's dedupe set so its first
+        post check skips existing posts. Upstream failures propagate so a
+        subscription that promises "new posts only" is not created on a
+        broken baseline.
+        """
+        page = await self.post_service.get_user_posts(
+            user_id, max_cursor=0, count=self.settings.watch.recent_id_cap
+        )
+        ids = [str(post.aweme_id) for post in page.posts if post.aweme_id]
+        return ids[: self.settings.watch.recent_id_cap]
+
+    def _merge_recent(self, new_ids: list[str], existing: list[str]) -> list[str]:
+        """Merge newly downloaded ids ahead of existing ones, bounded by cap.
+
+        Membership (not numeric ordering) is the dedupe oracle because
+        Douyin aweme_ids are only roughly time-ordered; pinned or
+        re-published posts can break a strict ``>`` comparison.
+        """
+        cap = self.settings.watch.recent_id_cap
+        merged: list[str] = []
+        seen: set[str] = set()
+        for aweme_id in (*new_ids, *existing):
+            if aweme_id and aweme_id not in seen:
+                seen.add(aweme_id)
+                merged.append(aweme_id)
+            if len(merged) >= cap:
+                break
+        return merged
+
+    def _jittered_interval(self, seconds: int) -> float:
+        """Return the interval with +/-10% jitter to avoid lockstep polling."""
+        return seconds * random.uniform(0.9, 1.1)
+
+    @staticmethod
+    def _now_iso() -> str:
+        """Return the current UTC timestamp in ISO 8601 format."""
+        return datetime.now(UTC).isoformat()

--- a/src/dyvine/services/watch.py
+++ b/src/dyvine/services/watch.py
@@ -127,6 +127,17 @@ class WatchService:
             else backfill_on_create
         )
 
+        # Fast path: if a subscription already exists for this user, return it
+        # idempotently WITHOUT paying for -- or failing on -- a baseline
+        # snapshot. Without this, a transient profile/upstream error during the
+        # snapshot would turn an idempotent retry into an error instead of the
+        # documented 200-with-existing-row. The locked re-check below remains
+        # the authority against a concurrent create.
+        existing = await self.watch_store.get_subscription_by_user(user_id)
+        if existing is not None:
+            self._start_loop(existing)
+            return existing, False
+
         # Snapshot the current feed BEFORE taking the lock so a non-backfill
         # subscription records a baseline of existing aweme_ids without
         # holding the lock across an upstream call. The newest-first feed
@@ -297,6 +308,14 @@ class WatchService:
         moment work *starts*, so a slow check pushes the next tick later
         rather than letting ticks pile up. Both due-times start "now" so a
         freshly created or resumed subscription is checked immediately.
+
+        Live and post checks run serially in this single loop and the post
+        check awaits its download inline, so a long post run (a fresh backfill
+        or catch-up after downtime) delays *this* subscription's next live
+        check until it finishes. That is an accepted trade-off of the
+        single-loop design: livestreams are long enough that a few minutes'
+        detection delay is tolerable, and every subscription has its own loop,
+        so one user's backfill never stalls another user's live detection.
         """
         next_live = time.monotonic()
         next_post = time.monotonic()
@@ -408,20 +427,22 @@ class WatchService:
             )
             return
 
-        if result.failed_count:
-            # Hold the checkpoint whenever any post in the freshly-fetched
-            # window failed to download. The newest-first early-stop would
-            # otherwise advance the boundary past a never-stored post and skip
-            # it forever; instead the next cycle re-scans this window (f2
-            # overwrites already-fetched posts idempotently) and retries the
-            # failures. This is the "advanced only after a successful run"
-            # contract this method's docstring promises.
+        if result.failed_count or result.truncated:
+            # Hold the checkpoint whenever the fetched window was incomplete:
+            # either a post failed to download, or pagination hit the page cap
+            # with more pages still available. The newest-first early-stop
+            # would otherwise advance the boundary past a never-stored post and
+            # skip it forever; instead the next cycle re-scans this window (f2
+            # overwrites already-fetched posts idempotently) and retries. This
+            # is the "advance only after a successful run" contract this
+            # method's docstring promises.
             logger.warning(
-                "watch: holding checkpoint after partial post download",
+                "watch: holding checkpoint after incomplete post run",
                 extra={
                     "subscription_id": record.subscription_id,
                     "new_count": result.new_count,
                     "failed_count": result.failed_count,
+                    "truncated": result.truncated,
                 },
             )
             return

--- a/tests/core/test_watch_store.py
+++ b/tests/core/test_watch_store.py
@@ -1,0 +1,169 @@
+"""Tests for the SQLite-backed watch subscription store."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from dyvine.core.exceptions import WatchSubscriptionNotFoundError
+from dyvine.core.operations import OperationStore
+from dyvine.core.watch_store import WatchSubscriptionStore
+
+
+def _make_store(tmp_path: Path) -> WatchSubscriptionStore:
+    """Build a store backed by an isolated SQLite file."""
+    return WatchSubscriptionStore(db_path=str(tmp_path / "watch.db"))
+
+
+async def test_create_and_get_round_trip(tmp_path: Path) -> None:
+    """A created subscription reads back with every field intact."""
+    store = _make_store(tmp_path)
+    record = await store.create_subscription(
+        user_id="user01",
+        live_poll_seconds=120,
+        post_poll_seconds=600,
+        checkpoint={
+            "newest_aweme_id": "7",
+            "recent_aweme_ids": ["7"],
+            "first_run_complete": True,
+        },
+    )
+    fetched = await store.get_subscription(record.subscription_id)
+    assert fetched.user_id == "user01"
+    assert fetched.enabled is True
+    assert fetched.live_poll_seconds == 120
+    assert fetched.post_poll_seconds == 600
+    assert fetched.checkpoint["newest_aweme_id"] == "7"
+
+
+async def test_get_by_user_returns_none_when_absent(tmp_path: Path) -> None:
+    """Looking up an unknown user returns None rather than raising."""
+    store = _make_store(tmp_path)
+    assert await store.get_subscription_by_user("nobody01") is None
+
+
+async def test_unique_user_constraint_rejects_duplicate(tmp_path: Path) -> None:
+    """A second subscription for the same user violates the UNIQUE index."""
+    store = _make_store(tmp_path)
+    await store.create_subscription(
+        user_id="user01", live_poll_seconds=120, post_poll_seconds=600
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        await store.create_subscription(
+            user_id="user01", live_poll_seconds=120, post_poll_seconds=600
+        )
+
+
+async def test_list_filters_disabled(tmp_path: Path) -> None:
+    """enabled_only excludes disabled subscriptions."""
+    store = _make_store(tmp_path)
+    enabled = await store.create_subscription(
+        user_id="user01", live_poll_seconds=120, post_poll_seconds=600
+    )
+    disabled = await store.create_subscription(
+        user_id="user02", live_poll_seconds=120, post_poll_seconds=600
+    )
+    await store.update_subscription(disabled.subscription_id, enabled=False)
+
+    all_subs = await store.list_subscriptions()
+    enabled_subs = await store.list_subscriptions(enabled_only=True)
+    assert {s.subscription_id for s in all_subs} == {
+        enabled.subscription_id,
+        disabled.subscription_id,
+    }
+    assert [s.subscription_id for s in enabled_subs] == [enabled.subscription_id]
+
+
+async def test_update_persists_checkpoint_and_advances_timestamp(
+    tmp_path: Path,
+) -> None:
+    """Updating the checkpoint persists JSON and bumps updated_at."""
+    store = _make_store(tmp_path)
+    record = await store.create_subscription(
+        user_id="user01", live_poll_seconds=120, post_poll_seconds=600
+    )
+    updated = await store.update_subscription(
+        record.subscription_id,
+        checkpoint={"newest_aweme_id": "42", "recent_aweme_ids": ["42"]},
+        last_post_check="2026-06-22T01:00:00+00:00",
+    )
+    assert updated.checkpoint["newest_aweme_id"] == "42"
+    assert updated.last_post_check == "2026-06-22T01:00:00+00:00"
+    assert updated.updated_at >= record.updated_at
+
+
+async def test_delete_reports_existence(tmp_path: Path) -> None:
+    """Deleting returns True the first time and False afterwards."""
+    store = _make_store(tmp_path)
+    record = await store.create_subscription(
+        user_id="user01", live_poll_seconds=120, post_poll_seconds=600
+    )
+    assert await store.delete_subscription(record.subscription_id) is True
+    assert await store.delete_subscription(record.subscription_id) is False
+
+
+async def test_count_subscriptions(tmp_path: Path) -> None:
+    """count_subscriptions reflects the number of rows."""
+    store = _make_store(tmp_path)
+    assert await store.count_subscriptions() == 0
+    await store.create_subscription(
+        user_id="user01", live_poll_seconds=120, post_poll_seconds=600
+    )
+    assert await store.count_subscriptions() == 1
+
+
+async def test_get_missing_raises(tmp_path: Path) -> None:
+    """A missing subscription raises the typed not-found error."""
+    store = _make_store(tmp_path)
+    with pytest.raises(WatchSubscriptionNotFoundError):
+        await store.get_subscription("does-not-exist")
+
+
+async def test_mark_incomplete_does_not_touch_subscriptions(tmp_path: Path) -> None:
+    """The operation store's restart sweep leaves subscriptions untouched.
+
+    This is the core safety property behind keeping subscriptions in their
+    own table: ``mark_incomplete_operations_failed`` flips running operations
+    to ``failed`` on boot, and a long-lived subscription must survive it.
+    """
+    db_path = str(tmp_path / "shared.db")
+    op_store = OperationStore(db_path=db_path)
+    watch_store = WatchSubscriptionStore(db_path=db_path)
+
+    op = await op_store.create_operation(
+        operation_type="user_posts_bulk_download",
+        subject_id="user01",
+        status="running",
+        message="in progress",
+    )
+    sub = await watch_store.create_subscription(
+        user_id="user01",
+        live_poll_seconds=120,
+        post_poll_seconds=600,
+        checkpoint={"newest_aweme_id": "1"},
+    )
+
+    swept = await op_store.mark_incomplete_operations_failed()
+    assert swept == 1
+
+    op_after = await op_store.get_operation(op.operation_id)
+    sub_after = await watch_store.get_subscription(sub.subscription_id)
+    assert op_after.status == "failed"
+    assert sub_after.enabled is True
+    assert sub_after.checkpoint == {"newest_aweme_id": "1"}
+
+    op_store.shutdown()
+    watch_store.shutdown()
+
+
+async def test_shutdown_is_idempotent(tmp_path: Path) -> None:
+    """shutdown can be called repeatedly without raising."""
+    store = _make_store(tmp_path)
+    await store.create_subscription(
+        user_id="user01", live_poll_seconds=120, post_poll_seconds=600
+    )
+    store.shutdown()
+    store.shutdown()
+    assert store.is_closed is True

--- a/tests/routers/test_watch_router.py
+++ b/tests/routers/test_watch_router.py
@@ -1,0 +1,137 @@
+"""Tests for watch-mode router endpoints.
+
+Handlers are invoked directly (as in the livestream router tests) so the
+``@handle_errors`` decorator's exception-to-HTTP mapping is exercised
+without standing up a full TestClient.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException, Response
+
+from dyvine.core.exceptions import RateLimitError, WatchSubscriptionNotFoundError
+from dyvine.schemas.watch import WatchSubscriptionCreate, WatchSubscriptionResponse
+
+
+def _response(subscription_id: str = "sub-12345") -> WatchSubscriptionResponse:
+    """Build a representative response model."""
+    return WatchSubscriptionResponse(
+        subscription_id=subscription_id,
+        user_id="user01",
+        enabled=True,
+        live_poll_seconds=300,
+        post_poll_seconds=2700,
+        last_live_check=None,
+        last_post_check=None,
+        newest_aweme_id=None,
+        created_at="2026-06-22T00:00:00+00:00",
+        updated_at="2026-06-22T00:00:00+00:00",
+    )
+
+
+@pytest.fixture
+def mock_watch_service() -> MagicMock:
+    """A WatchService double with async CRUD methods."""
+    svc = MagicMock()
+    svc.create_subscription = AsyncMock()
+    svc.get_subscription = AsyncMock()
+    svc.list_subscriptions = AsyncMock()
+    svc.delete_subscription = AsyncMock()
+    svc.to_response = MagicMock(return_value=_response())
+    return svc
+
+
+async def test_create_returns_201_for_new(mock_watch_service: MagicMock) -> None:
+    """Creating a new subscription sets HTTP 201."""
+    from dyvine.routers.watch import create_watch_subscription
+
+    mock_watch_service.create_subscription.return_value = (MagicMock(), True)
+    response = Response()
+    result = await create_watch_subscription(
+        request=WatchSubscriptionCreate(user_id="user01"),
+        service=mock_watch_service,
+        response=response,
+    )
+    assert response.status_code == 201
+    assert result.subscription_id == "sub-12345"
+
+
+async def test_create_returns_200_for_existing(mock_watch_service: MagicMock) -> None:
+    """Re-creating an existing subscription sets HTTP 200 (idempotent)."""
+    from dyvine.routers.watch import create_watch_subscription
+
+    mock_watch_service.create_subscription.return_value = (MagicMock(), False)
+    response = Response()
+    await create_watch_subscription(
+        request=WatchSubscriptionCreate(user_id="user01"),
+        service=mock_watch_service,
+        response=response,
+    )
+    assert response.status_code == 200
+
+
+async def test_create_over_limit_returns_429(mock_watch_service: MagicMock) -> None:
+    """The subscription cap surfaces as HTTP 429."""
+    from dyvine.routers.watch import create_watch_subscription
+
+    mock_watch_service.create_subscription.side_effect = RateLimitError("limit")
+    with pytest.raises(HTTPException) as exc_info:
+        await create_watch_subscription(
+            request=WatchSubscriptionCreate(user_id="user01"),
+            service=mock_watch_service,
+            response=Response(),
+        )
+    assert exc_info.value.status_code == 429
+
+
+async def test_list_returns_total(mock_watch_service: MagicMock) -> None:
+    """Listing reports the number of subscriptions."""
+    from dyvine.routers.watch import list_watch_subscriptions
+
+    mock_watch_service.list_subscriptions.return_value = [MagicMock(), MagicMock()]
+    mock_watch_service.to_response.side_effect = [_response("a"), _response("b")]
+    result = await list_watch_subscriptions(service=mock_watch_service)
+    assert result.total == 2
+    assert len(result.subscriptions) == 2
+
+
+async def test_get_unknown_returns_404(mock_watch_service: MagicMock) -> None:
+    """Fetching an unknown subscription returns HTTP 404."""
+    from dyvine.routers.watch import get_watch_subscription
+
+    mock_watch_service.get_subscription.side_effect = WatchSubscriptionNotFoundError(
+        "nf"
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await get_watch_subscription(
+            service=mock_watch_service, subscription_id="sub-99999"
+        )
+    assert exc_info.value.status_code == 404
+
+
+async def test_delete_success_returns_none(mock_watch_service: MagicMock) -> None:
+    """A successful delete returns None (HTTP 204 at the framework layer)."""
+    from dyvine.routers.watch import delete_watch_subscription
+
+    mock_watch_service.delete_subscription.return_value = None
+    result = await delete_watch_subscription(
+        service=mock_watch_service, subscription_id="sub-12345"
+    )
+    assert result is None
+
+
+async def test_delete_unknown_returns_404(mock_watch_service: MagicMock) -> None:
+    """Deleting an unknown subscription returns HTTP 404."""
+    from dyvine.routers.watch import delete_watch_subscription
+
+    mock_watch_service.delete_subscription.side_effect = WatchSubscriptionNotFoundError(
+        "nf"
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await delete_watch_subscription(
+            service=mock_watch_service, subscription_id="sub-99999"
+        )
+    assert exc_info.value.status_code == 404

--- a/tests/schemas/test_schemas_watch.py
+++ b/tests/schemas/test_schemas_watch.py
@@ -1,0 +1,80 @@
+"""Tests for watch-mode request/response schema validation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from dyvine.schemas.watch import (
+    WatchSubscriptionCreate,
+    WatchSubscriptionList,
+    WatchSubscriptionResponse,
+)
+
+
+def test_create_accepts_minimal_payload() -> None:
+    """A bare user_id is valid; interval overrides default to None."""
+    model = WatchSubscriptionCreate(user_id="user01")
+    assert model.user_id == "user01"
+    assert model.live_poll_seconds is None
+    assert model.post_poll_seconds is None
+    assert model.backfill_on_create is None
+
+
+def test_create_accepts_in_range_intervals() -> None:
+    """Interval overrides within bounds are accepted."""
+    model = WatchSubscriptionCreate(
+        user_id="user01",
+        live_poll_seconds=60,
+        post_poll_seconds=86400,
+        backfill_on_create=True,
+    )
+    assert model.live_poll_seconds == 60
+    assert model.post_poll_seconds == 86400
+    assert model.backfill_on_create is True
+
+
+@pytest.mark.parametrize("bad_user_id", ["u1", "", "has spaces", "bad/slash"])
+def test_create_rejects_invalid_user_id(bad_user_id: str) -> None:
+    """user_id must match the Douyin identifier pattern."""
+    with pytest.raises(ValidationError):
+        WatchSubscriptionCreate(user_id=bad_user_id)
+
+
+@pytest.mark.parametrize("seconds", [59, 3601])
+def test_create_rejects_out_of_range_live_interval(seconds: int) -> None:
+    """live_poll_seconds outside 60..3600 is rejected."""
+    with pytest.raises(ValidationError):
+        WatchSubscriptionCreate(user_id="user01", live_poll_seconds=seconds)
+
+
+@pytest.mark.parametrize("seconds", [299, 86401])
+def test_create_rejects_out_of_range_post_interval(seconds: int) -> None:
+    """post_poll_seconds outside 300..86400 is rejected."""
+    with pytest.raises(ValidationError):
+        WatchSubscriptionCreate(user_id="user01", post_poll_seconds=seconds)
+
+
+def test_response_round_trips_fields() -> None:
+    """The response model carries every surfaced subscription field."""
+    response = WatchSubscriptionResponse(
+        subscription_id="sub-12345",
+        user_id="user01",
+        enabled=True,
+        live_poll_seconds=300,
+        post_poll_seconds=2700,
+        last_live_check=None,
+        last_post_check=None,
+        newest_aweme_id="7423",
+        created_at="2026-06-22T00:00:00+00:00",
+        updated_at="2026-06-22T00:00:00+00:00",
+    )
+    assert response.newest_aweme_id == "7423"
+    assert response.enabled is True
+
+
+def test_list_envelope_defaults_to_empty() -> None:
+    """The list envelope reports an explicit total."""
+    envelope = WatchSubscriptionList(total=0)
+    assert envelope.subscriptions == []
+    assert envelope.total == 0

--- a/tests/services/test_post_incremental.py
+++ b/tests/services/test_post_incremental.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from dyvine.core.exceptions import UserNotFoundError
+from dyvine.core.exceptions import OperationNotFoundError, UserNotFoundError
 from dyvine.core.operations import OperationStore
 from dyvine.services import posts as posts_module
 from dyvine.services.posts import PostService
@@ -36,12 +36,13 @@ async def test_collect_new_posts_stops_at_known_id() -> None:
     service._fetch_posts_batch = AsyncMock(return_value=batch)  # type: ignore[method-assign]
     service._download_post_content = AsyncMock()  # type: ignore[method-assign]
 
-    new_ids, failed = await service._collect_new_posts(
+    new_ids, failed, truncated = await service._collect_new_posts(
         "user01", Path("/tmp/x"), known={"1"}, since_aweme_id=None
     )
 
     assert new_ids == ["3", "2"]
     assert failed == 0
+    assert truncated is False
     assert service._download_post_content.await_count == 2
 
 
@@ -58,12 +59,13 @@ async def test_collect_new_posts_counts_failures() -> None:
         side_effect=[None, RuntimeError("boom")]
     )
 
-    new_ids, failed = await service._collect_new_posts(
+    new_ids, failed, truncated = await service._collect_new_posts(
         "user01", Path("/tmp/x"), known=set(), since_aweme_id=None
     )
 
     assert new_ids == ["3"]
     assert failed == 1
+    assert truncated is False
 
 
 async def test_collect_new_posts_stops_on_empty_batch() -> None:
@@ -72,12 +74,13 @@ async def test_collect_new_posts_stops_on_empty_batch() -> None:
     service._fetch_posts_batch = AsyncMock(return_value={})  # type: ignore[method-assign]
     service._download_post_content = AsyncMock()  # type: ignore[method-assign]
 
-    new_ids, failed = await service._collect_new_posts(
+    new_ids, failed, truncated = await service._collect_new_posts(
         "user01", Path("/tmp/x"), known=set(), since_aweme_id=None
     )
 
     assert new_ids == []
     assert failed == 0
+    assert truncated is False
     service._download_post_content.assert_not_awaited()
 
 
@@ -160,11 +163,47 @@ async def test_collect_new_posts_warns_on_max_page_fallback(
         posts_module.logger, "warning", lambda *a, **k: warnings.append((a, k))
     )
 
-    new_ids, failed = await service._collect_new_posts(
+    new_ids, failed, truncated = await service._collect_new_posts(
         "user01", Path("/tmp/x"), known=set(), since_aweme_id=None
     )
 
     assert len(new_ids) == 3  # exactly MAX_PAGES_FALLBACK pages, one post each
     assert failed == 0
+    assert truncated is True
     assert warnings, "expected a max-page-fallback warning"
     assert "max page fallback" in str(warnings[0][0][0]).lower()
+
+
+async def test_get_bulk_download_status_accepts_incremental_op() -> None:
+    """Watch-created incremental operations are observable via the status route."""
+    service = _make_service()
+    op = await service.operation_store.create_operation(
+        operation_type="user_posts_incremental_download",
+        subject_id="user01",
+        status="completed",
+        message="Downloaded 2 new post(s)",
+        total_items=2,
+        completed_items=2,
+        metadata={"failed_count": 0, "new_count": 2},
+    )
+
+    resp = await service.get_bulk_download_status(op.operation_id)
+
+    assert resp.operation_id == op.operation_id
+    assert resp.sec_user_id == "user01"
+    assert resp.total_posts == 2
+    assert resp.total_downloaded == 2
+
+
+async def test_get_bulk_download_status_rejects_unrelated_op() -> None:
+    """An unrelated operation type still surfaces as not-found."""
+    service = _make_service()
+    op = await service.operation_store.create_operation(
+        operation_type="user_content_download",
+        subject_id="user01",
+        status="completed",
+        message="done",
+    )
+
+    with pytest.raises(OperationNotFoundError):
+        await service.get_bulk_download_status(op.operation_id)

--- a/tests/services/test_post_incremental.py
+++ b/tests/services/test_post_incremental.py
@@ -1,0 +1,88 @@
+"""Tests for PostService incremental (new-post) download logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dyvine.core.exceptions import UserNotFoundError
+from dyvine.core.operations import OperationStore
+from dyvine.services.posts import PostService
+
+
+def _make_service() -> PostService:
+    """Build a PostService with a mock handler and isolated store."""
+    handler = MagicMock()
+    handler.kwargs = {"mode": "all"}
+    return PostService(handler=handler, operation_store=OperationStore())
+
+
+async def test_collect_new_posts_stops_at_known_id() -> None:
+    """Pagination downloads only the strictly-new prefix before a known id."""
+    service = _make_service()
+    batch = {
+        "aweme_list": [
+            {"aweme_id": "3"},
+            {"aweme_id": "2"},
+            {"aweme_id": "1"},  # already known -> stop here
+        ],
+        "has_more": True,
+        "max_cursor": 999,
+    }
+    service._fetch_posts_batch = AsyncMock(return_value=batch)  # type: ignore[method-assign]
+    service._download_post_content = AsyncMock()  # type: ignore[method-assign]
+
+    new_ids, failed = await service._collect_new_posts(
+        "user01", Path("/tmp/x"), known={"1"}, since_aweme_id=None
+    )
+
+    assert new_ids == ["3", "2"]
+    assert failed == 0
+    assert service._download_post_content.await_count == 2
+
+
+async def test_collect_new_posts_counts_failures() -> None:
+    """A per-post download failure is counted, not fatal."""
+    service = _make_service()
+    batch = {
+        "aweme_list": [{"aweme_id": "3"}, {"aweme_id": "2"}],
+        "has_more": False,
+        "max_cursor": 0,
+    }
+    service._fetch_posts_batch = AsyncMock(return_value=batch)  # type: ignore[method-assign]
+    service._download_post_content = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[None, RuntimeError("boom")]
+    )
+
+    new_ids, failed = await service._collect_new_posts(
+        "user01", Path("/tmp/x"), known=set(), since_aweme_id=None
+    )
+
+    assert new_ids == ["3"]
+    assert failed == 1
+
+
+async def test_collect_new_posts_stops_on_empty_batch() -> None:
+    """An empty upstream batch ends pagination."""
+    service = _make_service()
+    service._fetch_posts_batch = AsyncMock(return_value={})  # type: ignore[method-assign]
+    service._download_post_content = AsyncMock()  # type: ignore[method-assign]
+
+    new_ids, failed = await service._collect_new_posts(
+        "user01", Path("/tmp/x"), known=set(), since_aweme_id=None
+    )
+
+    assert new_ids == []
+    assert failed == 0
+    service._download_post_content.assert_not_awaited()
+
+
+async def test_download_new_posts_rejects_unknown_user() -> None:
+    """An unknown profile raises before any operation work begins."""
+    service = _make_service()
+    service.handler.fetch_user_profile = AsyncMock(return_value=None)
+
+    with pytest.raises(UserNotFoundError):
+        await service.download_new_posts("user01", known_aweme_ids=set())

--- a/tests/services/test_post_incremental.py
+++ b/tests/services/test_post_incremental.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -9,6 +10,7 @@ import pytest
 
 from dyvine.core.exceptions import UserNotFoundError
 from dyvine.core.operations import OperationStore
+from dyvine.services import posts as posts_module
 from dyvine.services.posts import PostService
 
 
@@ -86,3 +88,83 @@ async def test_download_new_posts_rejects_unknown_user() -> None:
 
     with pytest.raises(UserNotFoundError):
         await service.download_new_posts("user01", known_aweme_ids=set())
+
+
+class _FakeUserDB:
+    """Minimal async-context stand-in for f2's AsyncUserDB in tests."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    async def __aenter__(self) -> object:
+        return object()
+
+    async def __aexit__(self, *args: object) -> bool:
+        return False
+
+
+async def test_download_new_posts_marks_operation_failed_on_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation mid-download marks the op terminal, not left as 'running'."""
+    service = _make_service()
+    service.handler.fetch_user_profile = AsyncMock(
+        return_value=MagicMock(nickname="someone")
+    )
+    service.handler.get_or_add_user_data = AsyncMock(return_value=Path("/tmp/u"))
+    monkeypatch.setattr(posts_module, "AsyncUserDB", _FakeUserDB)
+    monkeypatch.setattr(
+        posts_module, "relative_to_download_root", lambda _path: "users/user01"
+    )
+    service._collect_new_posts = AsyncMock(  # type: ignore[method-assign]
+        side_effect=asyncio.CancelledError()
+    )
+
+    captured: dict[str, object] = {}
+    real_update = service.operation_store.update_operation
+
+    async def _spy_update(operation_id: str, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return await real_update(operation_id, **kwargs)
+
+    monkeypatch.setattr(service.operation_store, "update_operation", _spy_update)
+
+    with pytest.raises(asyncio.CancelledError):
+        await service.download_new_posts("user01", known_aweme_ids=set())
+
+    assert captured.get("status") == "failed"
+    assert "cancelled" in str(captured.get("message", "")).lower()
+
+
+async def test_collect_new_posts_warns_on_max_page_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hitting the page cap logs a warning rather than truncating silently."""
+    service = _make_service()
+    monkeypatch.setattr(posts_module, "MAX_PAGES_FALLBACK", 3)
+    counter = {"n": 0}
+
+    async def _always_more(_uid: str, _cursor: int) -> dict[str, object]:
+        counter["n"] += 1
+        return {
+            "aweme_list": [{"aweme_id": f"id-{counter['n']}"}],
+            "has_more": True,
+            "max_cursor": counter["n"] * 1000,
+        }
+
+    service._fetch_posts_batch = _always_more  # type: ignore[method-assign]
+    service._download_post_content = AsyncMock()  # type: ignore[method-assign]
+
+    warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(
+        posts_module.logger, "warning", lambda *a, **k: warnings.append((a, k))
+    )
+
+    new_ids, failed = await service._collect_new_posts(
+        "user01", Path("/tmp/x"), known=set(), since_aweme_id=None
+    )
+
+    assert len(new_ids) == 3  # exactly MAX_PAGES_FALLBACK pages, one post each
+    assert failed == 0
+    assert warnings, "expected a max-page-fallback warning"
+    assert "max page fallback" in str(warnings[0][0][0]).lower()

--- a/tests/services/test_watch_service.py
+++ b/tests/services/test_watch_service.py
@@ -1,0 +1,310 @@
+"""Tests for the WatchService scheduler, checkpointing, and lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dyvine.core.exceptions import LivestreamError, WatchSubscriptionNotFoundError
+from dyvine.core.settings import settings
+from dyvine.core.watch_store import WatchSubscriptionRecord, WatchSubscriptionStore
+from dyvine.schemas.posts import PostDetail, PostType
+from dyvine.services.posts import IncrementalDownloadResult, UserPostsPage
+from dyvine.services.watch import WatchService
+
+
+def _make_service(tmp_path: Path) -> tuple[WatchService, MagicMock, MagicMock]:
+    """Build a WatchService over a real store with mocked sub-services."""
+    store = WatchSubscriptionStore(db_path=str(tmp_path / "watch.db"))
+    livestream = MagicMock()
+    livestream.download_stream = AsyncMock()
+    post = MagicMock()
+    post.download_new_posts = AsyncMock()
+    post.get_user_posts = AsyncMock()
+    service = WatchService(
+        watch_store=store,
+        livestream_service=livestream,
+        post_service=post,
+    )
+    return service, livestream, post
+
+
+def test_merge_recent_dedups_and_bounds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Newly seen ids go first, duplicates drop, and the cap is honoured."""
+    service = object.__new__(WatchService)
+    service.settings = settings
+    monkeypatch.setattr(settings.watch, "recent_id_cap", 3)
+    merged = service._merge_recent(["a", "b"], ["b", "c", "d"])
+    assert merged == ["a", "b", "c"]
+
+
+async def test_create_subscription_is_idempotent(tmp_path: Path) -> None:
+    """A second create for the same user returns the existing record."""
+    service, _, _ = _make_service(tmp_path)
+    service._start_loop = MagicMock()  # type: ignore[method-assign]
+
+    rec1, created1 = await service.create_subscription(
+        user_id="user01", backfill_on_create=True
+    )
+    rec2, created2 = await service.create_subscription(
+        user_id="user01", backfill_on_create=True
+    )
+
+    assert created1 is True
+    assert created2 is False
+    assert rec1.subscription_id == rec2.subscription_id
+    assert len(await service.list_subscriptions()) == 1
+
+
+async def test_create_subscription_enforces_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exceeding max_subscriptions raises RateLimitError."""
+    from dyvine.core.exceptions import RateLimitError
+
+    service, _, _ = _make_service(tmp_path)
+    service._start_loop = MagicMock()  # type: ignore[method-assign]
+    monkeypatch.setattr(settings.watch, "max_subscriptions", 1)
+
+    await service.create_subscription(user_id="user01", backfill_on_create=True)
+    with pytest.raises(RateLimitError):
+        await service.create_subscription(user_id="user02", backfill_on_create=True)
+
+
+async def test_create_subscription_backfill_false_snapshots_baseline(
+    tmp_path: Path,
+) -> None:
+    """A non-backfill subscription seeds its checkpoint from the first page."""
+    service, _, post = _make_service(tmp_path)
+    service._start_loop = MagicMock()  # type: ignore[method-assign]
+    post.get_user_posts.return_value = UserPostsPage(
+        posts=[
+            PostDetail(
+                aweme_id="9",
+                desc="",
+                create_time=0,
+                post_type=PostType.VIDEO,
+                video_info=None,
+                images=None,
+                statistics={},
+            )
+        ],
+        next_cursor=None,
+        has_more=False,
+    )
+
+    record, created = await service.create_subscription(
+        user_id="user01", backfill_on_create=False
+    )
+
+    assert created is True
+    assert record.checkpoint["newest_aweme_id"] == "9"
+    assert record.checkpoint["recent_aweme_ids"] == ["9"]
+    assert record.checkpoint["first_run_complete"] is True
+
+
+async def test_do_live_check_swallows_offline(tmp_path: Path) -> None:
+    """An offline user (LivestreamError) does not propagate from a check."""
+    service, livestream, _ = _make_service(tmp_path)
+    livestream.download_stream.side_effect = LivestreamError("not streaming")
+    record = await service.watch_store.create_subscription(
+        user_id="user01", live_poll_seconds=300, post_poll_seconds=600
+    )
+
+    await service._do_live_check(record)  # must not raise
+
+    livestream.download_stream.assert_awaited_once()
+
+
+async def test_do_post_check_advances_checkpoint(tmp_path: Path) -> None:
+    """A successful post check folds new ids into the checkpoint."""
+    service, _, post = _make_service(tmp_path)
+    post.download_new_posts.return_value = IncrementalDownloadResult(
+        operation_id="op",
+        new_count=2,
+        newest_aweme_id="200",
+        seen_aweme_ids=["200", "199"],
+        failed_count=0,
+    )
+    record = await service.watch_store.create_subscription(
+        user_id="user01",
+        live_poll_seconds=300,
+        post_poll_seconds=600,
+        checkpoint={
+            "newest_aweme_id": "100",
+            "recent_aweme_ids": ["100"],
+            "first_run_complete": True,
+        },
+    )
+
+    await service._do_post_check(record)
+
+    updated = await service.watch_store.get_subscription(record.subscription_id)
+    assert updated.checkpoint["newest_aweme_id"] == "200"
+    assert "200" in updated.checkpoint["recent_aweme_ids"]
+    assert "100" in updated.checkpoint["recent_aweme_ids"]
+
+
+async def test_do_post_check_keeps_checkpoint_when_no_new_posts(
+    tmp_path: Path,
+) -> None:
+    """A run with no new posts leaves the sentinel untouched."""
+    service, _, post = _make_service(tmp_path)
+    post.download_new_posts.return_value = IncrementalDownloadResult(
+        operation_id="op",
+        new_count=0,
+        newest_aweme_id=None,
+        seen_aweme_ids=[],
+        failed_count=0,
+    )
+    record = await service.watch_store.create_subscription(
+        user_id="user01",
+        live_poll_seconds=300,
+        post_poll_seconds=600,
+        checkpoint={"newest_aweme_id": "100", "recent_aweme_ids": ["100"]},
+    )
+
+    await service._do_post_check(record)
+
+    updated = await service.watch_store.get_subscription(record.subscription_id)
+    assert updated.checkpoint["newest_aweme_id"] == "100"
+    assert updated.last_post_check is not None
+
+
+async def test_resume_persisted_starts_loops_and_stop_all_cancels(
+    tmp_path: Path,
+) -> None:
+    """resume_persisted arms one loop per enabled subscription; stop_all clears."""
+    service, _, _ = _make_service(tmp_path)
+    service._do_live_check = AsyncMock()  # type: ignore[method-assign]
+    service._do_post_check = AsyncMock()  # type: ignore[method-assign]
+    await service.watch_store.create_subscription(
+        user_id="user01", live_poll_seconds=3600, post_poll_seconds=3600
+    )
+    await service.watch_store.create_subscription(
+        user_id="user02", live_poll_seconds=3600, post_poll_seconds=3600
+    )
+
+    count = await service.resume_persisted()
+    await asyncio.sleep(0.05)
+
+    assert count == 2
+    assert service.active_count == 2
+
+    await service.stop_all()
+    assert service.active_count == 0
+
+
+async def test_watch_loop_runs_first_cycle_then_cancellable(
+    tmp_path: Path,
+) -> None:
+    """The loop checks immediately on start and exits cleanly on cancel."""
+    service, _, _ = _make_service(tmp_path)
+    service._do_live_check = AsyncMock()  # type: ignore[method-assign]
+    service._do_post_check = AsyncMock()  # type: ignore[method-assign]
+    record = await service.watch_store.create_subscription(
+        user_id="user01", live_poll_seconds=3600, post_poll_seconds=3600
+    )
+
+    task = asyncio.create_task(service._watch_loop(record.subscription_id))
+    await asyncio.sleep(0.05)
+
+    assert service._do_live_check.await_count >= 1
+    assert service._do_post_check.await_count >= 1
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_watch_loop_exits_when_subscription_deleted(tmp_path: Path) -> None:
+    """A loop whose subscription disappears returns instead of erroring."""
+    service, _, _ = _make_service(tmp_path)
+    service._do_live_check = AsyncMock()  # type: ignore[method-assign]
+    service._do_post_check = AsyncMock()  # type: ignore[method-assign]
+    record = await service.watch_store.create_subscription(
+        user_id="user01", live_poll_seconds=3600, post_poll_seconds=3600
+    )
+    await service.watch_store.delete_subscription(record.subscription_id)
+
+    # Loop should observe the missing row on its first iteration and return.
+    await asyncio.wait_for(service._watch_loop(record.subscription_id), timeout=1.0)
+
+
+def test_to_response_surfaces_checkpoint_newest(tmp_path: Path) -> None:
+    """to_response lifts newest_aweme_id out of the checkpoint blob."""
+    service, _, _ = _make_service(tmp_path)
+    record = WatchSubscriptionRecord(
+        subscription_id="sub-1",
+        user_id="user01",
+        enabled=True,
+        live_poll_seconds=300,
+        post_poll_seconds=600,
+        checkpoint={"newest_aweme_id": "42"},
+        last_live_check=None,
+        last_post_check=None,
+        created_at="2026-06-22T00:00:00+00:00",
+        updated_at="2026-06-22T00:00:00+00:00",
+    )
+    response = service.to_response(record)
+    assert response.user_id == "user01"
+    assert response.newest_aweme_id == "42"
+
+
+def test_jittered_interval_within_bounds(tmp_path: Path) -> None:
+    """Jitter keeps the interval within +/-10% of the configured value."""
+    service, _, _ = _make_service(tmp_path)
+    for _ in range(20):
+        value = service._jittered_interval(100)
+        assert 90.0 <= value <= 110.0
+
+
+async def test_delete_subscription_cancels_loop_and_removes_row(
+    tmp_path: Path,
+) -> None:
+    """Deleting cancels the watcher loop and removes the persisted row."""
+    service, _, _ = _make_service(tmp_path)
+    service._do_live_check = AsyncMock()  # type: ignore[method-assign]
+    service._do_post_check = AsyncMock()  # type: ignore[method-assign]
+    record = await service.watch_store.create_subscription(
+        user_id="user01", live_poll_seconds=3600, post_poll_seconds=3600
+    )
+    service._start_loop(record)
+    await asyncio.sleep(0.02)
+    assert service.active_count == 1
+
+    await service.delete_subscription(record.subscription_id)
+
+    assert service.active_count == 0
+    assert await service.watch_store.get_subscription_by_user("user01") is None
+
+
+async def test_delete_unknown_subscription_raises(tmp_path: Path) -> None:
+    """Deleting a non-existent subscription raises the typed not-found error."""
+    service, _, _ = _make_service(tmp_path)
+    with pytest.raises(WatchSubscriptionNotFoundError):
+        await service.delete_subscription("missing")
+
+
+async def test_do_post_check_keeps_checkpoint_on_service_error(
+    tmp_path: Path,
+) -> None:
+    """An upstream failure leaves the checkpoint untouched for a later retry."""
+    from dyvine.core.exceptions import ServiceError
+
+    service, _, post = _make_service(tmp_path)
+    post.download_new_posts.side_effect = ServiceError("upstream down")
+    record = await service.watch_store.create_subscription(
+        user_id="user01",
+        live_poll_seconds=300,
+        post_poll_seconds=600,
+        checkpoint={"newest_aweme_id": "100", "recent_aweme_ids": ["100"]},
+    )
+
+    await service._do_post_check(record)  # must not raise
+
+    updated = await service.watch_store.get_subscription(record.subscription_id)
+    assert updated.checkpoint["newest_aweme_id"] == "100"

--- a/tests/services/test_watch_service.py
+++ b/tests/services/test_watch_service.py
@@ -308,3 +308,69 @@ async def test_do_post_check_keeps_checkpoint_on_service_error(
 
     updated = await service.watch_store.get_subscription(record.subscription_id)
     assert updated.checkpoint["newest_aweme_id"] == "100"
+
+
+async def test_do_post_check_holds_checkpoint_on_partial_failure(
+    tmp_path: Path,
+) -> None:
+    """Any failed download in the window must NOT advance the checkpoint.
+
+    Advancing past a post that was downloaded while an older sibling failed
+    would make the newest-first early-stop skip the failure forever; holding
+    the boundary lets the next cycle re-scan and retry it.
+    """
+    service, _, post = _make_service(tmp_path)
+    post.download_new_posts.return_value = IncrementalDownloadResult(
+        operation_id="op",
+        new_count=1,
+        newest_aweme_id="200",
+        seen_aweme_ids=["200"],
+        failed_count=1,
+    )
+    record = await service.watch_store.create_subscription(
+        user_id="user01",
+        live_poll_seconds=300,
+        post_poll_seconds=600,
+        checkpoint={
+            "newest_aweme_id": "100",
+            "recent_aweme_ids": ["100"],
+            "first_run_complete": True,
+        },
+    )
+
+    await service._do_post_check(record)
+
+    updated = await service.watch_store.get_subscription(record.subscription_id)
+    # Boundary held at the prior value despite a "new" post being reported.
+    assert updated.checkpoint["newest_aweme_id"] == "100"
+    assert updated.checkpoint["recent_aweme_ids"] == ["100"]
+    # The check itself still happened, only the checkpoint advance is withheld.
+    assert updated.last_post_check is not None
+
+
+async def test_delete_subscription_serialises_under_create_lock(
+    tmp_path: Path,
+) -> None:
+    """Delete takes the same lock as create, so the two cannot interleave."""
+    service, _, _ = _make_service(tmp_path)
+    service._do_live_check = AsyncMock()  # type: ignore[method-assign]
+    service._do_post_check = AsyncMock()  # type: ignore[method-assign]
+    record = await service.watch_store.create_subscription(
+        user_id="user01", live_poll_seconds=3600, post_poll_seconds=3600
+    )
+
+    lock = service._get_lock()
+    await lock.acquire()
+    try:
+        delete_task = asyncio.create_task(
+            service.delete_subscription(record.subscription_id)
+        )
+        await asyncio.sleep(0.02)
+        # While we hold the lock, delete must be parked rather than finished.
+        assert not delete_task.done()
+        assert await service.watch_store.get_subscription_by_user("user01") is not None
+    finally:
+        lock.release()
+
+    await asyncio.wait_for(delete_task, timeout=1.0)
+    assert await service.watch_store.get_subscription_by_user("user01") is None

--- a/tests/services/test_watch_service.py
+++ b/tests/services/test_watch_service.py
@@ -374,3 +374,81 @@ async def test_delete_subscription_serialises_under_create_lock(
 
     await asyncio.wait_for(delete_task, timeout=1.0)
     assert await service.watch_store.get_subscription_by_user("user01") is None
+
+
+async def test_do_post_check_holds_checkpoint_on_truncation(
+    tmp_path: Path,
+) -> None:
+    """A truncated run (page cap hit) must NOT advance the checkpoint.
+
+    Advancing would make the next newest-first scan stop at this run's newest
+    post and skip every post past the cap permanently.
+    """
+    service, _, post = _make_service(tmp_path)
+    post.download_new_posts.return_value = IncrementalDownloadResult(
+        operation_id="op",
+        new_count=2,
+        newest_aweme_id="200",
+        seen_aweme_ids=["200", "199"],
+        failed_count=0,
+        truncated=True,
+    )
+    record = await service.watch_store.create_subscription(
+        user_id="user01",
+        live_poll_seconds=300,
+        post_poll_seconds=600,
+        checkpoint={
+            "newest_aweme_id": "100",
+            "recent_aweme_ids": ["100"],
+            "first_run_complete": True,
+        },
+    )
+
+    await service._do_post_check(record)
+
+    updated = await service.watch_store.get_subscription(record.subscription_id)
+    assert updated.checkpoint["newest_aweme_id"] == "100"
+    assert updated.checkpoint["recent_aweme_ids"] == ["100"]
+    assert updated.last_post_check is not None
+
+
+async def test_create_subscription_existing_skips_baseline_snapshot(
+    tmp_path: Path,
+) -> None:
+    """A repeat non-backfill create returns the existing row without snapshotting.
+
+    The pre-lock existence check means a transient profile/upstream failure
+    during the baseline snapshot cannot turn an idempotent retry into an error.
+    """
+    service, _, post = _make_service(tmp_path)
+    service._start_loop = MagicMock()  # type: ignore[method-assign]
+    post.get_user_posts.return_value = UserPostsPage(
+        posts=[
+            PostDetail(
+                aweme_id="9",
+                desc="",
+                create_time=0,
+                post_type=PostType.VIDEO,
+                video_info=None,
+                images=None,
+                statistics={},
+            )
+        ],
+        next_cursor=None,
+        has_more=False,
+    )
+
+    rec1, created1 = await service.create_subscription(
+        user_id="user01", backfill_on_create=False
+    )
+    assert created1 is True
+    assert post.get_user_posts.await_count == 1  # baseline snapshot for the new row
+
+    # A second non-backfill create must short-circuit BEFORE snapshotting again.
+    post.get_user_posts.side_effect = AssertionError("must not snapshot again")
+    rec2, created2 = await service.create_subscription(
+        user_id="user01", backfill_on_create=False
+    )
+    assert created2 is False
+    assert rec2.subscription_id == rec1.subscription_id
+    assert post.get_user_posts.await_count == 1  # unchanged: no second snapshot

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 from fastapi import HTTPException
 
@@ -195,3 +197,59 @@ async def test_service_container_exposes_post_service(
     fetched = await container.operation_store.get_operation(operation.operation_id)
     assert fetched.operation_id == operation.operation_id
     assert dependencies.get_post_service.__name__ == "get_post_service"
+
+
+@pytest.mark.asyncio
+async def test_service_container_survives_watch_resume_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """A watch resume failure must not abort startup (watch is non-critical)."""
+    monkeypatch.setattr(
+        dependencies, "DouyinHandler", lambda kwargs: DummyHandler(kwargs)
+    )
+    monkeypatch.setattr(
+        dependencies.settings.api,
+        "operation_db_path",
+        str(tmp_path / "operations.db"),
+    )
+    monkeypatch.setattr(
+        dependencies.WatchService,
+        "resume_persisted",
+        AsyncMock(side_effect=RuntimeError("resume boom")),
+    )
+
+    container = dependencies.ServiceContainer()
+    await container.initialize()  # must not raise despite the resume failure
+
+    # The container still came up; non-watch services remain usable.
+    assert container._initialized is True
+    assert isinstance(container.post_service, dependencies.PostService)
+    await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_service_container_survives_watch_store_init_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """A watch-store construction failure leaves the rest of startup intact."""
+    monkeypatch.setattr(
+        dependencies, "DouyinHandler", lambda kwargs: DummyHandler(kwargs)
+    )
+    monkeypatch.setattr(
+        dependencies.settings.api,
+        "operation_db_path",
+        str(tmp_path / "operations.db"),
+    )
+
+    def _boom(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("watch store boom")
+
+    monkeypatch.setattr(dependencies, "WatchSubscriptionStore", _boom)
+
+    container = dependencies.ServiceContainer()
+    await container.initialize()  # must not raise or leak the executors above
+
+    assert container._initialized is True
+    assert isinstance(container.post_service, dependencies.PostService)
+    assert container._watch_store is None
+    await container.shutdown()  # clean teardown even without a watch store

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -73,7 +73,7 @@ def test_read_main():
         assert data["redoc"] == "/redoc"
         assert data["status"] == "operational"
         assert data["api_prefix"] == settings.prefix
-        assert data["features"] == ["users", "posts", "livestreams"]
+        assert data["features"] == ["users", "posts", "livestreams", "watch"]
 
 
 def test_readiness_probe_returns_ready_when_all_dependencies_ok(

--- a/users.txt.example
+++ b/users.txt.example
@@ -1,0 +1,9 @@
+# Dyvine batch-download user list.
+#
+# One Douyin sec_user_id per line. Blank lines and lines starting with "#"
+# are ignored. Copy this file to users.txt and replace the placeholders with
+# real IDs (the real users.txt is git-ignored so monitored targets are not
+# committed).
+#
+# MS4wLjABAAAA0000000000000000000000000000000000000000000
+# MS4wLjABAAAA1111111111111111111111111111111111111111111


### PR DESCRIPTION
## Summary
Add a watch mode that monitors specified Douyin users and auto-downloads their new posts (incrementally) and livestreams (auto-recorded when they go live), managed through a runtime `/watch` REST API whose subscriptions persist and resume across restarts.

## Related
- Not applicable

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| Watch scheduler | — | new | Per-subscription asyncio loops with independent live/post cadences |
| Persistence | — | `watch_subscriptions` table | Dedicated table sharing the operation SQLite DB; resumes on boot |
| Incremental posts | full re-paginate | new-only | `PostService.download_new_posts` early-exits at the first known aweme_id |
| REST API | — | `/api/v1/watch` | POST/GET/DELETE, API-key gated like the other routers |
| Config | — | `DOUYIN_WATCH_*` | Poll intervals, dedupe cap, max subscriptions, backfill toggle |
| Client scripts | local only | committed | `batch_download.py`, `download_serial.py`, `users.txt.example` |

## Details
### Watch subscriptions + scheduler
- Design/Spec: each subscription is one row in a new `watch_subscriptions` table (`core/watch_store.py`) plus one long-lived asyncio loop (`services/watch.py`). The table is deliberately separate from `operations` because the operation store's startup `mark_incomplete_operations_failed` sweep flips running rows to `failed` and has no enumeration query — both fatal for resumable subscriptions.
- Implementation notes: live and post checks run on independent `time.monotonic` due-times (defaults ~5 min / ~45 min) with ±10% jitter to avoid lockstep polling. Live hits reuse `LivestreamService.download_stream` (deduped by `room_id`, offline raises and is swallowed). Post hits call the new `PostService.download_new_posts`, which paginates newest-first and stops at the first already-known `aweme_id`, tracked by a bounded checkpoint (newest id + recent-id set). Each triggered download creates a normal operation row, so existing polling endpoints keep working. With `backfill_on_create=false` (default), a baseline of the user's current first page is snapshotted at create time so only posts published afterward are downloaded.
- Reviewer focus: the persistence/resume interplay (`ServiceContainer.initialize` resumes enabled subscriptions; `shutdown` stops loops before draining background tasks); the early-exit + checkpoint correctness in `download_new_posts`; and that `DELETE` cancels future checks but does not interrupt an in-progress recording (documented).

## Testing
- `uv run pytest` — 420 passed
- `uv run pytest --cov=src/dyvine --cov-fail-under=80` — 89.87% total (watch modules 88–100%)
- `uv run ruff check src tests` + `uv run mypy src/dyvine` — clean
- Manual end-to-end against a live Douyin session — Not run (no upstream session in CI)

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable (additive; existing endpoints and schemas unchanged)

## Risks and rollout
- Aggressive polling can trip Douyin rate limiting / cookie risk — mitigated by a 60s floor, conservative defaults, and jitter; all intervals are configurable.
- Single-replica only (pod-local SQLite) — same constraint as the rest of the service; documented.
- `DELETE` does not stop a recording already in progress — documented; a follow-up could thread a cancel hook into `download_stream`.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed (README, docs/index.html, .env.example)
- [x] Backward compatibility considered (additive only)
- [x] Rollout/monitoring considerations noted (single-replica; /health watch count)
